### PR TITLE
Fix gpose warning. Commands are lowercase only.

### DIFF
--- a/Anamnesis/Languages/de.json
+++ b/Anamnesis/Languages/de.json
@@ -116,7 +116,7 @@
 
 	"Character_ExWeapons_Header": "Erweiterte Waffen",
 
-	"Pose_WarningNotGPose": "Posing ist nur in GPose möglich. Gehe in GPose mit /Gpose.",
+	"Pose_WarningNotGPose": "Posing ist nur in GPose möglich. Gehe in GPose mit /gpose.",
 	"Pose_WarningNotFrozen": "Posing funktionert nur mit eingefrorenen Charakteren. Friere den Charakter im GPose Fenster ein.",
 	"Pose_GenerateSkeletonTitle": "Skelett nicht gefunden",
 	"Pose_GenerateSkeleton": "Für diesen Charakter wurde kein Skelett gefunden {0}- Jetzt eins erstellen?\nOhne ein Skelett funktionert das Parenting nicht richtig.",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -137,7 +137,7 @@
 
 	"Character_ExWeapons_Header": "Extended Weapons",
 
-	"Pose_WarningNotGPose": "Posing is only available while in Group Pose. Type /Gpose in chat.",
+	"Pose_WarningNotGPose": "Posing is only available while in Group Pose. Type /gpose in chat.",
 	"Pose_WarningNotFrozen": "Posing is only available for frozen actors. Freeze this actor in the Group Pose Settings window.",
 	"Pose_GenerateSkeletonTitle": "Skeleton not found",
 	"Pose_GenerateSkeleton": "No skeleton was found for the actor {0}- generate one now?\nWithout a skeleton, parenting will not work correctly.",

--- a/Anamnesis/Languages/fr.json
+++ b/Anamnesis/Languages/fr.json
@@ -132,7 +132,7 @@
 
 	"Character_ExWeapons_Header": "Armes Etendues",
 
-	"Pose_WarningNotGPose": "Le posing n'est disponible qu'en pose de groupe. Tapez /Gpose dans le chat.",
+	"Pose_WarningNotGPose": "Le posing n'est disponible qu'en pose de groupe. Tapez /gpose dans le chat.",
 	"Pose_WarningNotFrozen": "Le Posing n'est disponible que sur les personnages en pause. Mettez le personnage en pause dans la fenêtre des paramètres du Gpose.",
 	"Pose_GenerateSkeletonTitle": "Squelette non trouvé",
 	"Pose_GenerateSkeleton": "Aucun squelette sur le personnage {0}- En générer un ?\nSans squelette le parentage ne fonctionera pas",


### PR DESCRIPTION
change `Pose_WarningNotGPose` to use lowercase `/gpose` instead of titlecase `/Gpose`