### PR TITLE
Name verification and sensitivity edits

### DIFF
--- a/Anamnesis/Data/Monsters.json
+++ b/Anamnesis/Data/Monsters.json
@@ -1,1 +1,13207 @@
-﻿[	{		"ModelType": 0,		"Name": "Player",		"Type": "Character"	},	{		"ModelType": 1,		"Name": "Chocobo",		"Type": "Mount"	},	{		"ModelType": 2,		"Name": "Magitek Reaper",		"Type": "Monster"	},	{		"ModelType": 3,		"Name": "Amalj'aa",		"Type": "Monster"	},	{		"ModelType": 4,		"Name": "Ixal",		"Type": "Monster"	},	{		"ModelType": 5,		"Name": "Kobold",		"Type": "Monster"	},	{		"ModelType": 6,		"Name": "Goblin",		"Type": "Monster"	},	{		"ModelType": 7,		"Name": "Sylph",		"Type": "Monster"	},	{		"ModelType": 8,		"Name": "Moogle",		"Type": "Monster"	},	{		"ModelType": 9,		"Name": "Sahagin",		"Type": "Monster"	},	{		"ModelType": 10,		"Name": "Mamool Ja Warrior",		"Type": "Monster"	},	{		"ModelType": 11,		"Name": "Hecatonchier",		"Type": "Monster"	},	{		"ModelType": 12,		"Name": "Giant",		"Type": "Monster"	},	{		"ModelType": 13,		"Name": "Gigas",		"Type": "Monster"	},	{		"ModelType": 14,		"Name": "Qiqirn",		"Type": "Monster"	},	{		"ModelType": 15,		"Name": "Delivery Moogle",		"Type": "Monster"	},	{		"ModelType": 16,		"Name": "Lamia",		"Type": "Monster"	},	{		"ModelType": 17,		"Name": "Skeleton",		"Type": "Monster"	},	{		"ModelType": 18,		"Name": "Succubus",		"Type": "Monster"	},	{		"ModelType": 18,		"Name": "Halicarnassus",		"Type": "Monster",		"Body": 2	},	{		"ModelType": 19,		"Name": "Demon",		"Type": "Monster"	},	{		"ModelType": 20,		"Name": "Miteling",		"Type": "Monster"	},	{		"ModelType": 21,		"Name": "Diremite",		"Type": "Monster"	},	{		"ModelType": 22,		"Name": "Banemite",		"Type": "Monster"	},	{		"ModelType": 23,		"Name": "Graffias",		"Type": "Monster"	},	{		"ModelType": 24,		"Name": "Rat",		"Type": "Monster"	},	{		"ModelType": 25,		"Name": "Squirrel",		"Type": "Monster"	},	{		"ModelType": 26,		"Name": "Marmot",		"Type": "Monster"	},	{		"ModelType": 27,		"Name": "Dormouse",		"Type": "Monster"	},	{		"ModelType": 28,		"Name": "Funguar",		"Type": "Monster"	},	{		"ModelType": 29,		"Name": "Myconid",		"Type": "Monster"	},	{		"ModelType": 30,		"Name": "Funguar (Blue)",		"Type": "Monster"	},	{		"ModelType": 31,		"Name": "Galago",		"Type": "Monster"	},	{		"ModelType": 32,		"Name": "Lemur",		"Type": "Monster"	},	{		"ModelType": 33,		"Name": "Galago (collared)",		"Type": "Monster"	},	{		"ModelType": 34,		"Name": "Ochu",		"Type": "Monster"	},	{		"ModelType": 35,		"Name": "Microchu",		"Type": "Monster"	},	{		"ModelType": 36,		"Name": "Chigoe",		"Type": "Monster"	},	{		"ModelType": 37,		"Name": "Djigga",		"Type": "Monster"	},	{		"ModelType": 38,		"Name": "Flea",		"Type": "Monster"	},	{		"ModelType": 39,		"Name": "Buzzard",		"Type": "Monster"	},	{		"ModelType": 40,		"Name": "Condor",		"Type": "Monster"	},	{		"ModelType": 41,		"Name": "Bateleur",		"Type": "Monster"	},	{		"ModelType": 42,		"Name": "Kite",		"Type": "Monster"	},	{		"ModelType": 43,		"Name": "Falcon",		"Type": "Monster"	},	{		"ModelType": 44,		"Name": "Hog",		"Type": "Monster"	},	{		"ModelType": 45,		"Name": "Boar",		"Type": "Monster"	},	{		"ModelType": 46,		"Name": "Hog (lighter)",		"Type": "Monster"	},	{		"ModelType": 47,		"Name": "Kamapuaa",		"Type": "Monster"	},	{		"ModelType": 48,		"Name": "Roseling",		"Type": "Monster"	},	{		"ModelType": 49,		"Name": "Flytrap",		"Type": "Monster"	},	{		"ModelType": 50,		"Name": "Slug",		"Type": "Monster"	},	{		"ModelType": 51,		"Name": "Sea Hare",		"Type": "Monster"	},	{		"ModelType": 52,		"Name": "Dark Matter Slug",		"Type": "Monster"	},	{		"ModelType": 53,		"Name": "Gnat",		"Type": "Monster"	},	{		"ModelType": 54,		"Name": "Ked",		"Type": "Monster"	},	{		"ModelType": 55,		"Name": "Magitek Bit",		"Type": "Monster"	},	{		"ModelType": 56,		"Name": "Weevil",		"Type": "Monster"	},	{		"ModelType": 57,		"Name": "Ladybug",		"Type": "Monster"	},	{		"ModelType": 58,		"Name": "Midge Swarm",		"Type": "Monster"	},	{		"ModelType": 59,		"Name": "Syrphid Swarm",		"Type": "Monster"	},	{		"ModelType": 60,		"Name": "Bee Swarm",		"Type": "Monster"	},	{		"ModelType": 61,		"Name": "Antelope Doe",		"Type": "Monster"	},	{		"ModelType": 62,		"Name": "Antelope Stag",		"Type": "Monster"	},	{		"ModelType": 63,		"Name": "Imp",		"Type": "Monster"	},	{		"ModelType": 64,		"Name": "Devilet",		"Type": "Monster"	},	{		"ModelType": 65,		"Name": "Coeurl",		"Type": "Monster"	},	{		"ModelType": 66,		"Name": "Torama",		"Type": "Monster"	},	{		"ModelType": 67,		"Name": "Panther",		"Type": "Monster"	},	{		"ModelType": 68,		"Name": "Dark Matter Coeurl",		"Type": "Monster"	},	{		"ModelType": 69,		"Name": "Coeurl Pup",		"Type": "Monster"	},	{		"ModelType": 70,		"Name": "Coeurl",		"Type": "Mount"	},	{		"ModelType": 71,		"Name": "Mindflayer",		"Type": "Monster"	},	{		"ModelType": 72,		"Name": "Psycheflayer",		"Type": "Monster"	},	{		"ModelType": 73,		"Name": "Mindflayer (The Hunt)",		"Type": "Monster"	},	{		"ModelType": 74,		"Name": "Piscodemon",		"Type": "Monster"	},	{		"ModelType": 75,		"Name": "Sand Yarzon",		"Type": "Monster"	},	{		"ModelType": 76,		"Name": "Bog Yarzon",		"Type": "Monster"	},	{		"ModelType": 78,		"Name": "Firefly",		"Type": "Monster"	},	{		"ModelType": 79,		"Name": "Wisp",		"Type": "Monster"	},	{		"ModelType": 80,		"Name": "Plasmoid",		"Type": "Monster"	},	{		"ModelType": 81,		"Name": "Mudestone Golem",		"Type": "Monster"	},	{		"ModelType": 82,		"Name": "Chert Golem",		"Type": "Monster"	},	{		"ModelType": 83,		"Name": "Temple Guardian",		"Type": "Monster"	},	{		"ModelType": 84,		"Name": "Mudestone Golem (spike)",		"Type": "Monster"	},	{		"ModelType": 85,		"Name": "Chert Golem (spike)",		"Type": "Monster"	},	{		"ModelType": 86,		"Name": "Temple Guardian (spike)",		"Type": "Monster"	},	{		"ModelType": 87,		"Name": "Dark Matter Golem",		"Type": "Monster"	},	{		"ModelType": 88,		"Name": "Spriggolem",		"Type": "Monster"	},	{		"ModelType": 89,		"Name": "Tonberry",		"Type": "Monster"	},	{		"ModelType": 90,		"Name": "Tonberry (darker)",		"Type": "Monster"	},	{		"ModelType": 91,		"Name": "Tonberry King",		"Type": "Monster"	},	{		"ModelType": 92,		"Name": "Tonberry Scholar",		"Type": "Monster"	},	{		"ModelType": 93,		"Name": "Tonberry Black Mage",		"Type": "Monster"	},	{		"ModelType": 94,		"Name": "Tortoise",		"Type": "Monster"	},	{		"ModelType": 95,		"Name": "Adamantoise",		"Type": "Monster"	},	{		"ModelType": 96,		"Name": "Raptor",		"Type": "Monster"	},	{		"ModelType": 97,		"Name": "Anole",		"Type": "Monster"	},	{		"ModelType": 98,		"Name": "Bat",		"Type": "Monster"	},	{		"ModelType": 99,		"Name": "Kalong",		"Type": "Monster"	},	{		"ModelType": 100,		"Name": "Bomb",		"Type": "Monster"	},	{		"ModelType": 101,		"Name": "Grenade",		"Type": "Monster"	},	{		"ModelType": 102,		"Name": "Shrapnel",		"Type": "Monster"	},	{		"ModelType": 103,		"Name": "Bomb (flaming)",		"Type": "Monster"	},	{		"ModelType": 104,		"Name": "Treant",		"Type": "Monster"	},	{		"ModelType": 105,		"Name": "Treant (Greenwrath)",		"Type": "Monster"	},	{		"ModelType": 106,		"Name": "Dryad",		"Type": "Monster"	},	{		"ModelType": 107,		"Name": "Spriggan (Yellow-eyed/Lightning Rock)",		"Type": "Monster"	},	{		"ModelType": 108,		"Name": "Spriggan (Yellow-eyed/Earth Rock)",		"Type": "Monster"	},	{		"ModelType": 109,		"Name": "Spriggan (Yellow-eyed/Mythril Ore)",		"Type": "Monster"	},	{		"ModelType": 110,		"Name": "Spriggan (Yellow-eyed/Copper Ore)",		"Type": "Monster"	},	{		"ModelType": 111,		"Name": "Spriggan (Red-eyed/Lightning Rock)",		"Type": "Monster"	},	{		"ModelType": 112,		"Name": "Spriggan (Red-eyed/Earth Rock)",		"Type": "Monster"	},	{		"ModelType": 113,		"Name": "Spriggan (Red-eyed/Mythril Ore)",		"Type": "Monster"	},	{		"ModelType": 114,		"Name": "Spriggan (Red-eyed/Copper Ore)",		"Type": "Monster"	},	{		"ModelType": 115,		"Name": "Spriggan (Yellow-eyed/Pristine Egg)",		"Type": "Monster"	},	{		"ModelType": 116,		"Name": "Spriggan (Yellow-eyed/Chocobo Egg)",		"Type": "Monster"	},	{		"ModelType": 117,		"Name": "Spriggan (Yellow-eyed/Midnight Egg)",		"Type": "Monster"	},	{		"ModelType": 118,		"Name": "Spriggan (Yellow-eyed/Brilliant Egg)",		"Type": "Monster"	},	{		"ModelType": 119,		"Name": "Spriggan (Yellow-eyed/Vibrant Egg)",		"Type": "Monster"	},	{		"ModelType": 120,		"Name": "Spriggan (Yellow-eyed/Motley Egg)",		"Type": "Monster"	},	{		"ModelType": 121,		"Name": "Dullahan (clean)",		"Type": "Monster"	},	{		"ModelType": 122,		"Name": "Dullahan (shiny)",		"Type": "Monster"	},	{		"ModelType": 123,		"Name": "Dullahan (rusty)",		"Type": "Monster"	},	{		"ModelType": 124,		"Name": "Face of the Hero",		"Type": "Monster"	},	{		"ModelType": 125,		"Name": "Dullahan (clean)",		"Type": "Monster"	},	{		"ModelType": 126,		"Name": "Gigantoad",		"Type": "Monster"	},	{		"ModelType": 127,		"Name": "Nix",		"Type": "Monster"	},	{		"ModelType": 128,		"Name": "Poison Nix",		"Type": "Monster"	},	{		"ModelType": 129,		"Name": "Gigantoad (green)",		"Type": "Monster"	},	{		"ModelType": 130,		"Name": "Puk",		"Type": "Monster"	},	{		"ModelType": 131,		"Name": "Pteroc",		"Type": "Monster"	},	{		"ModelType": 132,		"Name": "Puk (yellow)",		"Type": "Monster"	},	{		"ModelType": 133,		"Name": "Hippocerf",		"Type": "Monster"	},	{		"ModelType": 134,		"Name": "Hippogryph",		"Type": "Monster"	},	{		"ModelType": 135,		"Name": "Basilisk",		"Type": "Monster"	},	{		"ModelType": 136,		"Name": "Peiste",		"Type": "Monster"	},	{		"ModelType": 137,		"Name": "Wadjet",		"Type": "Monster"	},	{		"ModelType": 138,		"Name": "Buffalo",		"Type": "Monster"	},	{		"ModelType": 139,		"Name": "Aurochs",		"Type": "Monster"	},	{		"ModelType": 140,		"Name": "Wisent",		"Type": "Monster"	},	{		"ModelType": 141,		"Name": "Cactuar",		"Type": "Monster"	},	{		"ModelType": 142,		"Name": "Sabotender",		"Type": "Monster"	},	{		"ModelType": 143,		"Name": "Flowertender",		"Type": "Monster"	},	{		"ModelType": 144,		"Name": "Cactuar (yellow)",		"Type": "Monster"	},	{		"ModelType": 145,		"Name": "Morbol",		"Type": "Monster"	},	{		"ModelType": 146,		"Name": "Great Morbol",		"Type": "Monster"	},	{		"ModelType": 147,		"Name": "Miser's Mistress",		"Type": "Monster"	},	{		"ModelType": 148,		"Name": "Clipper",		"Type": "Monster"	},	{		"ModelType": 149,		"Name": "Snipper",		"Type": "Monster"	},	{		"ModelType": 150,		"Name": "Nahn",		"Type": "Monster"	},	{		"ModelType": 151,		"Name": "Salamander",		"Type": "Monster"	},	{		"ModelType": 152,		"Name": "Eft",		"Type": "Monster"	},	{		"ModelType": 153,		"Name": "Eft (orange)",		"Type": "Monster"	},	{		"ModelType": 154,		"Name": "Blueback",		"Type": "Monster"	},	{		"ModelType": 155,		"Name": "Sableback",		"Type": "Monster"	},	{		"ModelType": 156,		"Name": "Violetback",		"Type": "Monster"	},	{		"ModelType": 157,		"Name": "Yellowback",		"Type": "Monster"	},	{		"ModelType": 158,		"Name": "Dark Matter Pelican",		"Type": "Monster"	},	{		"ModelType": 159,		"Name": "Wolf",		"Type": "Monster"	},	{		"ModelType": 160,		"Name": "Jackal",		"Type": "Monster"	},	{		"ModelType": 161,		"Name": "White Wolf",		"Type": "Monster"	},	{		"ModelType": 162,		"Name": "Tao Quan",		"Type": "Monster"	},	{		"ModelType": 163,		"Name": "Watchwolf",		"Type": "Monster"	},	{		"ModelType": 164,		"Name": "Scurvy Dog",		"Type": "Monster"	},	{		"ModelType": 165,		"Name": "Behemoth",		"Type": "Monster"	},	{		"ModelType": 166,		"Name": "Kaiser Behemoth",		"Type": "Monster"	},	{		"ModelType": 167,		"Name": "Floating Eye",		"Type": "Monster"	},	{		"ModelType": 168,		"Name": "Ahriman",		"Type": "Monster"	},	{		"ModelType": 169,		"Name": "Arimaspi",		"Type": "Monster"	},	{		"ModelType": 170,		"Name": "Ahriman (red)",		"Type": "Monster"	},	{		"ModelType": 171,		"Name": "Dirty Eye",		"Type": "Monster"	},	{		"ModelType": 172,		"Name": "Ahriman",		"Type": "Mount"	},	{		"ModelType": 173,		"Name": "Dodo",		"Type": "Monster"	},	{		"ModelType": 174,		"Name": "Cockatrice",		"Type": "Monster"	},	{		"ModelType": 175,		"Name": "Cockatrice (Blue)",		"Type": "Monster"	},	{		"ModelType": 176,		"Name": "Coblyn",		"Type": "Monster"	},	{		"ModelType": 177,		"Name": "Doblyn",		"Type": "Monster"	},	{		"ModelType": 178,		"Name": "Crystal Coblyn",		"Type": "Monster"	},	{		"ModelType": 179,		"Name": "Drake",		"Type": "Monster"	},	{		"ModelType": 180,		"Name": "Biast",		"Type": "Monster"	},	{		"ModelType": 181,		"Name": "Battle Drake",		"Type": "Monster"	},	{		"ModelType": 182,		"Name": "Elbst",		"Type": "Monster"	},	{		"ModelType": 183,		"Name": "Aldgoat Billy",		"Type": "Monster"	},	{		"ModelType": 184,		"Name": "Aldgoat Nanny",		"Type": "Monster"	},	{		"ModelType": 185,		"Name": "Mosshorn",		"Type": "Monster"	},	{		"ModelType": 186,		"Name": "Magitek Juggernaut",		"Type": "Monster"	},	{		"ModelType": 187,		"Name": "Ogre",		"Type": "Monster"	},	{		"ModelType": 188,		"Name": "Hapalit",		"Type": "Monster"	},	{		"ModelType": 189,		"Name": "Hrimthurs",		"Type": "Monster"	},	{		"ModelType": 190,		"Name": "Apkallu",		"Type": "Monster"	},	{		"ModelType": 192,		"Name": "Antling Soldier",		"Type": "Monster"	},	{		"ModelType": 193,		"Name": "Antling Princess",		"Type": "Monster"	},	{		"ModelType": 194,		"Name": "Antling Worker",		"Type": "Monster"	},	{		"ModelType": 195,		"Name": "Antling Marshal",		"Type": "Monster"	},	{		"ModelType": 196,		"Name": "Antling Queen",		"Type": "Monster"	},	{		"ModelType": 197,		"Name": "Chimera",		"Type": "Monster"	},	{		"ModelType": 198,		"Name": "Goobbue",		"Type": "Monster"	},	{		"ModelType": 199,		"Name": "Highland Goobbue",		"Type": "Monster"	},	{		"ModelType": 200,		"Name": "Goobbue",		"Type": "Mount"	},	{		"ModelType": 201,		"Name": "Marshmallow (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 202,		"Name": "Gelato (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 203,		"Name": "Flan (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 204,		"Name": "Custard (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 205,		"Name": "Pudding (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 206,		"Name": "Bavarois (White-eyed)",		"Type": "Monster"	},	{		"ModelType": 207,		"Name": "Marshmallow (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 208,		"Name": "Gelato (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 209,		"Name": "Flan (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 210,		"Name": "Custard (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 211,		"Name": "Pudding (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 212,		"Name": "Bavarois (Black-eyed)",		"Type": "Monster"	},	{		"ModelType": 213,		"Name": "Magitek Vanguard",		"Type": "Monster"	},	{		"ModelType": 214,		"Name": "Magitek Vanguard H",		"Type": "Monster"	},	{		"ModelType": 215,		"Name": "Magitek Vanguard F",		"Type": "Monster"	},	{		"ModelType": 216,		"Name": "Lesser Gargoyle",		"Type": "Monster"	},	{		"ModelType": 217,		"Name": "Greater Gargoyle",		"Type": "Monster"	},	{		"ModelType": 218,		"Name": "Batraal",		"Type": "Monster"	},	{		"ModelType": 219,		"Name": "Cyclops",		"Type": "Monster"	},	{		"ModelType": 220,		"Name": "Elder Cyclops",		"Type": "Monster"	},	{		"ModelType": 221,		"Name": "Mammet (Red Helmet)",		"Type": "Monster"	},	{		"ModelType": 222,		"Name": "Mammet (Blue Helmet)",		"Type": "Monster"	},	{		"ModelType": 223,		"Name": "Mammet (Black Helmet)",		"Type": "Monster"	},	{		"ModelType": 224,		"Name": "Wyvern",		"Type": "Monster"	},	{		"ModelType": 225,		"Name": "Aery Wyvern",		"Type": "Monster"	},	{		"ModelType": 226,		"Name": "Twintania",		"Type": "Monster"	},	{		"ModelType": 227,		"Name": "Atomos",		"Type": "Monster"	},	{		"ModelType": 228,		"Name": "Shadow Dragon",		"Type": "Monster"	},	{		"ModelType": 229,		"Name": "Thunder Dragon",		"Type": "Monster"	},	{		"ModelType": 230,		"Name": "Moss Dragon",		"Type": "Monster"	},	{		"ModelType": 231,		"Name": "Ice Dragon",		"Type": "Monster"	},	{		"ModelType": 232,		"Name": "Zombie Dragon",		"Type": "Monster"	},	{		"ModelType": 233,		"Name": "Deathgaze",		"Type": "Monster"	},	{		"ModelType": 234,		"Name": "Blue Cobra",		"Type": "Monster"	},	{		"ModelType": 235,		"Name": "Red Cobra",		"Type": "Monster"	},	{		"ModelType": 236,		"Name": "Coeurlregina",		"Type": "Monster"	},	{		"ModelType": 237,		"Name": "Rock Gaol",		"Type": "Monster"	},	{		"ModelType": 238,		"Name": "Sandworm",		"Type": "Monster"	},	{		"ModelType": 239,		"Name": "Brineworm",		"Type": "Monster"	},	{		"ModelType": 240,		"Name": "Giant Tunnel Worm",		"Type": "Monster"	},	{		"ModelType": 241,		"Name": "Abyss Worm",		"Type": "Monster"	},	{		"ModelType": 242,		"Name": "Gigaworm",		"Type": "Monster"	},	{		"ModelType": 243,		"Name": "Siren",		"Type": "Monster"	},	{		"ModelType": 244,		"Name": "Five-Headed Dragon",		"Type": "Monster"	},	{		"ModelType": 245,		"Name": "Hydra",		"Type": "Monster"	},	{		"ModelType": 246,		"Name": "Three-Headed (blue)"	},	{		"ModelType": 247,		"Name": "Three-Headed (yellow)"	},	{		"ModelType": 248,		"Name": "Fenrir",		"Type": "Monster"	},	{		"ModelType": 249,		"Name": "Granite Gaol",		"Type": "Monster"	},	{		"ModelType": 250,		"Name": "Phlegethon",		"Type": "Monster"	},	{		"ModelType": 251,		"Name": "Amon",		"Type": "Monster"	},	{		"ModelType": 252,		"Name": "Cait Sith",		"Type": "Monster"	},	{		"ModelType": 253,		"Name": "Magitek Colossus",		"Type": "Monster"	},	{		"ModelType": 254,		"Name": "Rubricatus",		"Type": "Monster"	},	{		"ModelType": 255,		"Name": "Mark II Magitek Colossus",		"Type": "Monster"	},	{		"ModelType": 256,		"Name": "Demon Wall",		"Type": "Monster"	},	{		"ModelType": 257,		"Name": "Demon Wall (copy)",		"Type": "Monster"	},	{		"ModelType": 258,		"Name": "Demon Wall (copy)",		"Type": "Monster"	},	{		"ModelType": 259,		"Name": "Demon Wall (copy)",		"Type": "Monster"	},	{		"ModelType": 260,		"Name": "Demon Wall (copy)",		"Type": "Monster"	},	{		"ModelType": 261,		"Name": "Typhon",		"Type": "Monster"	},	{		"ModelType": 262,		"Name": "Typhon [Investigate]",		"Type": "Monster"	},	{		"ModelType": 263,		"Name": "Magic Pot",		"Type": "Monster"	},	{		"ModelType": 264,		"Name": "Bogy",		"Type": "Monster"	},	{		"ModelType": 265,		"Name": "Revenant",		"Type": "Monster"	},	{		"ModelType": 266,		"Name": "Phurble",		"Type": "Monster"	},	{		"ModelType": 267,		"Name": "Snurble",		"Type": "Monster"	},	{		"ModelType": 268,		"Name": "Angler",		"Type": "Monster"	},	{		"ModelType": 269,		"Name": "Remora",		"Type": "Monster"	},	{		"ModelType": 270,		"Name": "Orobon",		"Type": "Monster"	},	{		"ModelType": 271,		"Name": "Fire Elemental",		"Type": "Monster"	},	{		"ModelType": 272,		"Name": "Lightning Elemental",		"Type": "Monster"	},	{		"ModelType": 273,		"Name": "Water Elemental",		"Type": "Monster"	},	{		"ModelType": 274,		"Name": "Elemental (brown)",		"Type": "Monster"	},	{		"ModelType": 275,		"Name": "Elemental (red)",		"Type": "Monster"	},	{		"ModelType": 276,		"Name": "Ice Elemental",		"Type": "Monster"	},	{		"ModelType": 277,		"Name": "Wind Elemental",		"Type": "Monster"	},	{		"ModelType": 278,		"Name": "Earth Elemental",		"Type": "Monster"	},	{		"ModelType": 279,		"Name": "Aurelia",		"Type": "Monster"	},	{		"ModelType": 280,		"Name": "Sea Wasp",		"Type": "Monster"	},	{		"ModelType": 281,		"Name": "Dark Matter Aurelia",		"Type": "Monster"	},	{		"ModelType": 282,		"Name": "Mole",		"Type": "Monster"	},	{		"ModelType": 283,		"Name": "Hedgemole",		"Type": "Monster"	},	{		"ModelType": 284,		"Name": "Ram (bell)",		"Type": "Monster"	},	{		"ModelType": 285,		"Name": "Ram",		"Type": "Monster"	},	{		"ModelType": 286,		"Name": "Ewe (bell)",		"Type": "Monster"	},	{		"ModelType": 287,		"Name": "Ewe",		"Type": "Monster"	},	{		"ModelType": 288,		"Name": "Karakul Ram (bell)",		"Type": "Monster"	},	{		"ModelType": 289,		"Name": "Karakul Ram",		"Type": "Monster"	},	{		"ModelType": 290,		"Name": "Karakul Ewe (bell)",		"Type": "Monster"	},	{		"ModelType": 291,		"Name": "Karakul Ewe",		"Type": "Monster"	},	{		"ModelType": 292,		"Name": "Slime",		"Type": "Monster"	},	{		"ModelType": 293,		"Name": "Slime (yellow)"	},	{		"ModelType": 294,		"Name": "Slime (purple)"	},	{		"ModelType": 295,		"Name": "Rheum",		"Type": "Monster"	},	{		"ModelType": 296,		"Name": "Dark Matter Slime",		"Type": "Monster"	},	{		"ModelType": 297,		"Name": "Mandragora",		"Type": "Monster"	},	{		"ModelType": 298,		"Name": "Infernal Nail",		"Type": "Monster"	},	{		"ModelType": 299,		"Name": "Field Generator A",		"Type": "Monster"	},	{		"ModelType": 300,		"Name": "Field Generator B",		"Type": "Monster"	},	{		"ModelType": 301,		"Name": "Monolith",		"Type": "Monster"	},	{		"ModelType": 302,		"Name": "Garuda's Plume",		"Type": "Monster"	},	{		"ModelType": 303,		"Name": "Garuda",		"Type": "Monster"	},	{		"ModelType": 304,		"Name": "Ifrit",		"Type": "Monster"	},	{		"ModelType": 305,		"Name": "Leviathan",		"Type": "Monster"	},	{		"ModelType": 306,		"Name": "Titan",		"Type": "Monster"	},	{		"ModelType": 307,		"Name": "Ultima Weapon",		"Type": "Monster"	},	{		"ModelType": 308,		"Name": "Ultima Weapon (no wings)",		"Type": "Monster"	},	{		"ModelType": 309,		"Name": "Ultima Weapon (copy)",		"Type": "Monster"	},	{		"ModelType": 310,		"Name": "Ultima Weapon (no wings/copy",		"Type": "Monster"	},	{		"ModelType": 311,		"Name": "Sleipnir",		"Type": "Monster"	},	{		"ModelType": 312,		"Name": "Shiva (weapons)",		"Type": "Monster"	},	{		"ModelType": 313,		"Name": "Vishap",		"Type": "Monster"	},	{		"ModelType": 314,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 315,		"Name": "Shadowlurker",		"Type": "Monster"	},	{		"ModelType": 316,		"Name": "ADS (Black/Red)",		"Type": "Monster"	},	{		"ModelType": 317,		"Name": "ADS (Black/White)",		"Type": "Monster"	},	{		"ModelType": 318,		"Name": "ADS (Black/Purple)",		"Type": "Monster"	},	{		"ModelType": 319,		"Name": "ADS (Black/Blue)",		"Type": "Monster"	},	{		"ModelType": 320,		"Name": "ADS (Black/Teal)",		"Type": "Monster"	},	{		"ModelType": 321,		"Name": "ADS (Black/Green)",		"Type": "Monster"	},	{		"ModelType": 322,		"Name": "ADS (Black/Yellow)",		"Type": "Monster"	},	{		"ModelType": 323,		"Name": "ADS (Black/Orange)",		"Type": "Monster"	},	{		"ModelType": 324,		"Name": "Proto Ultima Arm Unit",		"Type": "Monster"	},	{		"ModelType": 325,		"Name": "BUGGED - DO NOT CLICK",		"Type": "Unknown"	},	{		"ModelType": 326,		"Name": "Exdeath",		"Type": "Monster"	},	{		"ModelType": 327,		"Name": "Omega",		"Type": "Monster"	},	{		"ModelType": 328,		"Name": "Morbol Seedling",		"Type": "Monster"	},	{		"ModelType": 329,		"Name": "Kraken",		"Type": "Monster"	},	{		"ModelType": 330,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 331,		"Name": "Magitek Death Claw",		"Type": "Monster"	},	{		"ModelType": 332,		"Name": "Allagan Death Claw",		"Type": "Monster"	},	{		"ModelType": 333,		"Name": "Diabolos",		"Type": "Monster"	},	{		"ModelType": 334,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 335,		"Name": "Bahamut",		"Type": "Monster"	},	{		"ModelType": 336,		"Name": "Bahamut (blue)",		"Type": "Monster"	},	{		"ModelType": 337,		"Name": "Phoenix",		"Type": "Monster"	},	{		"ModelType": 338,		"Name": "Nidhogg (Hraesvelgr's left eye)",		"Type": "Monster"	},	{		"ModelType": 339,		"Name": "Hraesvelgr",		"Type": "Monster"	},	{		"ModelType": 340,		"Name": "Beta Zaghnal",		"Type": "Monster"	},	{		"ModelType": 341,		"Name": "FFXIII Behemoth (white)",		"Type": "Monster"	},	{		"ModelType": 342,		"Name": "FFXIII Behemoth (red)",		"Type": "Monster"	},	{		"ModelType": 343,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 344,		"Name": "Temple Mummy",		"Type": "Monster"	},	{		"ModelType": 345,		"Name": "Ramuh",		"Type": "Monster"	},	{		"ModelType": 346,		"Name": "Diabolos (Sc�thach)",		"Type": "Monster"	},	{		"ModelType": 347,		"Name": "Glasya Labolas",		"Type": "Monster"	},	{		"ModelType": 348,		"Name": "Scylla",		"Type": "Monster"	},	{		"ModelType": 349,		"Name": "Xande",		"Type": "Monster"	},	{		"ModelType": 350,		"Name": "Cerberus",		"Type": "Monster"	},	{		"ModelType": 351,		"Name": "Angra�Mainyu",		"Type": "Monster"	},	{		"ModelType": 352,		"Name": "Cloud of Darkness",		"Type": "Monster"	},	{		"ModelType": 353,		"Name": "Gilgamesh (six weapons)",		"Type": "Monster"	},	{		"ModelType": 354,		"Name": "Ultros",		"Type": "Monster"	},	{		"ModelType": 355,		"Name": "Stoneshell",		"Type": "Monster"	},	{		"ModelType": 356,		"Name": "Pugil",		"Type": "Monster"	},	{		"ModelType": 357,		"Name": "Dark Matter Pugil",		"Type": "Monster"	},	{		"ModelType": 358,		"Name": "Bulb",		"Type": "Monster"	},	{		"ModelType": 359,		"Name": "Hornet",		"Type": "Monster"	},	{		"ModelType": 360,		"Name": "Colibri",		"Type": "Monster"	},	{		"ModelType": 361,		"Name": "Clockwork Dreadnaught",		"Type": "Monster"	},	{		"ModelType": 362,		"Name": "Dragonfly",		"Type": "Monster"	},	{		"ModelType": 363,		"Name": "Vodoriga",		"Type": "Monster"	},	{		"ModelType": 364,		"Name": "Uragnite",		"Type": "Monster"	},	{		"ModelType": 365,		"Name": "Taurus",		"Type": "Monster"	},	{		"ModelType": 366,		"Name": "Adjudicator",		"Type": "Monster"	},	{		"ModelType": 367,		"Name": "Qarn Face",		"Type": "Monster"	},	{		"ModelType": 368,		"Name": "Qarn Face (copy)"	},	{		"ModelType": 369,		"Name": "Qarn Face (copy)"	},	{		"ModelType": 370,		"Name": "Qarn Face (copy)"	},	{		"ModelType": 371,		"Name": "Shield Dragon",		"Type": "Monster"	},	{		"ModelType": 372,		"Name": "Baritine Croc",		"Type": "Monster"	},	{		"ModelType": 373,		"Name": "Feral Croc",		"Type": "Monster"	},	{		"ModelType": 374,		"Name": "Killer Mantis",		"Type": "Monster"	},	{		"ModelType": 375,		"Name": "Dark Matter Mantis",		"Type": "Monster"	},	{		"ModelType": 376,		"Name": "Preying Mantis",		"Type": "Monster"	},	{		"ModelType": 377,		"Name": "Aevis",		"Type": "Monster"	},	{		"ModelType": 378,		"Name": "Mirrorknight",		"Type": "Monster"	},	{		"ModelType": 379,		"Name": "Dreadknight",		"Type": "Monster"	},	{		"ModelType": 380,		"Name": "Rook",		"Type": "Monster"	},	{		"ModelType": 381,		"Name": "Fire Sprite",		"Type": "Monster"	},	{		"ModelType": 382,		"Name": "Ice Sprite",		"Type": "Monster"	},	{		"ModelType": 383,		"Name": "Wind Sprite",		"Type": "Monster"	},	{		"ModelType": 384,		"Name": "Lightning Sprite",		"Type": "Monster"	},	{		"ModelType": 385,		"Name": "Water Sprite",		"Type": "Monster"	},	{		"ModelType": 386,		"Name": "Earth Sprite",		"Type": "Monster"	},	{		"ModelType": 387,		"Name": "Clockwork Soldier",		"Type": "Monster"	},	{		"ModelType": 388,		"Name": "Clockwork Knight",		"Type": "Monster"	},	{		"ModelType": 389,		"Name": "Orb (Lightning / White Center)",		"Type": "Monster"	},	{		"ModelType": 390,		"Name": "Orb (Blue / Guildhest Water Bubble?)",		"Type": "Monster"	},	{		"ModelType": 391,		"Name": "Orb (Purple / Guildhest Water Bubble?)",		"Type": "Monster"	},	{		"ModelType": 392,		"Name": "Bubble (ground)",		"Type": "Monster"	},	{		"ModelType": 393,		"Name": "Maelstrom Cannon",		"Type": "Monster"	},	{		"ModelType": 394,		"Name": "Adder Cannon [Investigate]",		"Type": "Monster"	},	{		"ModelType": 395,		"Name": "Flame Cannon",		"Type": "Monster"	},	{		"ModelType": 396,		"Name": "Gremlin",		"Type": "Monster"	},	{		"ModelType": 397,		"Name": "Gremlin (red)"	},	{		"ModelType": 398,		"Name": "Gremlin (green)"	},	{		"ModelType": 399,		"Name": "Gremlin (yellow)"	},	{		"ModelType": 400,		"Name": "FFXIII Bahamut",		"Type": "Monster"	},	{		"ModelType": 401,		"Name": "Anubys"	},	{		"ModelType": 402,		"Name": "Fallen Neurolink"	},	{		"ModelType": 403,		"Name": "Flying Ice Dragon"	},	{		"ModelType": 404,		"Name": "Missile Carrier Claw (Castrum)"	},	{		"ModelType": 405,		"Name": "Missile Launcher (Castrum)"	},	{		"ModelType": 406,		"Name": "FFXI Shantotto"	},	{		"ModelType": 407,		"Name": "Eos"	},	{		"ModelType": 408,		"Name": "Selene"	},	{		"ModelType": 409,		"Name": "Emerald Carbuncle"	},	{		"ModelType": 410,		"Name": "Ruby Carbuncle"	},	{		"ModelType": 411,		"Name": "Sapphire Carbuncle"	},	{		"ModelType": 412,		"Name": "Topaz Carbuncle"	},	{		"ModelType": 413,		"Name": "Diamond Carbuncle"	},	{		"ModelType": 414,		"Name": "Obsidian Carbuncle"	},	{		"ModelType": 415,		"Name": "Ifrit-Egi"	},	{		"ModelType": 416,		"Name": "Titan-Egi"	},	{		"ModelType": 417,		"Name": "Garuda-Egi"	},	{		"ModelType": 418,		"Name": "Ramuh-Egi"	},	{		"ModelType": 419,		"Name": "Mammet 001",		"Type": "Minion"	},	{		"ModelType": 420,		"Name": "Mammet 003L",		"Type": "Minion"	},	{		"ModelType": 421,		"Name": "Mammet 003G",		"Type": "Minion"	},	{		"ModelType": 422,		"Name": "Mammet 003U",		"Type": "Minion"	},	{		"ModelType": 423,		"Name": "Wayward Hatchling",		"Type": "Minion"	},	{		"ModelType": 424,		"Name": "Storm Hatchling",		"Type": "Minion"	},	{		"ModelType": 425,		"Name": "Serpent Hatchling",		"Type": "Minion"	},	{		"ModelType": 426,		"Name": "Flame Hatchling",		"Type": "Minion"	},	{		"ModelType": 427,		"Name": "Cherry Bomb",		"Type": "Minion"	},	{		"ModelType": 428,		"Name": "Baby Behemoth",		"Type": "Minion"	},	{		"ModelType": 429,		"Name": "Morbol Seedling",		"Type": "Minion"	},	{		"ModelType": 430,		"Name": "Cait Sith Doll",		"Type": "Minion"	},	{		"ModelType": 431,		"Name": "Tiny Rat",		"Type": "Minion"	},	{		"ModelType": 432,		"Name": "Baby Bun",		"Type": "Minion"	},	{		"ModelType": 433,		"Name": "Chigoe Larva",		"Type": "Minion"	},	{		"ModelType": 434,		"Name": "Bluebird",		"Type": "Minion"	},	{		"ModelType": 435,		"Name": "Wide-eyed Fawn",		"Type": "Minion"	},	{		"ModelType": 436,		"Name": "Infant Imp",		"Type": "Minion"	},	{		"ModelType": 437,		"Name": "Coeurl Kitten",		"Type": "Minion"	},	{		"ModelType": 438,		"Name": "Black Coeurl",		"Type": "Minion"	},	{		"ModelType": 440,		"Name": "Gravel Golem",		"Type": "Minion"	},	{		"ModelType": 441,		"Name": "Wind-Up Tonberry",		"Type": "Minion"	},	{		"ModelType": 442,		"Name": "Tiny Tortoise",		"Type": "Minion"	},	{		"ModelType": 443,		"Name": "Baby Raptor",		"Type": "Minion"	},	{		"ModelType": 444,		"Name": "Baby Bat",		"Type": "Minion"	},	{		"ModelType": 445,		"Name": "Tiny Bulb",		"Type": "Minion"	},	{		"ModelType": 446,		"Name": "Dust Bunny",		"Type": "Minion"	},	{		"ModelType": 447,		"Name": "Wind-Up Dullahan",		"Type": "Minion"	},	{		"ModelType": 448,		"Name": "Gigantpole",		"Type": "Minion"	},	{		"ModelType": 449,		"Name": "Pudgy Puk",		"Type": "Minion"	},	{		"ModelType": 450,		"Name": "Buffalo Calf",		"Type": "Minion"	},	{		"ModelType": 451,		"Name": "Cactuar Cutting",		"Type": "Minion"	},	{		"ModelType": 452,		"Name": "Smallshell",		"Type": "Minion"	},	{		"ModelType": 453,		"Name": "Wolf Pup",		"Type": "Minion"	},	{		"ModelType": 454,		"Name": "Beady Eye",		"Type": "Minion"	},	{		"ModelType": 455,		"Name": "Fledgling Dodo",		"Type": "Minion"	},	{		"ModelType": 456,		"Name": "Coblyn Larva",		"Type": "Minion"	},	{		"ModelType": 457,		"Name": "Wind-Up Aldgoat",		"Type": "Minion"	},	{		"ModelType": 458,		"Name": "Fledgling Apkallu",		"Type": "Minion"	},	{		"ModelType": 459,		"Name": "Goobbue Sproutling",		"Type": "Minion"	},	{		"ModelType": 460,		"Name": "Bite-sized Pudding",		"Type": "Minion"	},	{		"ModelType": 461,		"Name": "Model Vanguard",		"Type": "Minion"	},	{		"ModelType": 462,		"Name": "Demon Brick",		"Type": "Minion"	},	{		"ModelType": 463,		"Name": "Mini Mole",		"Type": "Minion"	},	{		"ModelType": 464,		"Name": "Tender Lamb",		"Type": "Minion"	},	{		"ModelType": 465,		"Name": "Slime Puddle",		"Type": "Minion"	},	{		"ModelType": 466,		"Name": "Kidragora",		"Type": "Minion"	},	{		"ModelType": 467,		"Name": "Wind-Up Goblin",		"Type": "Minion"	},	{		"ModelType": 468,		"Name": "Wind-Up Sylph",		"Type": "Minion"	},	{		"ModelType": 469,		"Name": "Wind-Up Cursor",		"Type": "Minion"	},	{		"ModelType": 470,		"Name": "Wind-Up Airship",		"Type": "Minion"	},	{		"ModelType": 471,		"Name": "Wind-Up Qiqirn",		"Type": "Minion"	},	{		"ModelType": 472,		"Name": "Wind-Up Dalamud",		"Type": "Minion"	},	{		"ModelType": 474,		"Name": "Chocobo Carriage"	},	{		"ModelType": 477,		"Name": "Gaius van Baelsar - X Slash"	},	{		"ModelType": 478,		"Name": "Tornado"	},	{		"ModelType": 485,		"Name": "Spider egg covered by plant"	},	{		"ModelType": 486,		"Name": "Spider egg covered by plant - different model"	},	{		"ModelType": 487,		"Name": "Weird plant"	},	{		"ModelType": 488,		"Name": "Brown Crate"	},	{		"ModelType": 489,		"Name": "Sandbag"	},	{		"ModelType": 490,		"Name": "Barrel with 3 wine bottles"	},	{		"ModelType": 491,		"Name": "Giant bird's nest"	},	{		"ModelType": 492,		"Name": "Box crate"	},	{		"ModelType": 493,		"Name": "Brown chest"	},	{		"ModelType": 494,		"Name": "Brown Drawer"	},	{		"ModelType": 495,		"Name": "Brown shipping crate with rope on it"	},	{		"ModelType": 496,		"Name": "Metal container"	},	{		"ModelType": 497,		"Name": "Jar with tied fabric lid"	},	{		"ModelType": 498,		"Name": "Campfire"	},	{		"ModelType": 503,		"Name": "Fancy pillar"	},	{		"ModelType": 505,		"Name": "Black Chocobo Chick",		"Type": "Minion"	},	{		"ModelType": 506,		"Name": "Tonberry Scholar (+ Darkness Effect)"	},	{		"ModelType": 507,		"Name": "Batraal (b) (Copy)"	},	{		"ModelType": 508,		"Name": "Clockwork Bug"	},	{		"ModelType": 509,		"Name": "Dark Matter Pteroc"	},	{		"ModelType": 511,		"Name": "Orb (Red / Lightning)"	},	{		"ModelType": 512,		"Name": "Orb (Twintania's Hatch)"	},	{		"ModelType": 513,		"Name": "Orb (Green / Bright Lightning)"	},	{		"ModelType": 514,		"Name": "Orb (Watery / Music Symbol)"	},	{		"ModelType": 515,		"Name": "Floor Circle (Twintania's Conflagration)"	},	{		"ModelType": 516,		"Name": "Floor Circle (Ice)"	},	{		"ModelType": 517,		"Name": "Floor Circle (Twintania's Liquid Hell)"	},	{		"ModelType": 518,		"Name": "Bertha Cannon"	},	{		"ModelType": 519,		"Name": "FFXIII Odin"	},	{		"ModelType": 520,		"Name": "Lightning (FFXIII Character)"	},	{		"ModelType": 521,		"Name": "Mythril Verge"	},	{		"ModelType": 523,		"Name": "Dreadknight Bind"	},	{		"ModelType": 524,		"Name": "Barrel of Cannonballs"	},	{		"ModelType": 525,		"Name": "Small Device"	},	{		"ModelType": 527,		"Name": "Wind-Up Shantotto",		"Type": "Minion"	},	{		"ModelType": 528,		"Name": "Box with Maps"	},	{		"ModelType": 529,		"Name": "Box"	},	{		"ModelType": 530,		"Name": "Crate"	},	{		"ModelType": 531,		"Name": "Standard w/ Torch"	},	{		"ModelType": 532,		"Name": "Book Glow (Green) (?)"	},	{		"ModelType": 533,		"Name": "Bomb Decoration (?)"	},	{		"ModelType": 534,		"Name": "Unicorn (Mount)"	},	{		"ModelType": 535,		"Name": "Small Void Gate"	},	{		"ModelType": 536,		"Name": "Large Void Gate"	},	{		"ModelType": 537,		"Name": "Belias-Egi"	},	{		"ModelType": 538,		"Name": "Gungnir"	},	{		"ModelType": 539,		"Name": "Black Circle"	},	{		"ModelType": 540,		"Name": "Glowing Circle"	},	{		"ModelType": 541,		"Name": "Purple (Book Glow?)"	},	{		"ModelType": 542,		"Name": "T-Pose Default Model"	},	{		"ModelType": 543,		"Name": "T-Pose Default Model"	},	{		"ModelType": 544,		"Name": "T-Pose Default Model"	},	{		"ModelType": 545,		"Name": "T-Pose Default Model"	},	{		"ModelType": 546,		"Name": "T-Pose Default Model"	},	{		"ModelType": 547,		"Name": "Generic Person"	},	{		"ModelType": 548,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 549,		"Name": "Generic Person"	},	{		"ModelType": 550,		"Name": "Spotlight"	},	{		"ModelType": 551,		"Name": "Garuda's Plume (Blue Aether)"	},	{		"ModelType": 552,		"Name": "Garuda's Plume (Pink Aether)"	},	{		"ModelType": 553,		"Name": "Garuda's Plume (No Aether)"	},	{		"ModelType": 554,		"Name": "Titan"	},	{		"ModelType": 555,		"Name": "Ancient Wyvern (- Neurolinks)"	},	{		"ModelType": 556,		"Name": "Floor Circle (Conflagration)"	},	{		"ModelType": 557,		"Name": "Floor Circle (Conflagration)"	},	{		"ModelType": 558,		"Name": "Caduceus"	},	{		"ModelType": 559,		"Name": "Blue Cobra (Glowing)"	},	{		"ModelType": 560,		"Name": "Red Cobra (Glowing)"	},	{		"ModelType": 562,		"Name": "Rat (2)"	},	{		"ModelType": 563,		"Name": "Catoblepas"	},	{		"ModelType": 564,		"Name": "Nandi"	},	{		"ModelType": 565,		"Name": "Catoblepas C (Yellow w/ Magenta)"	},	{		"ModelType": 566,		"Name": "Celphie"	},	{		"ModelType": 567,		"Name": "Archdemon"	},	{		"ModelType": 568,		"Name": "Archdemon (II) (Copy)"	},	{		"ModelType": 569,		"Name": "Archdemon (III) (Copy)"	},	{		"ModelType": 570,		"Name": "Okeanis A (Blue/Orange)"	},	{		"ModelType": 571,		"Name": "Ceremony Chocobo"	},	{		"ModelType": 572,		"Name": "Okeanis C (Red/Purple)"	},	{		"ModelType": 573,		"Name": "Okeanis D (Yellow)"	},	{		"ModelType": 574,		"Name": "Gold Bear"	},	{		"ModelType": 575,		"Name": "Tiger"	},	{		"ModelType": 576,		"Name": "Earthen Brickman (Dragon Quest)"	},	{		"ModelType": 577,		"Name": "Wind-Up Brickman",		"Type": "Minion"	},	{		"ModelType": 578,		"Name": "Minute Mindflayer",		"Type": "Minion"	},	{		"ModelType": 579,		"Name": "Tight-beaked Parrot",		"Type": "Minion"	},	{		"ModelType": 580,		"Name": "Wind-Up Amalj'aa",		"Type": "Minion"	},	{		"ModelType": 581,		"Name": "Wind-Up Ixal",		"Type": "Minion"	},	{		"ModelType": 582,		"Name": "Wind-Up Kobolder",		"Type": "Minion"	},	{		"ModelType": 583,		"Name": "Wind-Up Sea Devil",		"Type": "Minion"	},	{		"ModelType": 584,		"Name": "Wind-Up Edvya",		"Type": "Minion"	},	{		"ModelType": 585,		"Name": "Wind-Up Sun",		"Type": "Minion"	},	{		"ModelType": 586,		"Name": "Plush Cushion",		"Type": "Minion"	},	{		"ModelType": 587,		"Name": "Minion of Light (Minion) (Warrior)"	},	{		"ModelType": 588,		"Name": "Behemoth (Mount)"	},	{		"ModelType": 589,		"Name": "Stone Brickman (Dragon Quest)"	},	{		"ModelType": 590,		"Name": "Golden Brickman (Dragon Quest)"	},	{		"ModelType": 591,		"Name": "Imp (On Fire)"	},	{		"ModelType": 592,		"Name": "Cavalry Drake (Mount)"	},	{		"ModelType": 593,		"Name": "Laurel Goobbue (Mount)"	},	{		"ModelType": 594,		"Name": "Nightmare (Mount)"	},	{		"ModelType": 595,		"Name": "Zu Cockerel"	},	{		"ModelType": 596,		"Name": "Zu Pullet"	},	{		"ModelType": 597,		"Name": "Generic Person"	},	{		"ModelType": 598,		"Name": "Spotted Zu Egg"	},	{		"ModelType": 599,		"Name": "White Zu Egg"	},	{		"ModelType": 600,		"Name": "Leech"	},	{		"ModelType": 601,		"Name": "Bhoot"	},	{		"ModelType": 602,		"Name": "Sandman"	},	{		"ModelType": 603,		"Name": "Manticore"	},	{		"ModelType": 604,		"Name": "Zu"	},	{		"ModelType": 605,		"Name": "Dullahan (NNYNB) (Purple)"	},	{		"ModelType": 606,		"Name": "Zombie War Hound"	},	{		"ModelType": 607,		"Name": "Floating Eye (+ Void Effect)"	},	{		"ModelType": 608,		"Name": "Corrupted Flan"	},	{		"ModelType": 609,		"Name": "Iron Giant"	},	{		"ModelType": 610,		"Name": "Corrupted Slime"	},	{		"ModelType": 611,		"Name": "Garuda's Plume (Green Aether)"	},	{		"ModelType": 612,		"Name": "Corrupted Sprite"	},	{		"ModelType": 613,		"Name": "Pharos Aether Cloud"	},	{		"ModelType": 614,		"Name": "Orb (Green / Lighting w/ Purple Outline)"	},	{		"ModelType": 615,		"Name": "Amalj'aa Beacon"	},	{		"ModelType": 616,		"Name": "Sylph Shroom"	},	{		"ModelType": 617,		"Name": "Snowman"	},	{		"ModelType": 618,		"Name": "Granite Gaoler"	},	{		"ModelType": 619,		"Name": "Voidsent Energy Spear"	},	{		"ModelType": 620,		"Name": "Voidsent Energy Scythe"	},	{		"ModelType": 621,		"Name": "Generic Person"	},	{		"ModelType": 622,		"Name": "Void Portal"	},	{		"ModelType": 623,		"Name": "Minion of Light (Minion) (White Mage)"	},	{		"ModelType": 624,		"Name": "Minion of Light (Minion) (Black Mage)"	},	{		"ModelType": 625,		"Name": "Wind-Up Leader (Minion) (Raubahn)"	},	{		"ModelType": 626,		"Name": "Wind-Up Leader (Minion) (Merlwyb)"	},	{		"ModelType": 627,		"Name": "Wind-Up Leader (Minion) (Kan-E-Senna)"	},	{		"ModelType": 628,		"Name": "Starlight Treant"	},	{		"ModelType": 629,		"Name": "Rock (Gray)"	},	{		"ModelType": 630,		"Name": "Spear stuck in ground"	},	{		"ModelType": 631,		"Name": "Fancy pillar"	},	{		"ModelType": 632,		"Name": "Fancy circular relic"	},	{		"ModelType": 633,		"Name": "Clockwork Spider"	},	{		"ModelType": 634,		"Name": "Princely Hatchling",		"Type": "Minion"	},	{		"ModelType": 635,		"Name": "Wind"	},	{		"ModelType": 636,		"Name": "Gilgamesh (Bradamante)"	},	{		"ModelType": 637,		"Name": "Jandelaine",		"Type": "Character"	},	{		"ModelType": 638,		"Name": "Vassago"	},	{		"ModelType": 639,		"Name": "Green Toad (Battle on the Big Bridge)"	},	{		"ModelType": 640,		"Name": "Decaying Gourmand"	},	{		"ModelType": 641,		"Name": "Gobmachine G-VI"	},	{		"ModelType": 642,		"Name": "Leviathan's Tail"	},	{		"ModelType": 643,		"Name": "Fat Chocobo (Mount)"	},	{		"ModelType": 644,		"Name": "Bomb Palanquin (Mount)"	},	{		"ModelType": 645,		"Name": "Wamouracampa"	},	{		"ModelType": 646,		"Name": "Wamoura/Silkmoth"	},	{		"ModelType": 647,		"Name": "Nael deus Darnus"	},	{		"ModelType": 648,		"Name": "Mimic"	},	{		"ModelType": 649,		"Name": "Orb (Diabolos Nightmare)"	},	{		"ModelType": 650,		"Name": "Key"	},	{		"ModelType": 652,		"Name": "Enkidu (Chicken)"	},	{		"ModelType": 653,		"Name": "Arioch"	},	{		"ModelType": 654,		"Name": "Damselfly"	},	{		"ModelType": 655,		"Name": "Rafflesia"	},	{		"ModelType": 656,		"Name": "Dark Matter Bulb"	},	{		"ModelType": 657,		"Name": "Dark Matter Hornet"	},	{		"ModelType": 658,		"Name": "The Avatar"	},	{		"ModelType": 659,		"Name": "Down Wyvern"	},	{		"ModelType": 660,		"Name": "Fire Dragon"	},	{		"ModelType": 661,		"Name": "Dalamud Spawn"	},	{		"ModelType": 662,		"Name": "Flying Thunder Dragon"	},	{		"ModelType": 663,		"Name": "Flying Moss Dragon"	},	{		"ModelType": 664,		"Name": "Flying Fire Dragon"	},	{		"ModelType": 665,		"Name": "Flying Zombie Dragon"	},	{		"ModelType": 666,		"Name": "Rock (White)"	},	{		"ModelType": 667,		"Name": "Rock (White) (II)"	},	{		"ModelType": 668,		"Name": "Rock (White) (III)"	},	{		"ModelType": 669,		"Name": "N/A"	},	{		"ModelType": 670,		"Name": "Goblin Bomb"	},	{		"ModelType": 671,		"Name": "Goblin Bomb (Skull)"	},	{		"ModelType": 672,		"Name": "Goblin Bomb (Spiked)"	},	{		"ModelType": 673,		"Name": "Magitek Vangob"	},	{		"ModelType": 674,		"Name": "Pyracmon"	},	{		"ModelType": 675,		"Name": "Direwolf (Mount)"	},	{		"ModelType": 676,		"Name": "Orb (Yellow / Bubble)"	},	{		"ModelType": 677,		"Name": "Brown crate"	},	{		"ModelType": 678,		"Name": "Bomb Incubator (Red)"	},	{		"ModelType": 679,		"Name": "Whelk Ballista"	},	{		"ModelType": 681,		"Name": "Wind Cylinder"	},	{		"ModelType": 682,		"Name": "Zu Hatchling",		"Type": "Minion"	},	{		"ModelType": 683,		"Name": "Wind-Up Odin",		"Type": "Minion"	},	{		"ModelType": 684,		"Name": "Wind-Up Warrior of Light",		"Type": "Minion"	},	{		"ModelType": 685,		"Name": "Wind-Up Bahamut",		"Type": "Minion"	},	{		"ModelType": 686,		"Name": "Baby Opo-opo",		"Type": "Minion"	},	{		"ModelType": 687,		"Name": "Magic Broom",		"Type": "Minion"	},	{		"ModelType": 688,		"Name": "Wind-Up Moogle",		"Type": "Minion"	},	{		"ModelType": 689,		"Name": "Cavalry Elbst (Mount)"	},	{		"ModelType": 690,		"Name": "Hecteyes"	},	{		"ModelType": 691,		"Name": "Imp C (Green)"	},	{		"ModelType": 692,		"Name": "Gilgamesh (Unarmed)"	},	{		"ModelType": 693,		"Name": "Wamouracampa (II) (Copy)"	},	{		"ModelType": 694,		"Name": "Wamoura (II) (Copy)"	},	{		"ModelType": 695,		"Name": "Dark Matter Roselet"	},	{		"ModelType": 696,		"Name": "Crate"	},	{		"ModelType": 697,		"Name": "Spiked Balls"	},	{		"ModelType": 698,		"Name": "Dark Matter Slug (Honey)"	},	{		"ModelType": 699,		"Name": "Wind-Up Kobld",		"Type": "Minion"	},	{		"ModelType": 700,		"Name": "Wind-Up Sahagin",		"Type": "Minion"	},	{		"ModelType": 701,		"Name": "Generic Person"	},	{		"ModelType": 702,		"Name": "Default Model"	},	{		"ModelType": 703,		"Name": "Default Model"	},	{		"ModelType": 704,		"Name": "Default Model"	},	{		"ModelType": 705,		"Name": "Default Model"	},	{		"ModelType": 706,		"Name": "Default Model"	},	{		"ModelType": 707,		"Name": "Default Model"	},	{		"ModelType": 708,		"Name": "Default Model"	},	{		"ModelType": 709,		"Name": "Default Model"	},	{		"ModelType": 710,		"Name": "Default Model"	},	{		"ModelType": 711,		"Name": "Default Model"	},	{		"ModelType": 712,		"Name": "Default Model"	},	{		"ModelType": 713,		"Name": "Aithon (Mount)"	},	{		"ModelType": 714,		"Name": "Xanthos (Mount)"	},	{		"ModelType": 715,		"Name": "Markab (Mount)"	},	{		"ModelType": 716,		"Name": "Einbarr (Mount)"	},	{		"ModelType": 717,		"Name": "Persona"	},	{		"ModelType": 718,		"Name": "Armored Bear mount"	},	{		"ModelType": 719,		"Name": "Warbear (Mount)"	},	{		"ModelType": 720,		"Name": "Golden Lion mount"	},	{		"ModelType": 721,		"Name": "Warlion (Mount)"	},	{		"ModelType": 722,		"Name": "Sallet Crab"	},	{		"ModelType": 723,		"Name": "Leg Trap"	},	{		"ModelType": 724,		"Name": "Narbrooi"	},	{		"ModelType": 725,		"Name": "Kraken's Arm"	},	{		"ModelType": 726,		"Name": "Kraken's Tentacle"	},	{		"ModelType": 727,		"Name": "Harpeia"	},	{		"ModelType": 728,		"Name": "Ninki Nanka (w/ Nankas)"	},	{		"ModelType": 729,		"Name": "Ninki Nanka"	},	{		"ModelType": 730,		"Name": "Diresaur"	},	{		"ModelType": 731,		"Name": "Gorynich"	},	{		"ModelType": 732,		"Name": "Adamantoise Dragon"	},	{		"ModelType": 733,		"Name": "Allagan Naga"	},	{		"ModelType": 734,		"Name": "Avere Bravearm"	},	{		"ModelType": 735,		"Name": "Sasquatch"	},	{		"ModelType": 736,		"Name": "Floor Circle (Water / Hullbreaker)"	},	{		"ModelType": 737,		"Name": "Bubble (Hullbreaker)"	},	{		"ModelType": 738,		"Name": "Large Red Frog"	},	{		"ModelType": 739,		"Name": "Shield Dragonling"	},	{		"ModelType": 740,		"Name": "Nanka"	},	{		"ModelType": 741,		"Name": "Ogrebon"	},	{		"ModelType": 742,		"Name": "Onion Prince",		"Type": "Minion"	},	{		"ModelType": 743,		"Name": "Eggplant Knight",		"Type": "Minion"	},	{		"ModelType": 744,		"Name": "Garlic Jester",		"Type": "Minion"	},	{		"ModelType": 745,		"Name": "Tomato King",		"Type": "Minion"	},	{		"ModelType": 746,		"Name": "Mandragora Queen",		"Type": "Minion"	},	{		"ModelType": 747,		"Name": "Treasure Box",		"Type": "Minion"	},	{		"ModelType": 748,		"Name": "Wind-Up Succubus",		"Type": "Minion"	},	{		"ModelType": 749,		"Name": "Wind-Up Onion Knight",		"Type": "Minion"	},	{		"ModelType": 750,		"Name": "Wind-Up Y'shtola",		"Type": "Minion"	},	{		"ModelType": 751,		"Name": "Wind-Up Nanamo",		"Type": "Minion"	},	{		"ModelType": 752,		"Name": "Nana Bear",		"Type": "Minion"	},	{		"ModelType": 753,		"Name": "Miniature Minecart",		"Type": "Minion"	},	{		"ModelType": 754,		"Name": "Tiny Tapir",		"Type": "Minion"	},	{		"ModelType": 755,		"Name": "Nutkin",		"Type": "Minion"	},	{		"ModelType": 756,		"Name": "Wind-Up Gilgamesh",		"Type": "Minion"	},	{		"ModelType": 757,		"Name": "Onion Prince"	},	{		"ModelType": 758,		"Name": "Eggplant Knight"	},	{		"ModelType": 759,		"Name": "Garlic Prince"	},	{		"ModelType": 760,		"Name": "Tomato King"	},	{		"ModelType": 761,		"Name": "Mandragora Queen"	},	{		"ModelType": 763,		"Name": "Enkidu (Primal)"	},	{		"ModelType": 764,		"Name": "Icicle"	},	{		"ModelType": 766,		"Name": "Interceptor Drone (PVP)"	},	{		"ModelType": 767,		"Name": "Yeti"	},	{		"ModelType": 768,		"Name": "Scylla's Staff"	},	{		"ModelType": 769,		"Name": "Main Meteor Target"	},	{		"ModelType": 770,		"Name": "Dullahan (YYYYB) (Blue)"	},	{		"ModelType": 771,		"Name": "Dullahan (NNYYB) (Red)"	},	{		"ModelType": 772,		"Name": "Okeanis B (Green/Blue)"	},	{		"ModelType": 773,		"Name": "Allagan Mamool Ja Warrior"	},	{		"ModelType": 774,		"Name": "Kum Kum"	},	{		"ModelType": 775,		"Name": "Clockwork Bit"	},	{		"ModelType": 776,		"Name": "Gomory"	},	{		"ModelType": 777,		"Name": "Tursus"	},	{		"ModelType": 778,		"Name": "Azer"	},	{		"ModelType": 779,		"Name": "Ice Gaol"	},	{		"ModelType": 780,		"Name": "Interceptor Node (PVP)"	},	{		"ModelType": 781,		"Name": "Abaia"	},	{		"ModelType": 782,		"Name": "Aevis B (White)"	},	{		"ModelType": 783,		"Name": "Orb (Red / Syrcus Fire)"	},	{		"ModelType": 784,		"Name": "Orb (Blue / Syrcus Ice)"	},	{		"ModelType": 785,		"Name": "Orb (Purple / Syrcus Lightning)"	},	{		"ModelType": 786,		"Name": "Orb (Purple / Aether Lines)"	},	{		"ModelType": 787,		"Name": "Orb (Purple / Tam-Tara HM?)"	},	{		"ModelType": 788,		"Name": "Orb (Dark Blue)"	},	{		"ModelType": 789,		"Name": "Orb (Purple)"	},	{		"ModelType": 790,		"Name": "Hunters Moon Disc (Syrcus)"	},	{		"ModelType": 791,		"Name": "Aetherochemical Explosion Marker (Syrcus)"	},	{		"ModelType": 792,		"Name": "Varis zos Galvus"	},	{		"ModelType": 793,		"Name": "Archbishop Thordan VII"	},	{		"ModelType": 794,		"Name": "Endymion"	},	{		"ModelType": 795,		"Name": "Boogeyman"	},	{		"ModelType": 796,		"Name": "Wind-Up Thancred",		"Type": "Minion"	},	{		"ModelType": 797,		"Name": "Wind-Up Minfilia",		"Type": "Minion"	},	{		"ModelType": 798,		"Name": "Mummy's Little Mummy",		"Type": "Minion"	},	{		"ModelType": 799,		"Name": "Wind-Up Ultros",		"Type": "Minion"	},	{		"ModelType": 800,		"Name": "Heavy Hatchling",		"Type": "Minion"	},	{		"ModelType": 801,		"Name": "Littlefoot",		"Type": "Minion"	},	{		"ModelType": 802,		"Name": "Fat Cat",		"Type": "Minion"	},	{		"ModelType": 803,		"Name": "Hoary the Snowman",		"Type": "Minion"	},	{		"ModelType": 805,		"Name": "Demon Box",		"Type": "Minion"	},	{		"ModelType": 807,		"Name": "Assassin Fry",		"Type": "Minion"	},	{		"ModelType": 808,		"Name": "Naughty Nanka",		"Type": "Minion"	},	{		"ModelType": 809,		"Name": "Wind-Up Delivery Moogle",		"Type": "Minion"	},	{		"ModelType": 810,		"Name": "Small Red Frog"	},	{		"ModelType": 811,		"Name": "Warsteed (Maelstrom)"	},	{		"ModelType": 812,		"Name": "Warsteed (Adders)"	},	{		"ModelType": 813,		"Name": "Warsteed (Flames)"	},	{		"ModelType": 814,		"Name": "Postmoogle"	},	{		"ModelType": 815,		"Name": "Field Generator B (Allagan)"	},	{		"ModelType": 816,		"Name": "Wind-Up Panda",		"Type": "Minion"	},	{		"ModelType": 817,		"Name": "Gullfaxi (Mount)"	},	{		"ModelType": 818,		"Name": "Boreas (Mount)"	},	{		"ModelType": 819,		"Name": "Small Meteor Target"	},	{		"ModelType": 820,		"Name": "Moonfire Elbst (Mount) (2014)"	},	{		"ModelType": 821,		"Name": "Fireworks Launcher"	},	{		"ModelType": 822,		"Name": "Kaliya"	},	{		"ModelType": 824,		"Name": "Karlabos"	},	{		"ModelType": 825,		"Name": "Ice Commander"	},	{		"ModelType": 826,		"Name": "Battle Biast"	},	{		"ModelType": 827,		"Name": "Gaelicat"	},	{		"ModelType": 828,		"Name": "Sentient Inkhorn"	},	{		"ModelType": 829,		"Name": "ADS (Cuboid - Black - Red)"	},	{		"ModelType": 830,		"Name": "ADS (Ovoid - Black - Red)"	},	{		"ModelType": 831,		"Name": "Byblos"	},	{		"ModelType": 832,		"Name": "Gnath"	},	{		"ModelType": 833,		"Name": "Imdugud"	},	{		"ModelType": 834,		"Name": "Opken"	},	{		"ModelType": 835,		"Name": "White Gaol"	},	{		"ModelType": 836,		"Name": "Water Imp (Dragon's Neck)"	},	{		"ModelType": 837,		"Name": "Manxome�Molaa�Ja�Ja"	},	{		"ModelType": 838,		"Name": "Frumious Koheel Ja (on Wivre)"	},	{		"ModelType": 839,		"Name": "Crawler"	},	{		"ModelType": 840,		"Name": "Bitoso"	},	{		"ModelType": 841,		"Name": "Deepeye"	},	{		"ModelType": 842,		"Name": "Reptoid"	},	{		"ModelType": 843,		"Name": "Vicegerent's Right Hand"	},	{		"ModelType": 844,		"Name": "Vicegerent's Left Hand"	},	{		"ModelType": 845,		"Name": "Captain Madison (Monster)"	},	{		"ModelType": 846,		"Name": "Daughter of Imdugud"	},	{		"ModelType": 847,		"Name": "Son of Imdugud"	},	{		"ModelType": 848,		"Name": "Orb (Phoenix's Blackfire)"	},	{		"ModelType": 849,		"Name": "Floor Fire (Phoenix)"	},	{		"ModelType": 850,		"Name": "Orb (Phoenix's Redfire)"	},	{		"ModelType": 851,		"Name": "Bennu (Small)"	},	{		"ModelType": 852,		"Name": "Bennu (Medium)"	},	{		"ModelType": 853,		"Name": "Bennu (Large)"	},	{		"ModelType": 854,		"Name": "Phoenix (Glowing)"	},	{		"ModelType": 855,		"Name": "The Blood of Meracydia"	},	{		"ModelType": 856,		"Name": "The Pain of Meracydia (Neurolinked)"	},	{		"ModelType": 857,		"Name": "The Gust of Meracydia"	},	{		"ModelType": 858,		"Name": "The Shadow of Meracydia"	},	{		"ModelType": 859,		"Name": "The Sin of Meracydia (Neurolinked)"	},	{		"ModelType": 860,		"Name": "Vicegerent's Head"	},	{		"ModelType": 861,		"Name": "Sastasha Pugil"	},	{		"ModelType": 862,		"Name": "Belah'dian Knight"	},	{		"ModelType": 863,		"Name": "Steinbock Doe"	},	{		"ModelType": 864,		"Name": "Snoll"	},	{		"ModelType": 865,		"Name": "Spriggan (Blue-eyed: Ice Rock)"	},	{		"ModelType": 866,		"Name": "Sleipnir (Mount)"	},	{		"ModelType": 867,		"Name": "Snowball?"	},	{		"ModelType": 868,		"Name": "Temple Mummy (Lalafell)"	},	{		"ModelType": 869,		"Name": "Temple Mummy (Roegadyn)"	},	{		"ModelType": 870,		"Name": "Polar Bear"	},	{		"ModelType": 871,		"Name": "Vine (Purple)"	},	{		"ModelType": 872,		"Name": "Vine"	},	{		"ModelType": 873,		"Name": "Sabotender Empiratriz"	},	{		"ModelType": 874,		"Name": "Sabotender Guardia"	},	{		"ModelType": 875,		"Name": "Sabotender Guardia (+ Shield)"	},	{		"ModelType": 876,		"Name": "Vicegerent to the Warden"	},	{		"ModelType": 877,		"Name": "Sentient Tome"	},	{		"ModelType": 878,		"Name": "Wind-Up Yda",		"Type": "Minion"	},	{		"ModelType": 879,		"Name": "Wind-Up Papalymo",		"Type": "Minion"	},	{		"ModelType": 880,		"Name": "Wind-Up Urianger",		"Type": "Minion"	},	{		"ModelType": 881,		"Name": "Wind-Up Louisoix",		"Type": "Minion"	},	{		"ModelType": 882,		"Name": "Wind-Up Gentleman",		"Type": "Minion"	},	{		"ModelType": 883,		"Name": "Midgardsormr",		"Type": "Minion"	},	{		"ModelType": 884,		"Name": "Wind-Up Alphinaud",		"Type": "Minion"	},	{		"ModelType": 885,		"Name": "Wind-Up Alisaie",		"Type": "Minion"	},	{		"ModelType": 886,		"Name": "Water Imp",		"Type": "Minion"	},	{		"ModelType": 887,		"Name": "Model Enterprise",		"Type": "Minion"	},	{		"ModelType": 888,		"Name": "Enkidu",		"Type": "Minion"	},	{		"ModelType": 889,		"Name": "Wind-Up Gundu Warrior",		"Type": "Minion"	},	{		"ModelType": 890,		"Name": "Unicolt",		"Type": "Minion"	},	{		"ModelType": 891,		"Name": "Wind-Up Cid",		"Type": "Minion"	},	{		"ModelType": 892,		"Name": "Wind-Up Tataru",		"Type": "Minion"	},	{		"ModelType": 893,		"Name": "Owlet",		"Type": "Minion"	},	{		"ModelType": 894,		"Name": "Atrophied Atomos",		"Type": "Minion"	},	{		"ModelType": 895,		"Name": "Lesser Panda",		"Type": "Minion"	},	{		"ModelType": 896,		"Name": "Clockwork Barrow",		"Type": "Minion"	},	{		"ModelType": 897,		"Name": "Griffin Hatchling",		"Type": "Minion"	},	{		"ModelType": 898,		"Name": "Iron Dwarf",		"Type": "Minion"	},	{		"ModelType": 899,		"Name": "Ugly Duckling",		"Type": "Minion"	},	{		"ModelType": 900,		"Name": "Page 63",		"Type": "Minion"	},	{		"ModelType": 901,		"Name": "Wind-Up Violet",		"Type": "Minion"	},	{		"ModelType": 902,		"Name": "Wind-Up Founder",		"Type": "Minion"	},	{		"ModelType": 903,		"Name": "Wind-Up Dezul Qualan",		"Type": "Minion"	},	{		"ModelType": 904,		"Name": "Skatene"	},	{		"ModelType": 905,		"Name": "Paissa"	},	{		"ModelType": 906,		"Name": "Typhon's FUNGAH!"	},	{		"ModelType": 907,		"Name": "A Tornado"	},	{		"ModelType": 908,		"Name": "4-tonze Weight"	},	{		"ModelType": 909,		"Name": "Damaged Adjudicator"	},	{		"ModelType": 910,		"Name": "Orb (Sandy / Qarn HM?)"	},	{		"ModelType": 911,		"Name": "Shiva (No Weapons)"	},	{		"ModelType": 912,		"Name": "Feridad"	},	{		"ModelType": 913,		"Name": "Bandersnatch"	},	{		"ModelType": 914,		"Name": "Miacid"	},	{		"ModelType": 915,		"Name": "Syricta"	},	{		"ModelType": 916,		"Name": "Empuse"	},	{		"ModelType": 917,		"Name": "Midgardsormr (Head)"	},	{		"ModelType": 918,		"Name": "Page 64/128/256"	},	{		"ModelType": 919,		"Name": "Okeanis E (Blue/Red)"	},	{		"ModelType": 920,		"Name": "Imp (b)"	},	{		"ModelType": 921,		"Name": "Bat (b) (Copy)"	},	{		"ModelType": 922,		"Name": "Floating Eye (b)"	},	{		"ModelType": 923,		"Name": "Bogy (b) (Copy)"	},	{		"ModelType": 924,		"Name": "Vodoriga (b)"	},	{		"ModelType": 925,		"Name": "Everliving Bibliotaph"	},	{		"ModelType": 926,		"Name": "Midgardsormr (Mount)"	},	{		"ModelType": 927,		"Name": "Megalotragus"	},	{		"ModelType": 928,		"Name": "Orb (Purple/Blue)"	},	{		"ModelType": 929,		"Name": "White Manacutter (Mount)"	},	{		"ModelType": 930,		"Name": "Magitek Gunship"	},	{		"ModelType": 931,		"Name": "Orb (Green)"	},	{		"ModelType": 932,		"Name": "Ultros (One Lump)"	},	{		"ModelType": 933,		"Name": "Ultros (Two Lumps)"	},	{		"ModelType": 934,		"Name": "Ulros (Three Lumps)"	},	{		"ModelType": 935,		"Name": "Vodoriga (Slumbering)"	},	{		"ModelType": 936,		"Name": "Mamool Ja sacred Standard"	},	{		"ModelType": 937,		"Name": "Mamool Ja sacred Standard"	},	{		"ModelType": 941,		"Name": "Gungnir"	},	{		"ModelType": 942,		"Name": "Archaeosaur"	},	{		"ModelType": 943,		"Name": "Bladed Vinegaroon"	},	{		"ModelType": 944,		"Name": "Archaeornis"	},	{		"ModelType": 945,		"Name": "Falak"	},	{		"ModelType": 946,		"Name": "Waukkeon"	},	{		"ModelType": 947,		"Name": "Spear"	},	{		"ModelType": 948,		"Name": "Wivre"	},	{		"ModelType": 949,		"Name": "Tarantula Hawk"	},	{		"ModelType": 950,		"Name": "Brobinyak"	},	{		"ModelType": 951,		"Name": "Yak"	},	{		"ModelType": 952,		"Name": "Vouivre"	},	{		"ModelType": 953,		"Name": "Nunyenunc"	},	{		"ModelType": 954,		"Name": "Harmachis"	},	{		"ModelType": 955,		"Name": "Griffin"	},	{		"ModelType": 956,		"Name": "Anchag"	},	{		"ModelType": 957,		"Name": "Mylodon"	},	{		"ModelType": 958,		"Name": "Kirin (Mount)"	},	{		"ModelType": 959,		"Name": "Kaliya (II) (Copy)"	},	{		"ModelType": 960,		"Name": "Orb (Blue)"	},	{		"ModelType": 962,		"Name": "Oppressor"	},	{		"ModelType": 963,		"Name": "Manipulator"	},	{		"ModelType": 964,		"Name": "SDS Fenrir"	},	{		"ModelType": 965,		"Name": "Parade Chocobo (Mount)"	},	{		"ModelType": 966,		"Name": "Chocobo (II)"	},	{		"ModelType": 967,		"Name": "Sacrificed Allagan Mamool Ja Warrior"	},	{		"ModelType": 968,		"Name": "Garm"	},	{		"ModelType": 969,		"Name": "Queen Scylla"	},	{		"ModelType": 970,		"Name": "Atomos Avatar"	},	{		"ModelType": 971,		"Name": "Sacrificed Soldier"	},	{		"ModelType": 972,		"Name": "Dragonfire Fly"	},	{		"ModelType": 973,		"Name": "Triad Table"	},	{		"ModelType": 974,		"Name": "Einhander"	},	{		"ModelType": 975,		"Name": "Bismarck"	},	{		"ModelType": 976,		"Name": "Ravana (Four Small Swords)"	},	{		"ModelType": 977,		"Name": "Tioman"	},	{		"ModelType": 978,		"Name": "Steam Doll (Faust)"	},	{		"ModelType": 979,		"Name": "Magitek Gobwidow"	},	{		"ModelType": 980,		"Name": "Proto-Ultima"	},	{		"ModelType": 981,		"Name": "Cloud of Darkness (- Clouds)"	},	{		"ModelType": 982,		"Name": "White Knight"	},	{		"ModelType": 983,		"Name": "Fire Dragonet"	},	{		"ModelType": 984,		"Name": "Oliphaunt"	},	{		"ModelType": 985,		"Name": "Alpha Groundskeeper"	},	{		"ModelType": 986,		"Name": "Demon Tome"	},	{		"ModelType": 987,		"Name": "Adamantoise (Mount)"	},	{		"ModelType": 988,		"Name": "Gaelikitten",		"Type": "Minion"	},	{		"ModelType": 989,		"Name": "Wind-Up Kain",		"Type": "Minion"	},	{		"ModelType": 990,		"Name": "Chocobo Chick Courier",		"Type": "Minion"	},	{		"ModelType": 991,		"Name": "Broken Mooglebox",		"Type": "Minion"	},	{		"ModelType": 992,		"Name": "Griffin (Mount)"	},	{		"ModelType": 993,		"Name": "Waitress",		"Type": "Character"	},	{		"ModelType": 994,		"Name": "Mirage Dragon (Thunder)"	},	{		"ModelType": 995,		"Name": "Mirage Dragon (Ice)"	},	{		"ModelType": 996,		"Name": "Astraea"	},	{		"ModelType": 997,		"Name": "Ceruleum Tank"	},	{		"ModelType": 998,		"Name": "Ceruleum Tank"	},	{		"ModelType": 999,		"Name": "Generator (Keeper of the Lake)"	},	{		"ModelType": 1000,		"Name": "Atomos Prime"	},	{		"ModelType": 1001,		"Name": "Dragon Head (Gilgamesh)"	},	{		"ModelType": 1002,		"Name": "Snare (Steps of Faith)"	},	{		"ModelType": 1003,		"Name": "Exploding Barrels (Steps of Faith)"	},	{		"ModelType": 1004,		"Name": "Xande's Clone"	},	{		"ModelType": 1005,		"Name": "Two-Headed Dragon"	},	{		"ModelType": 1006,		"Name": "Dark Sprite"	},	{		"ModelType": 1007,		"Name": "Orb (White / Five-headed Dragon?)"	},	{		"ModelType": 1008,		"Name": "Orb (Blue Static)"	},	{		"ModelType": 1009,		"Name": "Cloud of Darkness' Dark Storm"	},	{		"ModelType": 1010,		"Name": "Orb (Binding Chains)"	},	{		"ModelType": 1011,		"Name": "Gobwalker (Mount)"	},	{		"ModelType": 1012,		"Name": "Vinegaroon"	},	{		"ModelType": 1013,		"Name": "Piston Lubricant"	},	{		"ModelType": 1014,		"Name": "Gear Lubricant"	},	{		"ModelType": 1015,		"Name": "Orb (Lightning)"	},	{		"ModelType": 1016,		"Name": "Model Magitek Bit",		"Type": "Minion"	},	{		"ModelType": 1017,		"Name": "Puff of Darkness",		"Type": "Minion"	},	{		"ModelType": 1018,		"Name": "Mandragora (b) (Gardening Copy)"	},	{		"ModelType": 1019,		"Name": "Midgardsormr (Head)"	},	{		"ModelType": 1020,		"Name": "Midgardsormr (Head)"	},	{		"ModelType": 1021,		"Name": "ADS (Enormous Egg) (Hartching-tide 2015)"	},	{		"ModelType": 1022,		"Name": "Spriggan (Yellow-eyed w/ Red Egg)"	},	{		"ModelType": 1023,		"Name": "Spriggan (Yellow-eyed w/ Yellow Egg)"	},	{		"ModelType": 1024,		"Name": "Generic Person - Carrying Crate",		"Type": "Character"	},	{		"ModelType": 1025,		"Name": "Cloud of Darkness - Dark Cloud"	},	{		"ModelType": 1026,		"Name": "Fenrir (Mount)"	},	{		"ModelType": 1027,		"Name": "Rook Autoturret"	},	{		"ModelType": 1028,		"Name": "Bishop Autoturret"	},	{		"ModelType": 1029,		"Name": "Logistics System"	},	{		"ModelType": 1030,		"Name": "Magitek Gunship B (Blue)"	},	{		"ModelType": 1031,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1032,		"Name": "Hecteyes (II) (Slightly Lighter Copy)"	},	{		"ModelType": 1033,		"Name": "Lily of the Saint"	},	{		"ModelType": 1034,		"Name": "Corpse Flower"	},	{		"ModelType": 1035,		"Name": "Icetrap"	},	{		"ModelType": 1036,		"Name": "Melia"	},	{		"ModelType": 1037,		"Name": "Frostbitten War Hound"	},	{		"ModelType": 1038,		"Name": "Gastornis"	},	{		"ModelType": 1039,		"Name": "Zoblyn"	},	{		"ModelType": 1040,		"Name": "Hropken"	},	{		"ModelType": 1041,		"Name": "Minotaur"	},	{		"ModelType": 1042,		"Name": "Elder Wyvern"	},	{		"ModelType": 1043,		"Name": "Endymion B (Rainbow)"	},	{		"ModelType": 1044,		"Name": "Meracydian Vouivre"	},	{		"ModelType": 1045,		"Name": "Sankchinni"	},	{		"ModelType": 1046,		"Name": "Korrigan"	},	{		"ModelType": 1047,		"Name": "Ascian Prime"	},	{		"ModelType": 1048,		"Name": "Nidhogg (Hraesvelgr's Left Eye / Fresh Scars)"	},	{		"ModelType": 1049,		"Name": "Nidhogg (No Eyes / Fresh Left Scar)"	},	{		"ModelType": 1050,		"Name": "Hraesvelgr (One Eye)"	},	{		"ModelType": 1051,		"Name": "Tiamat"	},	{		"ModelType": 1052,		"Name": "Tulihand"	},	{		"ModelType": 1053,		"Name": "Bifericeras"	},	{		"ModelType": 1054,		"Name": "Vanu Totem"	},	{		"ModelType": 1055,		"Name": "Ratel"	},	{		"ModelType": 1056,		"Name": "Sun Leech"	},	{		"ModelType": 1057,		"Name": "Clay Claw"	},	{		"ModelType": 1058,		"Name": "Sanuwa"	},	{		"ModelType": 1060,		"Name": "Living Liquid (Vessel)"	},	{		"ModelType": 1061,		"Name": "Living Liquid (Anthromorph)"	},	{		"ModelType": 1062,		"Name": "Living Liquid (Chiromorph Right)"	},	{		"ModelType": 1063,		"Name": "Living Liquid (Chiromorph Left)"	},	{		"ModelType": 1064,		"Name": "Dhalmel"	},	{		"ModelType": 1065,		"Name": "Pegasus (Mount)"	},	{		"ModelType": 1066,		"Name": "Matoya"	},	{		"ModelType": 1067,		"Name": "King Thordan"	},	{		"ModelType": 1068,		"Name": "Topaz Carbuncle",		"Type": "Minion"	},	{		"ModelType": 1070,		"Name": "Cloth Scraps?"	},	{		"ModelType": 1071,		"Name": "Dragonkiller Cannon"	},	{		"ModelType": 1072,		"Name": "Raskovnik"	},	{		"ModelType": 1073,		"Name": "Gallimimus"	},	{		"ModelType": 1074,		"Name": "Bit C (Red)"	},	{		"ModelType": 1075,		"Name": "Poroggo"	},	{		"ModelType": 1076,		"Name": "Biohazard"	},	{		"ModelType": 1078,		"Name": "Rheum of the Mountain"	},	{		"ModelType": 1079,		"Name": "Blood of the Mountain"	},	{		"ModelType": 1080,		"Name": "Black Knight"	},	{		"ModelType": 1081,		"Name": "Clockwork Spider B (Violet Glow)"	},	{		"ModelType": 1082,		"Name": "Gobtank"	},	{		"ModelType": 1083,		"Name": "Eruca"	},	{		"ModelType": 1084,		"Name": "Oppressor 0.5"	},	{		"ModelType": 1085,		"Name": "Ravana (Glowing Red: Two Large Swords)"	},	{		"ModelType": 1086,		"Name": "Ravana (Shadowed)"	},	{		"ModelType": 1087,		"Name": "Ravana (Two Large Swords)"	},	{		"ModelType": 1088,		"Name": "Beta Groundskeeper"	},	{		"ModelType": 1089,		"Name": "Enforcement Droid"	},	{		"ModelType": 1090,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1092,		"Name": "Cultured Shabti"	},	{		"ModelType": 1093,		"Name": "Shabti"	},	{		"ModelType": 1094,		"Name": "Biblioklept"	},	{		"ModelType": 1095,		"Name": "Phantom Ray"	},	{		"ModelType": 1096,		"Name": "Moon Gana"	},	{		"ModelType": 1097,		"Name": "Spirit Gana"	},	{		"ModelType": 1098,		"Name": "Steam Bit"	},	{		"ModelType": 1099,		"Name": "Iksalion"	},	{		"ModelType": 1100,		"Name": "The Curator"	},	{		"ModelType": 1101,		"Name": "Vanu Vanu"	},	{		"ModelType": 1102,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1103,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1104,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1105,		"Name": "Chandrahas"	},	{		"ModelType": 1106,		"Name": "Amphiptere"	},	{		"ModelType": 1107,		"Name": "Azys Lla ADS (Spheroid - Silver - Red)"	},	{		"ModelType": 1108,		"Name": "Azys Lla ADS (Spheroid - Silver - White)"	},	{		"ModelType": 1109,		"Name": "Azys Lla ADS (Spheroid - Silver - Violet)"	},	{		"ModelType": 1110,		"Name": "Azys Lla ADS (Spheroid - Silver - Lavender)"	},	{		"ModelType": 1111,		"Name": "Azys Lla ADS (Spheroid - Silver - Aqua)"	},	{		"ModelType": 1112,		"Name": "Azys Lla ADS (Spheroid - Silver - Green)"	},	{		"ModelType": 1113,		"Name": "Azys Lla ADS (Spheroid - Silver - Yellow)"	},	{		"ModelType": 1114,		"Name": "Azys Lla ADS (Spheroid - Silver - Orange)"	},	{		"ModelType": 1115,		"Name": "Azys Lla ADS (Spheroid - White - Red)"	},	{		"ModelType": 1116,		"Name": "Azys Lla ADS (Spheroid - White - White)"	},	{		"ModelType": 1117,		"Name": "Azys Lla ADS (Spheroid - White - Violet)"	},	{		"ModelType": 1118,		"Name": "Azys Lla ADS (Spheroid - White - Lavender)"	},	{		"ModelType": 1119,		"Name": "Azys Lla ADS (Spheroid - White - Aqua)"	},	{		"ModelType": 1120,		"Name": "Azys Lla ADS (Spheroid - White - Green)"	},	{		"ModelType": 1121,		"Name": "Azys Lla ADS (Spheroid - White - Yellow)"	},	{		"ModelType": 1122,		"Name": "Azys Lla ADS (Spheroid - White - Orange)"	},	{		"ModelType": 1123,		"Name": "Azys Lla ADS (Cuboid - Silver - Red)"	},	{		"ModelType": 1124,		"Name": "Azys Lla ADS (Cuboid - Silver - White)"	},	{		"ModelType": 1125,		"Name": "Azys Lla ADS (Cuboid - Silver - Violet)"	},	{		"ModelType": 1126,		"Name": "Azys Lla ADS (Cuboid - Silver - Lavender)"	},	{		"ModelType": 1127,		"Name": "Azys Lla ADS (Cuboid - Silver - Aqua)"	},	{		"ModelType": 1128,		"Name": "Azys Lla ADS (Cuboid - Silver - Green)"	},	{		"ModelType": 1129,		"Name": "Azys Lla ADS (Cuboid - Silver - Yellow)"	},	{		"ModelType": 1130,		"Name": "Azys Lla ADS (Cuboid - Silver - Orange)"	},	{		"ModelType": 1131,		"Name": "Azys Lla ADS (Cuboid - White - Red)"	},	{		"ModelType": 1132,		"Name": "Azys Lla ADS (Cuboid - White - White)"	},	{		"ModelType": 1133,		"Name": "Azys Lla ADS (Cuboid - White - Violet)"	},	{		"ModelType": 1134,		"Name": "Azys Lla ADS (Cuboid - White - Lavender)"	},	{		"ModelType": 1135,		"Name": "Azys Lla ADS (Cuboid - White - Aqua)"	},	{		"ModelType": 1136,		"Name": "Azys Lla ADS (Cuboid - White - Green)"	},	{		"ModelType": 1137,		"Name": "Azys Lla ADS (Cuboid - White - Yellow)"	},	{		"ModelType": 1138,		"Name": "Azys Lla ADS (Cuboid - White - Orange)"	},	{		"ModelType": 1139,		"Name": "Azys Lla ADS (Ovoid - Silver - Red)"	},	{		"ModelType": 1140,		"Name": "Azys Lla ADS (Ovoid - Silver - White)"	},	{		"ModelType": 1141,		"Name": "Azys Lla ADS (Ovoid - Silver - Violet)"	},	{		"ModelType": 1142,		"Name": "Azys Lla ADS (Ovoid - Silver - Lavender)"	},	{		"ModelType": 1143,		"Name": "Azys Lla ADS (Ovoid - Silver - Aqua)"	},	{		"ModelType": 1144,		"Name": "Azys Lla ADS (Ovoid - Silver - Green)"	},	{		"ModelType": 1145,		"Name": "Azys Lla ADS (Ovoid - Silver - Yellow)"	},	{		"ModelType": 1146,		"Name": "Azys Lla ADS (Ovoid - Silver - Orange)"	},	{		"ModelType": 1147,		"Name": "Azys Lla ADS (Ovoid - White - Red)"	},	{		"ModelType": 1148,		"Name": "Azys Lla ADS (Ovoid - White - White)"	},	{		"ModelType": 1149,		"Name": "Azys Lla ADS (Ovoid - White - Violet)"	},	{		"ModelType": 1150,		"Name": "Azys Lla ADS (Ovoid - White - Lavender)"	},	{		"ModelType": 1151,		"Name": "Azys Lla ADS (Ovoid - White - Aqua)"	},	{		"ModelType": 1152,		"Name": "Azys Lla ADS (Ovoid - White - Green)"	},	{		"ModelType": 1153,		"Name": "Azys Lla ADS (Ovoid - White - Yellow)"	},	{		"ModelType": 1154,		"Name": "Azys Lla ADS (Ovoid - White - Orange)"	},	{		"ModelType": 1155,		"Name": "Toco Toco"	},	{		"ModelType": 1156,		"Name": "Cathedral Gargoyle"	},	{		"ModelType": 1157,		"Name": "Sphinx"	},	{		"ModelType": 1158,		"Name": "Pterygotus"	},	{		"ModelType": 1159,		"Name": "Griffin B (Brown)"	},	{		"ModelType": 1160,		"Name": "Sanguiptere"	},	{		"ModelType": 1161,		"Name": "Sanuwa (Mount)"	},	{		"ModelType": 1162,		"Name": "Behemoth Heir",		"Type": "Minion"	},	{		"ModelType": 1163,		"Name": "Accompanyment Node",		"Type": "Minion"	},	{		"ModelType": 1164,		"Name": "Steam-powered Gobwalker G-VII",		"Type": "Minion"	},	{		"ModelType": 1165,		"Name": "Wind-Up Iceheart",		"Type": "Minion"	},	{		"ModelType": 1166,		"Name": "Wind-Up Gestahl",		"Type": "Minion"	},	{		"ModelType": 1167,		"Name": "Wind-Up Yugiri",		"Type": "Minion"	},	{		"ModelType": 1168,		"Name": "Emerald Carbuncle",		"Type": "Minion"	},	{		"ModelType": 1169,		"Name": "Bug minion with army hat"	},	{		"ModelType": 1170,		"Name": "Paissa Brat",		"Type": "Minion"	},	{		"ModelType": 1171,		"Name": "Wind-Up Illuminatus",		"Type": "Minion"	},	{		"ModelType": 1172,		"Name": "Pumpkin Butler",		"Type": "Minion"	},	{		"ModelType": 1173,		"Name": "Hunting Hawk",		"Type": "Minion"	},	{		"ModelType": 1174,		"Name": "Shalloweye",		"Type": "Minion"	},	{		"ModelType": 1175,		"Name": "Penguin Prince",		"Type": "Minion"	},	{		"ModelType": 1176,		"Name": "Wind-Up Relm",		"Type": "Minion"	},	{		"ModelType": 1181,		"Name": "Nunyenunc's Shadow"	},	{		"ModelType": 1182,		"Name": "Bit D (Black & Gold)"	},	{		"ModelType": 1183,		"Name": "Steam Bit B (Purple)"	},	{		"ModelType": 1184,		"Name": "Panther (Mount)"	},	{		"ModelType": 1185,		"Name": "Graoully"	},	{		"ModelType": 1186,		"Name": "Vidofnir"	},	{		"ModelType": 1187,		"Name": "Coeurlregina (Darkened)"	},	{		"ModelType": 1188,		"Name": "So'sanuwa"	},	{		"ModelType": 1189,		"Name": "Ul'sanuwa"	},	{		"ModelType": 1190,		"Name": "Ice Dragonet"	},	{		"ModelType": 1191,		"Name": "Moss Dragonet"	},	{		"ModelType": 1192,		"Name": "Dragon Statue (Aery)"	},	{		"ModelType": 1193,		"Name": "Crystals"	},	{		"ModelType": 1194,		"Name": "Drakespur"	},	{		"ModelType": 1195,		"Name": "Garuda's Plume (Many Feathers)"	},	{		"ModelType": 1196,		"Name": "Orb (Blue Fire)"	},	{		"ModelType": 1197,		"Name": "Orb (Green Wind)"	},	{		"ModelType": 1198,		"Name": "Orb (Red/Blue)"	},	{		"ModelType": 1199,		"Name": "Orb (Green Cloud)"	},	{		"ModelType": 1200,		"Name": "Orb (Fire)"	},	{		"ModelType": 1201,		"Name": "Circle (Vertical Purple Effect)"	},	{		"ModelType": 1202,		"Name": "Orb (Sky Blue)"	},	{		"ModelType": 1203,		"Name": "Orb (Golden Electricity)"	},	{		"ModelType": 1204,		"Name": "Orb (Bubble)"	},	{		"ModelType": 1205,		"Name": "Wind Circle"	},	{		"ModelType": 1206,		"Name": "Water Circle"	},	{		"ModelType": 1207,		"Name": "Landmine (Pulsing)"	},	{		"ModelType": 1208,		"Name": "Orb (Darkness)"	},	{		"ModelType": 1209,		"Name": "Gaius van Baelsar X Slash"	},	{		"ModelType": 1210,		"Name": "Elder Syricta"	},	{		"ModelType": 1211,		"Name": "Poroggo (+ Blue Hat)"	},	{		"ModelType": 1212,		"Name": "Gold Rush Minecart",		"Type": "Minion"	},	{		"ModelType": 1213,		"Name": "Black Fat Cat",		"Type": "Minion"	},	{		"ModelType": 1214,		"Name": "Senmurv"	},	{		"ModelType": 1215,		"Name": "The Pale Rider"	},	{		"ModelType": 1216,		"Name": "Gandarewa"	},	{		"ModelType": 1217,		"Name": "Bird of Paradise"	},	{		"ModelType": 1218,		"Name": "Leucrotta"	},	{		"ModelType": 1219,		"Name": "Mirka"	},	{		"ModelType": 1220,		"Name": "Pylraster"	},	{		"ModelType": 1221,		"Name": "Bune"	},	{		"ModelType": 1222,		"Name": "Agathos"	},	{		"ModelType": 1223,		"Name": "Campacti"	},	{		"ModelType": 1224,		"Name": "Stench Blossom"	},	{		"ModelType": 1225,		"Name": "Alteci"	},	{		"ModelType": 1226,		"Name": "Thextera"	},	{		"ModelType": 1227,		"Name": "The Scarecrow"	},	{		"ModelType": 1228,		"Name": "Tonberry Marauder"	},	{		"ModelType": 1229,		"Name": "Gobtank G-IV"	},	{		"ModelType": 1230,		"Name": "Magic Broom 2",		"Type": "Minion"	},	{		"ModelType": 1231,		"Name": "Flying Shark"	},	{		"ModelType": 1232,		"Name": "Sword"	},	{		"ModelType": 1234,		"Name": "Cuchulainn"	},	{		"ModelType": 1235,		"Name": "Drum Bit A (Red)"	},	{		"ModelType": 1236,		"Name": "Bit E (Blue & Orange)"	},	{		"ModelType": 1237,		"Name": "Field Generator A (Allagan)"	},	{		"ModelType": 1238,		"Name": "Vedrfolnir"	},	{		"ModelType": 1239,		"Name": "Boomtype Magitek Gobwalker G-VII"	},	{		"ModelType": 1240,		"Name": "Sentient Inkhorn 2 (Flightless)"	},	{		"ModelType": 1241,		"Name": "King Thordan (b)"	},	{		"ModelType": 1242,		"Name": "Knight of the Round"	},	{		"ModelType": 1243,		"Name": "Knight of the Round (2)"	},	{		"ModelType": 1244,		"Name": "Orb (Spinning Discs?)"	},	{		"ModelType": 1245,		"Name": "Cone (Spinning Discs?)"	},	{		"ModelType": 1246,		"Name": "Orb (White / Five Heade Dragon?)"	},	{		"ModelType": 1249,		"Name": "Twintania (Mount)"	},	{		"ModelType": 1250,		"Name": "Knight of the Round (b)"	},	{		"ModelType": 1251,		"Name": "Wyvern"	},	{		"ModelType": 1252,		"Name": "Thunder Dragon (b)"	},	{		"ModelType": 1253,		"Name": "Moss Dragon (b)"	},	{		"ModelType": 1254,		"Name": "Ice Dragon (b)"	},	{		"ModelType": 1255,		"Name": "Fire Dragon (b)"	},	{		"ModelType": 1256,		"Name": "Zombie Dragon (b)"	},	{		"ModelType": 1257,		"Name": "Vidofnir (b)"	},	{		"ModelType": 1258,		"Name": "Flying Thunder Dragon (b)"	},	{		"ModelType": 1259,		"Name": "Flying Moss Dragon (b)"	},	{		"ModelType": 1260,		"Name": "Flying Ice Dragon (b)"	},	{		"ModelType": 1261,		"Name": "Flying Fire Dragon (b)"	},	{		"ModelType": 1262,		"Name": "Flying Zombie Dragon (Grounded)"	},	{		"ModelType": 1263,		"Name": "Ice Dragonet (b)"	},	{		"ModelType": 1264,		"Name": "Midgardsormr (Mount)"	},	{		"ModelType": 1265,		"Name": "Generic Person"	},	{		"ModelType": 1266,		"Name": "Fallen Debris (Dusk Vigil)"	},	{		"ModelType": 1267,		"Name": "Fallen Debris (Dusk Vigil)"	},	{		"ModelType": 1268,		"Name": "Fallen Debris (Dusk Vigil)"	},	{		"ModelType": 1269,		"Name": "Purple Wyrm with pink eyes"	},	{		"ModelType": 1270,		"Name": "Belladonna"	},	{		"ModelType": 1271,		"Name": "Hybodus"	},	{		"ModelType": 1272,		"Name": "Echidna"	},	{		"ModelType": 1273,		"Name": "Blackguard"	},	{		"ModelType": 1274,		"Name": "Queen Hawk"	},	{		"ModelType": 1275,		"Name": "Sawtooth"	},	{		"ModelType": 1276,		"Name": "Hellhound"	},	{		"ModelType": 1277,		"Name": "Darkscale"	},	{		"ModelType": 1278,		"Name": "Flying Graoully"	},	{		"ModelType": 1279,		"Name": "Manipulator (Four Short Legs)"	},	{		"ModelType": 1280,		"Name": "Shiva (Sword)"	},	{		"ModelType": 1281,		"Name": "Rose Garden"	},	{		"ModelType": 1283,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1288,		"Name": "Holder with 3 banners in it"	},	{		"ModelType": 1289,		"Name": "Banner"	},	{		"ModelType": 1290,		"Name": "Glowing Purple Crystal"	},	{		"ModelType": 1291,		"Name": "Bird's Nest / Rosebear"	},	{		"ModelType": 1292,		"Name": "Brown drawer"	},	{		"ModelType": 1293,		"Name": "Living Rock"	},	{		"ModelType": 1294,		"Name": "Living Rock (II) (Copy)"	},	{		"ModelType": 1295,		"Name": "Poroggo C (Purple w/ Blue Hat)"	},	{		"ModelType": 1296,		"Name": "Vodoriga (II) (Slightly Lighter Copy)"	},	{		"ModelType": 1297,		"Name": "Grizzly Host"	},	{		"ModelType": 1298,		"Name": "Progenitrix"	},	{		"ModelType": 1299,		"Name": "Progenitor"	},	{		"ModelType": 1300,		"Name": "Water Tornado (Neverreap? Alexander?)"	},	{		"ModelType": 1301,		"Name": "Biloko"	},	{		"ModelType": 1302,		"Name": "Triceratops"	},	{		"ModelType": 1303,		"Name": "Brachiosaur"	},	{		"ModelType": 1304,		"Name": "Construct 8"	},	{		"ModelType": 1305,		"Name": "Ligeia"	},	{		"ModelType": 1306,		"Name": "Meracydian Falak"	},	{		"ModelType": 1307,		"Name": "Falak (II) (Copy)"	},	{		"ModelType": 1308,		"Name": "Grey Bomb"	},	{		"ModelType": 1309,		"Name": "Remedy Bomb"	},	{		"ModelType": 1310,		"Name": "Diplocaulus"	},	{		"ModelType": 1311,		"Name": "Foobar"	},	{		"ModelType": 1312,		"Name": "Dexter (Mob-Left Frill)"	},	{		"ModelType": 1313,		"Name": "Bismarck (Broken Chitin)"	},	{		"ModelType": 1314,		"Name": "Gana C (Purple/Yellow)"	},	{		"ModelType": 1315,		"Name": "Korpokkur"	},	{		"ModelType": 1316,		"Name": "FFXI Beetle"	},	{		"ModelType": 1317,		"Name": "Ghrah Lumiary (Sphere)"	},	{		"ModelType": 1318,		"Name": "Wind-Up Ifrit",		"Type": "Minion"	},	{		"ModelType": 1319,		"Name": "Clockwork Twintania",		"Type": "Minion"	},	{		"ModelType": 1320,		"Name": "Korpokkur Kid",		"Type": "Minion"	},	{		"ModelType": 1321,		"Name": "Wind-Up Firion",		"Type": "Minion"	},	{		"ModelType": 1322,		"Name": "Wind-Up Echidna",		"Type": "Minion"	},	{		"ModelType": 1323,		"Name": "Barghest"	},	{		"ModelType": 1324,		"Name": "Plague Purge"	},	{		"ModelType": 1326,		"Name": "Witch's Broom (Mount)"	},	{		"ModelType": 1327,		"Name": "Ascian Prime (Not Glowing)"	},	{		"ModelType": 1328,		"Name": "Sinister (Mob-Right Frill)"	},	{		"ModelType": 1330,		"Name": "Wind up Garuda",		"Type": "Minion"	},	{		"ModelType": 1331,		"Name": "Wind up Titan",		"Type": "Minion"	},	{		"ModelType": 1332,		"Name": "Midgardsormr",		"Type": "Minion"	},	{		"ModelType": 1333,		"Name": "Wind up Yshtola",		"Type": "Minion"	},	{		"ModelType": 1334,		"Name": "Wind-Up Haurchefant",		"Type": "Minion"	},	{		"ModelType": 1335,		"Name": "Wind-Up Nero",		"Type": "Minion"	},	{		"ModelType": 1336,		"Name": "Wind-Up Krile",		"Type": "Minion"	},	{		"ModelType": 1337,		"Name": "Little bird",		"Type": "Minion"	},	{		"ModelType": 1338,		"Name": "Pteranodon"	},	{		"ModelType": 1339,		"Name": "Irminsul (Small)"	},	{		"ModelType": 1340,		"Name": "Irminsul (Large)"	},	{		"ModelType": 1341,		"Name": "Sawbones (Head Vine)"	},	{		"ModelType": 1342,		"Name": "Echidna (Lamia)"	},	{		"ModelType": 1343,		"Name": "Army hat bug",		"Type": "Minion"	},	{		"ModelType": 1344,		"Name": "Boomtype Magitek Gobwalker G-VII (b)"	},	{		"ModelType": 1345,		"Name": "Sephirot"	},	{		"ModelType": 1346,		"Name": "Cetus"	},	{		"ModelType": 1347,		"Name": "Corruption (Sphere)"	},	{		"ModelType": 1348,		"Name": "Corruption (Doll)"	},	{		"ModelType": 1349,		"Name": "Corruption (Vulture)"	},	{		"ModelType": 1350,		"Name": "Corruption (Spider)"	},	{		"ModelType": 1351,		"Name": "Diabolos (b)"	},	{		"ModelType": 1352,		"Name": "Onslaughter (Alexander)"	},	{		"ModelType": 1353,		"Name": "Blaster (Alexander)"	},	{		"ModelType": 1354,		"Name": "Vortexer (Alexander)"	},	{		"ModelType": 1355,		"Name": "Swindler (Alexander)"	},	{		"ModelType": 1356,		"Name": "Brawler (Alexander)"	},	{		"ModelType": 1357,		"Name": "Brute Justice?"	},	{		"ModelType": 1358,		"Name": "Glowing Brute Justice?"	},	{		"ModelType": 1359,		"Name": "Void Ark Scrap"	},	{		"ModelType": 1360,		"Name": "The Pagan's Knot"	},	{		"ModelType": 1361,		"Name": "Pharos HM Generator"	},	{		"ModelType": 1362,		"Name": "Rose Hip"	},	{		"ModelType": 1363,		"Name": "Hunched Goblin"	},	{		"ModelType": 1364,		"Name": "Weird flying bug"	},	{		"ModelType": 1365,		"Name": "Scary Floating Demon"	},	{		"ModelType": 1366,		"Name": "Piloted Sky Armor"	},	{		"ModelType": 1367,		"Name": "Rose Bud"	},	{		"ModelType": 1368,		"Name": "Bomb Incubator (Blue)"	},	{		"ModelType": 1369,		"Name": "Ghrah Lumiary (Doll)"	},	{		"ModelType": 1371,		"Name": "Spider"	},	{		"ModelType": 1372,		"Name": "Orb (Red/Black)"	},	{		"ModelType": 1373,		"Name": "Orb (Gold)"	},	{		"ModelType": 1374,		"Name": "Gyretower"	},	{		"ModelType": 1375,		"Name": "Calcabrina"	},	{		"ModelType": 1376,		"Name": "Calca"	},	{		"ModelType": 1377,		"Name": "Brina"	},	{		"ModelType": 1378,		"Name": "Bloated Bulb"	},	{		"ModelType": 1379,		"Name": "Silver Manacutter (Mount)"	},	{		"ModelType": 1380,		"Name": "Black Manacutter (Mount)"	},	{		"ModelType": 1381,		"Name": "Knight Hawk"	},	{		"ModelType": 1382,		"Name": "Sephirot (different form)"	},	{		"ModelType": 1385,		"Name": "Tiny eye"	},	{		"ModelType": 1386,		"Name": "Little monkey",		"Type": "Minion"	},	{		"ModelType": 1387,		"Name": "Dwarf rabbit",		"Type": "Minion"	},	{		"ModelType": 1388,		"Name": "Giraffe",		"Type": "Minion"	},	{		"ModelType": 1390,		"Name": "Jibanyan",		"Type": "Minion"	},	{		"ModelType": 1391,		"Name": "Komasan",		"Type": "Minion"	},	{		"ModelType": 1392,		"Name": "Whisper",		"Type": "Minion"	},	{		"ModelType": 1393,		"Name": "Blizzaria",		"Type": "Minion"	},	{		"ModelType": 1394,		"Name": "Kyuubi",		"Type": "Minion"	},	{		"ModelType": 1395,		"Name": "Komajiro",		"Type": "Minion"	},	{		"ModelType": 1396,		"Name": "Manjimutt",		"Type": "Minion"	},	{		"ModelType": 1397,		"Name": "Noko",		"Type": "Minion"	},	{		"ModelType": 1398,		"Name": "Venoct",		"Type": "Minion"	},	{		"ModelType": 1399,		"Name": "Shogunyan",		"Type": "Minion"	},	{		"ModelType": 1400,		"Name": "Hovernyan",		"Type": "Minion"	},	{		"ModelType": 1401,		"Name": "Robonyan F-Type",		"Type": "Minion"	},	{		"ModelType": 1402,		"Name": "USApyon",		"Type": "Minion"	},	{		"ModelType": 1403,		"Name": "Valkyrie boss from Amdapor"	},	{		"ModelType": 1404,		"Name": "Magitek Hexadrone"	},	{		"ModelType": 1405,		"Name": "Flying bug from Amdapor"	},	{		"ModelType": 1406,		"Name": "Nidhogg (Both Eyes / No Scars)"	},	{		"ModelType": 1407,		"Name": "Elemental F (White)"	},	{		"ModelType": 1408,		"Name": "Animus Elemental"	},	{		"ModelType": 1409,		"Name": "Second boss from Amdapor Hard"	},	{		"ModelType": 1410,		"Name": "The Strongman (Heavensturn 2016)"	},	{		"ModelType": 1411,		"Name": "Kongamato (mount)"	},	{		"ModelType": 1412,		"Name": "Wyvern (Mount)"	},	{		"ModelType": 1413,		"Name": "Magitek Reaper (Glowing)"	},	{		"ModelType": 1414,		"Name": "Gobblydegroper (Alexander 8 Add)"	},	{		"ModelType": 1415,		"Name": "Ark Ked"	},	{		"ModelType": 1416,		"Name": "Soldier Hawk"	},	{		"ModelType": 1417,		"Name": "Incinerator (Alexander 11 Trash)"	},	{		"ModelType": 1418,		"Name": "Monk Chimera"	},	{		"ModelType": 1419,		"Name": "Spiked Monk Chimera"	},	{		"ModelType": 1420,		"Name": "Forgotten Wisent"	},	{		"ModelType": 1421,		"Name": "Charybterix"	},	{		"ModelType": 1422,		"Name": "Trained Sanuwa"	},	{		"ModelType": 1423,		"Name": "Wind-Up Zundu Warrior",		"Type": "Minion"	},	{		"ModelType": 1424,		"Name": "Okeanis F (Purple)"	},	{		"ModelType": 1425,		"Name": "Spinnning Wheel  with spikes in the middle"	},	{		"ModelType": 1426,		"Name": "Spriggan (w/ huge rock)"	},	{		"ModelType": 1427,		"Name": "Enraged Marid"	},	{		"ModelType": 1428,		"Name": "Groundskeeper C (Purple)"	},	{		"ModelType": 1429,		"Name": "Skatene B (White)"	},	{		"ModelType": 1430,		"Name": "Sephirot-Egi"	},	{		"ModelType": 1431,		"Name": "Mammet - PVP"	},	{		"ModelType": 1432,		"Name": "Wind Elemental"	},	{		"ModelType": 1433,		"Name": "Tornado with leaves"	},	{		"ModelType": 1434,		"Name": "Anima",		"Type": "Minion"	},	{		"ModelType": 1435,		"Name": "Glowing Anima",		"Type": "Minion"	},	{		"ModelType": 1436,		"Name": "Byakko (Beast Form)"	},	{		"ModelType": 1437,		"Name": "Byakko (Beast Form - Enraged)"	},	{		"ModelType": 1438,		"Name": "Sabertooth tiger"	},	{		"ModelType": 1439,		"Name": "Vanara"	},	{		"ModelType": 1443,		"Name": "Enormous Black Boulder/Ball"	},	{		"ModelType": 1444,		"Name": "Personal Airship pvp mount"	},	{		"ModelType": 1445,		"Name": "Zuro Roggo (Antitower Boss 1)"	},	{		"ModelType": 1446,		"Name": "Zu mount"	},	{		"ModelType": 1447,		"Name": "Red Zu mount"	},	{		"ModelType": 1448,		"Name": "Floating pink and red hearts"	},	{		"ModelType": 1449,		"Name": "Magic Pot from FFXI"	},	{		"ModelType": 1450,		"Name": "Weird floating meteorite"	},	{		"ModelType": 1451,		"Name": "Magic Doll from sky in FFXI"	},	{		"ModelType": 1452,		"Name": "Pink orb with floating pink diamonds"	},	{		"ModelType": 1453,		"Name": "Wind tornado"	},	{		"ModelType": 1454,		"Name": "Floating black void with purple glow"	},	{		"ModelType": 1455,		"Name": "Sasquatch (Hullbreaker Isle Boss 1)"	},	{		"ModelType": 1456,		"Name": "Tuco Tuco"	},	{		"ModelType": 1457,		"Name": "Zurvan Add"	},	{		"ModelType": 1458,		"Name": "Faust",		"Type": "Minion"	},	{		"ModelType": 1459,		"Name": "Morpho",		"Type": "Minion"	},	{		"ModelType": 1461,		"Name": "Calca",		"Type": "Minion"	},	{		"ModelType": 1462,		"Name": "Brina",		"Type": "Minion"	},	{		"ModelType": 1463,		"Name": "Dragonet",		"Type": "Minion"	},	{		"ModelType": 1464,		"Name": "Lucky Bucket",		"Type": "Minion"	},	{		"ModelType": 1465,		"Name": "Piggy",		"Type": "Minion"	},	{		"ModelType": 1466,		"Name": "Poroggo",		"Type": "Minion"	},	{		"ModelType": 1467,		"Name": "Fenrir",		"Type": "Minion"	},	{		"ModelType": 1468,		"Name": "Cheerleader",		"Type": "Minion"	},	{		"ModelType": 1469,		"Name": "Calamari",		"Type": "Minion"	},	{		"ModelType": 1470,		"Name": "Brachiosaur",		"Type": "Minion"	},	{		"ModelType": 1471,		"Name": "Blaster Clone (Alexander)"	},	{		"ModelType": 1472,		"Name": "Nightmare Pegasus Mount"	},	{		"ModelType": 1473,		"Name": "Minotaur"	},	{		"ModelType": 1474,		"Name": "Minotaur (Mottled - Red)"	},	{		"ModelType": 1475,		"Name": "Large Egg (White)"	},	{		"ModelType": 1476,		"Name": "2000 Mentor roulette Pegasus mount"	},	{		"ModelType": 1477,		"Name": "Sephirot (Pre-Fight Cutscene)"	},	{		"ModelType": 1478,		"Name": "Vanara of Biting Cold"	},	{		"ModelType": 1479,		"Name": "Vanara of Resonating Thunder"	},	{		"ModelType": 1480,		"Name": "Ozma Phase One"	},	{		"ModelType": 1481,		"Name": "Ozma Phase Two"	},	{		"ModelType": 1482,		"Name": "Crimson Morpho"	},	{		"ModelType": 1483,		"Name": "Moon Gana"	},	{		"ModelType": 1484,		"Name": "Edward FF4 Minion?"	},	{		"ModelType": 1486,		"Name": "Vath Warlord"	},	{		"ModelType": 1487,		"Name": "Raubahn Sword on the ground"	},	{		"ModelType": 1488,		"Name": "Calistoferi"	},	{		"ModelType": 1489,		"Name": "Green Caterpillar"	},	{		"ModelType": 1490,		"Name": "Hraesvelgr"	},	{		"ModelType": 1491,		"Name": "Arachne Eve"	},	{		"ModelType": 1492,		"Name": "Blaster (Alexander) "	},	{		"ModelType": 1493,		"Name": "Vortexer (Alexander)"	},	{		"ModelType": 1494,		"Name": "Swindler (Alexander)"	},	{		"ModelType": 1495,		"Name": "Brawler (Alexander)"	},	{		"ModelType": 1496,		"Name": "Siege Breaker (Doma Castle 1st Boss)"	},	{		"ModelType": 1498,		"Name": "Forgall"	},	{		"ModelType": 1499,		"Name": "Black Cat",		"Type": "Minion"	},	{		"ModelType": 1501,		"Name": "Small Glowing Orb with Music Note in it"	},	{		"ModelType": 1502,		"Name": "Striking Dummy"	},	{		"ModelType": 1503,		"Name": "Edda"	},	{		"ModelType": 1504,		"Name": "Revenant (Grey)"	},	{		"ModelType": 1505,		"Name": "Nimbus Cloud (Mount)"	},	{		"ModelType": 1506,		"Name": "Glowing Orb"	},	{		"ModelType": 1507,		"Name": "Whelk from FF6 - Purple"	},	{		"ModelType": 1508,		"Name": "Whelk from FF6 - Grey"	},	{		"ModelType": 1509,		"Name": "Sarchosurcus"	},	{		"ModelType": 1510,		"Name": "Dragon (Zombie)"	},	{		"ModelType": 1511,		"Name": "Lanner (Bismarck)"	},	{		"ModelType": 1512,		"Name": "Lanner (Ravana)"	},	{		"ModelType": 1513,		"Name": "Lanner (Thordan)"	},	{		"ModelType": 1514,		"Name": "Lanner (Sephirot)"	},	{		"ModelType": 1515,		"Name": "Moogle Pom Fluff mount"	},	{		"ModelType": 1516,		"Name": "Brute Justice"	},	{		"ModelType": 1517,		"Name": "Creepy Black Mage"	},	{		"ModelType": 1518,		"Name": "Creepy White Mage"	},	{		"ModelType": 1519,		"Name": "Groundskeeper A"	},	{		"ModelType": 1520,		"Name": "Original Fat Chocobo (Mount)"	},	{		"ModelType": 1521,		"Name": "Ahriman (Purple)"	},	{		"ModelType": 1522,		"Name": "Sea Monk (Spiked - Blue)"	},	{		"ModelType": 1523,		"Name": "Striking Dummy (Special)"	},	{		"ModelType": 1524,		"Name": "Dragonet (Silver Blue - Dragoon Questline NPC)"	},	{		"ModelType": 1525,		"Name": "Gryphon (Irisdescent Blue-Green)"	},	{		"ModelType": 1526,		"Name": "Blue treasure chest"	},	{		"ModelType": 1527,		"Name": "Red treasure chest"	},	{		"ModelType": 1528,		"Name": "Fan Construct"	},	{		"ModelType": 1529,		"Name": "Atomos (Silver)"	},	{		"ModelType": 1530,		"Name": "Bird of Paradise (Rainbow)"	},	{		"ModelType": 1531,		"Name": "Estinien (Nidhogg Fusion)"	},	{		"ModelType": 1532,		"Name": "Flying moogle 2 seater mount"	},	{		"ModelType": 1533,		"Name": "Nidhogg Phase 3"	},	{		"ModelType": 1534,		"Name": "Whisper Mount"	},	{		"ModelType": 1535,		"Name": "The Epigraph (Weeping City Mid-Boss)"	},	{		"ModelType": 1536,		"Name": "Sophia"	},	{		"ModelType": 1537,		"Name": "Sophia's Head"	},	{		"ModelType": 1538,		"Name": "Sarcophagus of the Demon Queen: Scathach"	},	{		"ModelType": 1539,		"Name": "Zurvan"	},	{		"ModelType": 1541,		"Name": "Diremite (Green-Yellow)"	},	{		"ModelType": 1542,		"Name": "Spider Mite (Green-Yellow)"	},	{		"ModelType": 1543,		"Name": "Spider Mite (Yellow-Brown)"	},	{		"ModelType": 1544,		"Name": "Wind-Up Ramuh",		"Type": "Minion"	},	{		"ModelType": 1545,		"Name": "Wind-Up Shiva",		"Type": "Minion"	},	{		"ModelType": 1546,		"Name": "Callistoferi",		"Type": "Minion"	},	{		"ModelType": 1547,		"Name": "Wind-Up Aymeric",		"Type": "Minion"	},	{		"ModelType": 1548,		"Name": "Asian Moogle",		"Type": "Minion"	},	{		"ModelType": 1549,		"Name": "Lamia-Dalvag-Parthenope"	},	{		"ModelType": 1550,		"Name": "Lamia-Dalvag-Parthenope"	},	{		"ModelType": 1551,		"Name": "Lamia-Dalvag-Parthenope"	},	{		"ModelType": 1552,		"Name": "Ancient Wyvern (Iridescent Blue)"	},	{		"ModelType": 1553,		"Name": "Dragon (Shadow)"	},	{		"ModelType": 1554,		"Name": "Ancient Wyvern (Deep White)"	},	{		"ModelType": 1555,		"Name": "Nidhogg"	},	{		"ModelType": 1556,		"Name": "Nidhogg Phase 2 or 3?"	},	{		"ModelType": 1557,		"Name": "Hraesvelgr again"	},	{		"ModelType": 1558,		"Name": "Another Hraesvelgr"	},	{		"ModelType": 1559,		"Name": "Hraesvelgr with eyes closed"	},	{		"ModelType": 1560,		"Name": "Hraesvelgr with one eye open"	},	{		"ModelType": 1561,		"Name": "Tiger (Spirit - Blue)"	},	{		"ModelType": 1562,		"Name": "Dangerous Boquet"	},	{		"ModelType": 1563,		"Name": "A barrel"	},	{		"ModelType": 1564,		"Name": "Calofisteri Spine [SKL]"	},	{		"ModelType": 1565,		"Name": "Calofisteri's Hair Attack"	},	{		"ModelType": 1566,		"Name": "Giant Neon Tentacle"	},	{		"ModelType": 1567,		"Name": "Giant Neon Tentacle - 2nd form"	},	{		"ModelType": 1568,		"Name": "Giant Neon vore plant"	},	{		"ModelType": 1569,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1570,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 1571,		"Name": "Floating ball of ice"	},	{		"ModelType": 1572,		"Name": "Thundercloud"	},	{		"ModelType": 1573,		"Name": "Floating orb of ice"	},	{		"ModelType": 1574,		"Name": "Flame Sergeant Dalvag"	},	{		"ModelType": 1575,		"Name": "Flame Sergeant Dalvag lookalike without the glowing eyes"	},	{		"ModelType": 1577,		"Name": "Parthenope"	},	{		"ModelType": 1578,		"Name": "Bijou (Calofisteri Add)"	},	{		"ModelType": 1579,		"Name": "Wyvern (White) [Locked]"	},	{		"ModelType": 1580,		"Name": "Lanner (Nidhogg)"	},	{		"ModelType": 1581,		"Name": "Gaol (Ozma)"	},	{		"ModelType": 1582,		"Name": "Tozol Huatotl (Xelphatol Final Boss)"	},	{		"ModelType": 1583,		"Name": "Alexander Prime"	},	{		"ModelType": 1584,		"Name": "Diloc Ciluoc (Xelphatol 1st Boss)"	},	{		"ModelType": 1585,		"Name": "Garo Event Mount - Gold"	},	{		"ModelType": 1586,		"Name": "Garo Event Mount - Silver"	},	{		"ModelType": 1587,		"Name": "Garo Event Mount - Black"	},	{		"ModelType": 1588,		"Name": "Nidhogg (Spirit)"	},	{		"ModelType": 1589,		"Name": "Dragonet (Blue/White)"	},	{		"ModelType": 1590,		"Name": "Callistoferi again"	},	{		"ModelType": 1591,		"Name": "Callistoferi yet again"	},	{		"ModelType": 1592,		"Name": "Strix (Gubal HM Final Boss)"	},	{		"ModelType": 1593,		"Name": "Panda Mount"	},	{		"ModelType": 1599,		"Name": "Revenant (Red)"	},	{		"ModelType": 1600,		"Name": "Fancy glowing blue spear/pole"	},	{		"ModelType": 1601,		"Name": "Fancy giant red sword buried in the ground"	},	{		"ModelType": 1602,		"Name": "Dragon's Head (Shinryu Add)"	},	{		"ModelType": 1603,		"Name": "Demon Tome (Gubal 1st Boss)"	},	{		"ModelType": 1604,		"Name": "Zu Pullet (Mount)"	},	{		"ModelType": 1605,		"Name": "Cruise Chaser"	},	{		"ModelType": 1606,		"Name": "Cruise Chaser again"	},	{		"ModelType": 1607,		"Name": "A silhouette of Sophia"	},	{		"ModelType": 1608,		"Name": "Tsanahale (Green/Pink)"	},	{		"ModelType": 1609,		"Name": "Demon of the Tome (Unbound - Gubal HM 1st Boss)"	},	{		"ModelType": 1610,		"Name": "Eradicator (Alex 11 Trash)"	},	{		"ModelType": 1611,		"Name": "Wind-Up Yuna",		"Type": "Minion"	},	{		"ModelType": 1612,		"Name": "Wind-Up Rikku",		"Type": "Minion"	},	{		"ModelType": 1613,		"Name": "Wind-Up Lulu",		"Type": "Minion"	},	{		"ModelType": 1614,		"Name": "Namingway",		"Type": "Minion"	},	{		"ModelType": 1615,		"Name": "Shaggy Shoat",		"Type": "Minion"	},	{		"ModelType": 1616,		"Name": "Wind-Up Thancred",		"Type": "Minion"	},	{		"ModelType": 1617,		"Name": "Wind-Up Alisaie",		"Type": "Minion"	},	{		"ModelType": 1618,		"Name": "Wind-Up Alexander",		"Type": "Minion"	},	{		"ModelType": 1619,		"Name": "Kum Kum (Syrcus Tower Amon Adds)"	},	{		"ModelType": 1620,		"Name": "Pudding (Oil)"	},	{		"ModelType": 1621,		"Name": "Hraesvalgr (Spirit)"	},	{		"ModelType": 1622,		"Name": "Glowing Toxic Neon Green Orb"	},	{		"ModelType": 1623,		"Name": "Flaming Orb"	},	{		"ModelType": 1624,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1626,		"Name": "Wind-Up Edda",		"Type": "Minion"	},	{		"ModelType": 1627,		"Name": "3 Rocks"	},	{		"ModelType": 1628,		"Name": "Balloon Turret (Xelphatol Diloc Add)"	},	{		"ModelType": 1629,		"Name": "Managarm Mount"	},	{		"ModelType": 1630,		"Name": "Sahagin (EQ)"	},	{		"ModelType": 1631,		"Name": "Minotaur"	},	{		"ModelType": 1632,		"Name": "Naked Yumemi"	},	{		"ModelType": 1633,		"Name": "Cruise Seeker (Cruise Chaser Add)"	},	{		"ModelType": 1634,		"Name": "Skystone (Xelphatol Diloc Add)"	},	{		"ModelType": 1635,		"Name": "Palace of The Dead Mount"	},	{		"ModelType": 1636,		"Name": "Glowing sky blue Allagan orb"	},	{		"ModelType": 1637,		"Name": "Refurbisher (Alexander)"	},	{		"ModelType": 1638,		"Name": "Gobbie (EQ)"	},	{		"ModelType": 1639,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 1640,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 1641,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 1642,		"Name": "Sahagin (EQ)"	},	{		"ModelType": 1643,		"Name": "Ugly Red Demon"	},	{		"ModelType": 1644,		"Name": "Succubus (EQ)"	},	{		"ModelType": 1646,		"Name": "Glowing Whisper Mount"	},	{		"ModelType": 1647,		"Name": "Nidhogg (Fused with Estinien) 2"	},	{		"ModelType": 1648,		"Name": "Little Midgardsormr",		"Type": "Minion"	},	{		"ModelType": 1649,		"Name": "Coincounter Primus (Aquapolis Final Boss)"	},	{		"ModelType": 1650,		"Name": "Unicolt",		"Type": "Minion"	},	{		"ModelType": 1651,		"Name": "Wind-Up Moenbryda",		"Type": "Minion"	},	{		"ModelType": 1652,		"Name": "T-pose Default Model"	},	{		"ModelType": 1653,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1654,		"Name": "Magitek Killer Mantis"	},	{		"ModelType": 1656,		"Name": "Gobbie (EQ)"	},	{		"ModelType": 1657,		"Name": "Orange Kappa"	},	{		"ModelType": 1658,		"Name": "Christmas Bear mount"	},	{		"ModelType": 1659,		"Name": "Frog"	},	{		"ModelType": 1660,		"Name": "Green Kappa"	},	{		"ModelType": 1663,		"Name": "Ixal (EQ)"	},	{		"ModelType": 1664,		"Name": "Liquid Flame (Humanoid Form)"	},	{		"ModelType": 1665,		"Name": "Liquid Flame (Hand Form)"	},	{		"ModelType": 1666,		"Name": "Liquid Flame (PIllar Form)"	},	{		"ModelType": 1667,		"Name": "Allagan Drone (Ant)"	},	{		"ModelType": 1668,		"Name": "Nybeth Obdilord"	},	{		"ModelType": 1669,		"Name": "Magitek Predator (w/ Pilot)"	},	{		"ModelType": 1670,		"Name": "Gobroller Mk. VI (Alexander 7)"	},	{		"ModelType": 1671,		"Name": "A floating multicolored crystal"	},	{		"ModelType": 1672,		"Name": "Crystal-Powered Laser Cannon"	},	{		"ModelType": 1673,		"Name": "Exploding Fat Cannister (Alexander 11 Adds)"	},	{		"ModelType": 1674,		"Name": "Susanoo"	},	{		"ModelType": 1675,		"Name": "Lakshmi"	},	{		"ModelType": 1676,		"Name": "Syldra Mount from Stormblood Pre-order"	},	{		"ModelType": 1677,		"Name": "Palace of the Dead - Kuribu (Pomander of Resolution)"	},	{		"ModelType": 1678,		"Name": "Gaol (Obsidian)"	},	{		"ModelType": 1679,		"Name": "Armored Weapon (Magitek Laser Thing)"	},	{		"ModelType": 1680,		"Name": "Amikiri (Shisui of the Violet Tides 1st Boss)"	},	{		"ModelType": 1681,		"Name": "Gowrow (Sohm Al HM 2nd Boss)"	},	{		"ModelType": 1682,		"Name": "Tatsunoko (Blue/Purple)"	},	{		"ModelType": 1683,		"Name": "Bombfish"	},	{		"ModelType": 1684,		"Name": "Yak Ram Thing"	},	{		"ModelType": 1685,		"Name": "A giant tornado"	},	{		"ModelType": 1686,		"Name": "Ozma (Shade Form - Adds Sub-boss)"	},	{		"ModelType": 1687,		"Name": "Floating Glowing White Staff"	},	{		"ModelType": 1688,		"Name": "Christmas Paissa"	},	{		"ModelType": 1689,		"Name": "Scathach"	},	{		"ModelType": 1690,		"Name": "Bulldog Pup",		"Type": "Minion"	},	{		"ModelType": 1691,		"Name": "Cupid (Minion) From valentines day event"	},	{		"ModelType": 1692,		"Name": "Wind-Up Bartz",		"Type": "Minion"	},	{		"ModelType": 1693,		"Name": "Wind-Up Kain",		"Type": "Minion"	},	{		"ModelType": 1694,		"Name": "Hraesvelgr artbook",		"Type": "Minion"	},	{		"ModelType": 1695,		"Name": "Gigi",		"Type": "Minion"	},	{		"ModelType": 1696,		"Name": "Castaway Chick",		"Type": "Minion"	},	{		"ModelType": 1697,		"Name": "Anima",		"Type": "Minion"	},	{		"ModelType": 1698,		"Name": "Wind-Up Red Mage",		"Type": "Minion"	},	{		"ModelType": 1699,		"Name": "Blue Kojin (EQ - Headless)"	},	{		"ModelType": 1700,		"Name": "Sophia (without head)"	},	{		"ModelType": 1701,		"Name": "Sophia (second form)"	},	{		"ModelType": 1702,		"Name": "Sophia's glowing scales"	},	{		"ModelType": 1703,		"Name": "Arrhidaeus' Lanner (Alexander Prime Add)"	},	{		"ModelType": 1704,		"Name": "Arrhidaeus' Lanner (Winged - Alexander Prime Add)"	},	{		"ModelType": 1705,		"Name": "Arrhidaeus' Lanner (Clock - Alexander Prime Add)"	},	{		"ModelType": 1706,		"Name": "Arrhidaeus' Lanner (Guns - Alexander Prime Add)"	},	{		"ModelType": 1708,		"Name": "Shinryu EX?"	},	{		"ModelType": 1709,		"Name": "Ugly Blue Scorpion Bug"	},	{		"ModelType": 1710,		"Name": "Purple Gryphon"	},	{		"ModelType": 1711,		"Name": "Governor (Sirensong Sea 1st Boss)"	},	{		"ModelType": 1712,		"Name": "Magna Roader (Purple)"	},	{		"ModelType": 1713,		"Name": "Alte Roite (Omega 1) [Frozen]"	},	{		"ModelType": 1714,		"Name": "Ghost Aurelia (Sirensong Sea)"	},	{		"ModelType": 1716,		"Name": "Lorelei (Sirensong Sea Final Boss)"	},	{		"ModelType": 1717,		"Name": "Antlion"	},	{		"ModelType": 1718,		"Name": "Matamata"	},	{		"ModelType": 1719,		"Name": "Unkiu"	},	{		"ModelType": 1720,		"Name": "Simurgh from FFXI / Phorusrhacos"	},	{		"ModelType": 1721,		"Name": "Gyuk"	},	{		"ModelType": 1722,		"Name": "Refurbisher (Alexander)"	},	{		"ModelType": 1723,		"Name": "Refurbisher (Alexander)"	},	{		"ModelType": 1724,		"Name": "Alexander Prime (Alexander)"	},	{		"ModelType": 1725,		"Name": "Paladin Achievement Mount"	},	{		"ModelType": 1726,		"Name": "Qiqirn (EQ)"	},	{		"ModelType": 1727,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1728,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1729,		"Name": "T-Pose Default Model"	},	{		"ModelType": 1730,		"Name": "Stone Gaol (Titan)"	},	{		"ModelType": 1731,		"Name": "Ferdiad Hollow"	},	{		"ModelType": 1732,		"Name": "Canis Pugnax"	},	{		"ModelType": 1733,		"Name": "Magma Snipper"	},	{		"ModelType": 1734,		"Name": "Cait Sith"	},	{		"ModelType": 1735,		"Name": "Cait Sith (Clean - Redbill Scarf)"	},	{		"ModelType": 1736,		"Name": "Magitek Driller"	},	{		"ModelType": 1737,		"Name": "Anala (Magma)"	},	{		"ModelType": 1738,		"Name": "Garula (Bardam's Mettle 1st Boss)"	},	{		"ModelType": 1739,		"Name": "Ying-Yang"	},	{		"ModelType": 1740,		"Name": "Ananta (EQ)"	},	{		"ModelType": 1741,		"Name": "Magitek Gobwalker Mk. IX"	},	{		"ModelType": 1742,		"Name": "Gobbie (EQ)"	},	{		"ModelType": 1743,		"Name": "Suzaku"	},	{		"ModelType": 1744,		"Name": "Voidsent Wyvern (Boss?)"	},	{		"ModelType": 1745,		"Name": "Revenant (Purple)"	},	{		"ModelType": 1746,		"Name": "Rock Rhino (Mossy)"	},	{		"ModelType": 1747,		"Name": "Goobbue (Frozen)"	},	{		"ModelType": 1748,		"Name": "Shadow Dragon (Purple/Green)"	},	{		"ModelType": 1749,		"Name": "Generic Blue Demon thing"	},	{		"ModelType": 1750,		"Name": "Sea Monk (Psychadelic)"	},	{		"ModelType": 1751,		"Name": "Doom Knight"	},	{		"ModelType": 1752,		"Name": "Behemoth"	},	{		"ModelType": 1753,		"Name": "Arbuda (Temple of the Fist 2nd Boss)"	},	{		"ModelType": 1754,		"Name": "Inferno (Castrum Abania Final Boss)"	},	{		"ModelType": 1755,		"Name": "Catastrophe"	},	{		"ModelType": 1756,		"Name": "Execrated Will(EQ - Zurvan Adds)"	},	{		"ModelType": 1757,		"Name": "Ivan Coeurlfist"	},	{		"ModelType": 1758,		"Name": "Ozma"	},	{		"ModelType": 1759,		"Name": "Tenaga (Yanxian Dryad)"	},	{		"ModelType": 1760,		"Name": "Sad Pumpkin"	},	{		"ModelType": 1761,		"Name": "Lugat (Sirensong Sea 1st Boss)"	},	{		"ModelType": 1762,		"Name": "Sophia without head (gold)"	},	{		"ModelType": 1763,		"Name": "Cruise Chaser"	},	{		"ModelType": 1764,		"Name": "Numbers (Eureka NM)"	},	{		"ModelType": 1765,		"Name": "Firebird (Mount - Lanner Collection Achievement)"	},	{		"ModelType": 1766,		"Name": "Yojimbo"	},	{		"ModelType": 1767,		"Name": "Muud Suud"	},	{		"ModelType": 1768,		"Name": "Lanner (Sophia)"	},	{		"ModelType": 1769,		"Name": "Halloween Ahriman",		"Type": "Minion"	},	{		"ModelType": 1770,		"Name": "Weirdly colored lion"	},	{		"ModelType": 1771,		"Name": "Rock monster with two hands"	},	{		"ModelType": 1772,		"Name": "Rock Plant Fish Mouth???"	},	{		"ModelType": 1773,		"Name": "Falcon (Mount)"	},	{		"ModelType": 1774,		"Name": "Power Core (Deconstructor Add)"	},	{		"ModelType": 1775,		"Name": "Garo Mount (Rival Wings)"	},	{		"ModelType": 1776,		"Name": "Archon Throne Mount"	},	{		"ModelType": 1777,		"Name": "Golden Egg"	},	{		"ModelType": 1778,		"Name": "Zenos Yae Galvus (No Helm)"	},	{		"ModelType": 1779,		"Name": "Captain Madison (Satasha HM 1st Boss)"	},	{		"ModelType": 1780,		"Name": "Atomos (Yellow/Black)"	},	{		"ModelType": 1781,		"Name": "Diabolos (Injured)"	},	{		"ModelType": 1782,		"Name": "Scathach",		"Type": "Minion"	},	{		"ModelType": 1783,		"Name": "Nidhogg",		"Type": "Minion"	},	{		"ModelType": 1784,		"Name": "Fox",		"Type": "Minion"	},	{		"ModelType": 1785,		"Name": "Kitten Thing",		"Type": "Minion"	},	{		"ModelType": 1786,		"Name": "Odder Otter",		"Type": "Minion"	},	{		"ModelType": 1787,		"Name": "Tiny Tatsunoko",		"Type": "Minion"	},	{		"ModelType": 1788,		"Name": "Bom Boko",		"Type": "Minion"	},	{		"ModelType": 1789,		"Name": "Sparrow",		"Type": "Minion"	},	{		"ModelType": 1790,		"Name": "Bombfish",		"Type": "Minion"	},	{		"ModelType": 1791,		"Name": "Faehound S (Red/Black)"	},	{		"ModelType": 1792,		"Name": "Karakuri Shinobi (Boss)"	},	{		"ModelType": 1793,		"Name": "Namazu (Big)"	},	{		"ModelType": 1794,		"Name": "Number XXIV (Castrum Abania 2nd Boss)"	},	{		"ModelType": 1795,		"Name": "Imp Jester"	},	{		"ModelType": 1796,		"Name": "Connla (Scathach Add)"	},	{		"ModelType": 1797,		"Name": "Karakuri Mask?"	},	{		"ModelType": 1798,		"Name": "Shisui Yohi (Shisui Final Boss)"	},	{		"ModelType": 1799,		"Name": "Halicarnassus (Omega 3)"	},	{		"ModelType": 1800,		"Name": "Hecatoncheir (Green)"	},	{		"ModelType": 1801,		"Name": "Zurvan"	},	{		"ModelType": 1802,		"Name": "Player (T)"	},	{		"ModelType": 1803,		"Name": "Scathach (Dead)"	},	{		"ModelType": 1804,		"Name": "Player (T)"	},	{		"ModelType": 1805,		"Name": "Ixion"	},	{		"ModelType": 1806,		"Name": "Khun Shavar (Staff Training Dummy)"	},	{		"ModelType": 1807,		"Name": "Grasshopper"	},	{		"ModelType": 1808,		"Name": "Armored Weapon (Magitek Laser Spider)"	},	{		"ModelType": 1811,		"Name": "Zurvan (Fettered)"	},	{		"ModelType": 1812,		"Name": "Wolf Dude (Headless?)"	},	{		"ModelType": 1813,		"Name": "Doman Armor Golem? (Steel)"	},	{		"ModelType": 1814,		"Name": "Coralshell"	},	{		"ModelType": 1815,		"Name": "Coeurl (Grey/Green)"	},	{		"ModelType": 1816,		"Name": "Coeurl (Red/Orange)"	},	{		"ModelType": 1817,		"Name": "Bardam's Hammer Golem"	},	{		"ModelType": 1818,		"Name": "Magitek Avenger"	},	{		"ModelType": 1819,		"Name": "Dhara? (Yellow/Brown)"	},	{		"ModelType": 1820,		"Name": "Scathach Tendril Hand"	},	{		"ModelType": 1821,		"Name": "Fat Demon Spikey Mouth Head?"	},	{		"ModelType": 1822,		"Name": "Diabolos"	},	{		"ModelType": 1823,		"Name": "Player (T)"	},	{		"ModelType": 1824,		"Name": "Worst Girl",		"Type": "Minion"	},	{		"ModelType": 1825,		"Name": "Yugiri",		"Type": "Minion"	},	{		"ModelType": 1826,		"Name": "Gosetsu",		"Type": "Minion"	},	{		"ModelType": 1827,		"Name": "Yotsuyu",		"Type": "Minion"	},	{		"ModelType": 1828,		"Name": "Grynethwaht",		"Type": "Minion"	},	{		"ModelType": 1829,		"Name": "Angel bell",		"Type": "Minion"	},	{		"ModelType": 1830,		"Name": "Namazu",		"Type": "Minion"	},	{		"ModelType": 1831,		"Name": "Ivon Coeurlfist",		"Type": "Minion"	},	{		"ModelType": 1832,		"Name": "Demon Doll?",		"Type": "Minion"	},	{		"ModelType": 1833,		"Name": "Rat Thing?",		"Type": "Minion"	},	{		"ModelType": 1834,		"Name": "Magitek Avenger",		"Type": "Minion"	},	{		"ModelType": 1835,		"Name": "Wolf (White/Light Red)"	},	{		"ModelType": 1836,		"Name": "Wolf (Blue/Red)"	},	{		"ModelType": 1837,		"Name": "Faehound L (Blue/Black)"	},	{		"ModelType": 1838,		"Name": "The Griffin's Blade"	},	{		"ModelType": 1839,		"Name": "Scathach"	},	{		"ModelType": 1841,		"Name": "Blue Orb (Big)"	},	{		"ModelType": 1842,		"Name": "Orange Rotating Rings"	},	{		"ModelType": 1843,		"Name": "Bulbasaur? (Skalla Boss)"	},	{		"ModelType": 1844,		"Name": "Lion (White)"	},	{		"ModelType": 1845,		"Name": "Lion"	},	{		"ModelType": 1846,		"Name": "Lion (Magma)"	},	{		"ModelType": 1847,		"Name": "Fist Temple Golem?"	},	{		"ModelType": 1848,		"Name": "Dhruva? (Ice)"	},	{		"ModelType": 1849,		"Name": "Dhara? (Blue/Black) / Gnome"	},	{		"ModelType": 1850,		"Name": "Bear (Black)"	},	{		"ModelType": 1851,		"Name": "Dragonfly (Green/Yellow)"	},	{		"ModelType": 1852,		"Name": "Griffin (True)"	},	{		"ModelType": 1853,		"Name": "Treant?"	},	{		"ModelType": 1854,		"Name": "Electral Orb"	},	{		"ModelType": 1855,		"Name": "Wind-Up Moon",		"Type": "Minion"	},	{		"ModelType": 1856,		"Name": "Dragonet ( Blue)"	},	{		"ModelType": 1857,		"Name": "Lanner (Zurvan)"	},	{		"ModelType": 1858,		"Name": "Faehound L (Purple/Black)"	},	{		"ModelType": 1859,		"Name": "Faehound S (Blue/Black)"	},	{		"ModelType": 1860,		"Name": "T-Pose"	},	{		"ModelType": 1861,		"Name": "Atomos (Chrome Blue)"	},	{		"ModelType": 1862,		"Name": "Hex Shield Thing"	},	{		"ModelType": 1863,		"Name": "Neo Exdeath"	},	{		"ModelType": 1864,		"Name": "Garlean Scientist Asshole"	},	{		"ModelType": 1865,		"Name": "Cait Sith"	},	{		"ModelType": 1866,		"Name": "Diabolos Prime"	},	{		"ModelType": 1867,		"Name": "Apa/Undine"	},	{		"ModelType": 1868,		"Name": "Tengu"	},	{		"ModelType": 1869,		"Name": "Elephant (Grey/Blankets)"	},	{		"ModelType": 1870,		"Name": "Manta (No Saddle)"	},	{		"ModelType": 1871,		"Name": "Gobroller Mk. VII (Alex 10)"	},	{		"ModelType": 1872,		"Name": "Rock Beast (Purple Crystals)"	},	{		"ModelType": 1873,		"Name": "Zenos (Wind Katana)"	},	{		"ModelType": 1875,		"Name": "Alte Roite (Omega 1)"	},	{		"ModelType": 1876,		"Name": "Hellhound (Steel Grey)"	},	{		"ModelType": 1877,		"Name": "Nine-Tails (FATE Boss)"	},	{		"ModelType": 1878,		"Name": "Echidna (EQ)"	},	{		"ModelType": 1885,		"Name": "Zenos Yae Galvus (Helmet)"	},	{		"ModelType": 1886,		"Name": "Player (?)"	},	{		"ModelType": 1887,		"Name": "Player (?)"	},	{		"ModelType": 1888,		"Name": "Demon Face Totem (Omega 4)"	},	{		"ModelType": 1889,		"Name": "Ruby Tide Princess"	},	{		"ModelType": 1890,		"Name": "Magna Roader (Red)"	},	{		"ModelType": 1891,		"Name": "Maned Dragon?"	},	{		"ModelType": 1892,		"Name": "Level Checker"	},	{		"ModelType": 1893,		"Name": "Shinryu (Huge)"	},	{		"ModelType": 1894,		"Name": "Yol"	},	{		"ModelType": 1895,		"Name": "Genbu",		"Type": "Minion"	},	{		"ModelType": 1896,		"Name": "Exdeath",		"Type": "Minion"	},	{		"ModelType": 1897,		"Name": "Khloe",		"Type": "Minion"	},	{		"ModelType": 1898,		"Name": "Susanoo",		"Type": "Minion"	},	{		"ModelType": 1899,		"Name": "Lakshmi",		"Type": "Minion"	},	{		"ModelType": 1900,		"Name": "Temple of the Fist Ghost"	},	{		"ModelType": 1901,		"Name": "Mossling"	},	{		"ModelType": 1902,		"Name": "Pig",		"Type": "Minion"	},	{		"ModelType": 1903,		"Name": "Magitek Colossus (Cobalt)"	},	{		"ModelType": 1904,		"Name": "Manzasiri"	},	{		"ModelType": 1905,		"Name": "Cobra (Blue)"	},	{		"ModelType": 1906,		"Name": "Shalloweye"	},	{		"ModelType": 1907,		"Name": "Archamoth"	},	{		"ModelType": 1908,		"Name": "Mossy Stone Block Demon"	},	{		"ModelType": 1909,		"Name": "Razor Disc (Doma Boss Add)"	},	{		"ModelType": 1910,		"Name": "Karakuri Shinobi"	},	{		"ModelType": 1911,		"Name": "Susanoo"	},	{		"ModelType": 1913,		"Name": "Zenos Sword (Wind)"	},	{		"ModelType": 1914,		"Name": "Zenos Sword (Lightning)"	},	{		"ModelType": 1915,		"Name": "Zenos Sword (Force?)"	},	{		"ModelType": 1917,		"Name": "Hypertuned Grynewaht",		"Type": "Character"	},	{		"ModelType": 1918,		"Name": "Tomegi",		"Type": "Character"	},	{		"ModelType": 1919,		"Name": "Ushitora",		"Type": "Character"	},	{		"ModelType": 1920,		"Name": "Player (T)"	},	{		"ModelType": 1923,		"Name": "Wind Blob?"	},	{		"ModelType": 1924,		"Name": "Alpha (Omega)"	},	{		"ModelType": 1925,		"Name": "Catastrophe Tentacle"	},	{		"ModelType": 1926,		"Name": "Shinryu Tail"	},	{		"ModelType": 1927,		"Name": "Hrodric Poisontongue"	},	{		"ModelType": 1928,		"Name": "Dragon (Yellow)"	},	{		"ModelType": 1929,		"Name": "Coblyn (Pink)"	},	{		"ModelType": 1930,		"Name": "Bahamut (Large-Blue)"	},	{		"ModelType": 1931,		"Name": "Wolf (Red/Grey)"	},	{		"ModelType": 1932,		"Name": "Stone Gaol (Susanoo)"	},	{		"ModelType": 1933,		"Name": "Namazu (Blank Eyes)"	},	{		"ModelType": 1934,		"Name": "Glowing Dragon Skull (Yojimbo Add)"	},	{		"ModelType": 1935,		"Name": "Steppe Stone Block?"	},	{		"ModelType": 1936,		"Name": "Void Ark Plant Beast?"	},	{		"ModelType": 1937,		"Name": "Living Liquid (Alex)"	},	{		"ModelType": 1938,		"Name": "Gowrow (Sohl Al HM)"	},	{		"ModelType": 1939,		"Name": "Manta (Trippy)"	},	{		"ModelType": 1940,		"Name": "Magitek... Crawley Thing (Red/Black)"	},	{		"ModelType": 1941,		"Name": "Yumemi (Non-Naked)"	},	{		"ModelType": 1942,		"Name": "Doman Armor Golem? (Red)"	},	{		"ModelType": 1943,		"Name": "Dhammel"	},	{		"ModelType": 1944,		"Name": "Lammergeyer? (Red)"	},	{		"ModelType": 1945,		"Name": "Scarab (Tan)"	},	{		"ModelType": 1947,		"Name": "Crab Scorpion (Grey)"	},	{		"ModelType": 1948,		"Name": "Doman Bear? (Orange) Wolverene"	},	{		"ModelType": 1949,		"Name": "Doman Treant?"	},	{		"ModelType": 1950,		"Name": "Phurble (Green)"	},	{		"ModelType": 1951,		"Name": "Angler Fish (Brown/Orange)"	},	{		"ModelType": 1952,		"Name": "Horse (Brown)"	},	{		"ModelType": 1953,		"Name": "Lanner (Brown)"	},	{		"ModelType": 1954,		"Name": "Zenos Yae Galvus (Again)"	},	{		"ModelType": 1955,		"Name": "Zenos Yae Galvus (Again)"	},	{		"ModelType": 1956,		"Name": "Zenos Yae Galvus (Helmet)"	},	{		"ModelType": 1957,		"Name": "Feather Orb"	},	{		"ModelType": 1958,		"Name": "Water Orb"	},	{		"ModelType": 1959,		"Name": "Water Globe (Purple)"	},	{		"ModelType": 1960,		"Name": "Shining Orb"	},	{		"ModelType": 1961,		"Name": "Fire Orb"	},	{		"ModelType": 1962,		"Name": "Sun Orb"	},	{		"ModelType": 1963,		"Name": "Electric Orb"	},	{		"ModelType": 1964,		"Name": "Targeting mark on ground"	},	{		"ModelType": 1965,		"Name": "Susanoo Blocking Shield Effect"	},	{		"ModelType": 1966,		"Name": "Black Hole"	},	{		"ModelType": 1967,		"Name": "Black Hole [Effect]"	},	{		"ModelType": 1968,		"Name": "Wind-Up Bismark",		"Type": "Minion"	},	{		"ModelType": 1969,		"Name": "Zenos in black armor with no helmet"	},	{		"ModelType": 1970,		"Name": "Red Armor Zenos without helmet and with Wind Katana"	},	{		"ModelType": 1971,		"Name": "Zenos in black armor"	},	{		"ModelType": 1972,		"Name": "Red Armor Zenos with Wind Katana"	},	{		"ModelType": 1973,		"Name": "Lammergeyer? (Green)"	},	{		"ModelType": 1974,		"Name": "Magitek Bit"	},	{		"ModelType": 1975,		"Name": "Lakshmi"	},	{		"ModelType": 1978,		"Name": "Wind-Up Hien",		"Type": "Minion"	},	{		"ModelType": 1979,		"Name": "Wind-Up Ravana",		"Type": "Minion"	},	{		"ModelType": 1980,		"Name": "Wind-Up Kojin",		"Type": "Minion"	},	{		"ModelType": 1981,		"Name": "Mameshiba",		"Type": "Minion"	},	{		"ModelType": 1982,		"Name": "Tengu",		"Type": "Minion"	},	{		"ModelType": 1983,		"Name": "Matanga",		"Type": "Minion"	},	{		"ModelType": 1984,		"Name": "Garlean Gatling Gun"	},	{		"ModelType": 1985,		"Name": "Ancient Wyvern (Spined - Black/Purple)"	},	{		"ModelType": 1986,		"Name": "Doom Knight Champion"	},	{		"ModelType": 1987,		"Name": "Ixion"	},	{		"ModelType": 1988,		"Name": "Salt and Light (S-Rank SB Hunt)"	},	{		"ModelType": 1989,		"Name": "Orcus (A-Rank SB Hunt)"	},	{		"ModelType": 1990,		"Name": "Erle (A-Rank SB Hunt)"	},	{		"ModelType": 1991,		"Name": "Sum (A-Rank SB Hunt)"	},	{		"ModelType": 1992,		"Name": "Grimekhala (A-Rank SB Hunt)"	},	{		"ModelType": 1993,		"Name": "Vochtstein (A-Rank SB Hunt)"	},	{		"ModelType": 1994,		"Name": "Salt Dhruva"	},	{		"ModelType": 1995,		"Name": "Manta (Mount)"	},	{		"ModelType": 1996,		"Name": "Arhhenius Lanner (Mount)"	},	{		"ModelType": 1997,		"Name": "Khun Chuluu (Sad Bardam Walls)"	},	{		"ModelType": 1998,		"Name": "Spirit Coeurl"	},	{		"ModelType": 1999,		"Name": "Namazu (Lewd)"	},	{		"ModelType": 2000,		"Name": "Adamantoise"	},	{		"ModelType": 2001,		"Name": "Harakiri Hanya (Kugane Castle)"	},	{		"ModelType": 2002,		"Name": "Magitek Rearguard (Doma Castle 1st Boss)"	},	{		"ModelType": 2003,		"Name": "Magitek Bit Bomb (Rearguard Add)"	},	{		"ModelType": 2004,		"Name": "Magitek Heavy Loader (Bomb)"	},	{		"ModelType": 2005,		"Name": "Cerberus (Red - Eureka)"	},	{		"ModelType": 2006,		"Name": "Ent"	},	{		"ModelType": 2007,		"Name": "Red Egg"	},	{		"ModelType": 2008,		"Name": "Blue Egg"	},	{		"ModelType": 2009,		"Name": "Floating Purple Dragon Head"	},	{		"ModelType": 2010,		"Name": "Ivan Coeurlfist"	},	{		"ModelType": 2011,		"Name": "T-Pose Default Model"	},	{		"ModelType": 2012,		"Name": "Susanoo Sword Part"	},	{		"ModelType": 2013,		"Name": "Lakshmi"	},	{		"ModelType": 2014,		"Name": "Hoarhound (Fenrir - Purple/Red)"	},	{		"ModelType": 2015,		"Name": "Demon Tome (Blank)"	},	{		"ModelType": 2016,		"Name": "Zenos Without Helmet"	},	{		"ModelType": 2017,		"Name": "Zenos With Helmet"	},	{		"ModelType": 2018,		"Name": "Tentacle (Exdeath Add)"	},	{		"ModelType": 2019,		"Name": "T-Pose Default Model"	},	{		"ModelType": 2020,		"Name": "Yol (Pink)"	},	{		"ModelType": 2021,		"Name": "Gold Namazu"	},	{		"ModelType": 2022,		"Name": "Susanoo Battle Mode"	},	{		"ModelType": 2023,		"Name": "Floating Blue Light"	},	{		"ModelType": 2024,		"Name": "Neo Exdeath"	},	{		"ModelType": 2025,		"Name": "Spirit Warrior (Temple of the Fist)"	},	{		"ModelType": 2026,		"Name": "Spirit Warrior 2 (Temple of the Fist)"	},	{		"ModelType": 2027,		"Name": "Matoya (EQ-Headless)"	},	{		"ModelType": 2028,		"Name": "T-Pose Default Model"	},	{		"ModelType": 2029,		"Name": "Horse (Mount)"	},	{		"ModelType": 2030,		"Name": "Fire Segway Mount"	},	{		"ModelType": 2031,		"Name": "Generic Person - With Carrying Pole",		"Type": "Character"	},	{		"ModelType": 2032,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2033,		"Name": "Generic Person - Holding Lamp",		"Type": "Character"	},	{		"ModelType": 2034,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2035,		"Name": "Generic Person - Holding Bento",		"Type": "Character"	},	{		"ModelType": 2036,		"Name": "Spectre (Blue)"	},	{		"ModelType": 2037,		"Name": "Hashmal: Bringer of Order (Rabanastre 2nd Boss)"	},	{		"ModelType": 2038,		"Name": "Mateus: the Corrupt (Rabanastre 1st Boss)"	},	{		"ModelType": 2039,		"Name": "Treant (Christmas Event)"	},	{		"ModelType": 2040,		"Name": "Level Checker (Red)"	},	{		"ModelType": 2041,		"Name": "Level Checker (Green)"	},	{		"ModelType": 2042,		"Name": "Kelpie (Skalla 1st Boss)"	},	{		"ModelType": 2043,		"Name": "Sea Faerie? (Skall Add)"	},	{		"ModelType": 2044,		"Name": "The Ultima Beast (Fractal Cont. HM Final Boss)"	},	{		"ModelType": 2045,		"Name": "The Ultima Warrior (Fractal Cont. HM 1st Boss)"	},	{		"ModelType": 2046,		"Name": "Wind-Up Ramza"	},	{		"ModelType": 2047,		"Name": "Coeurl (Regular) [Frozen]"	},	{		"ModelType": 2048,		"Name": "Coeurl (Red) [Frozen]"	},	{		"ModelType": 2049,		"Name": "Coeurl (Dark Red) [Frozen]"	},	{		"ModelType": 2050,		"Name": "Zenos with Skull Helmet"	},	{		"ModelType": 2051,		"Name": "Halicarnassus (Omega 3)"	},	{		"ModelType": 2052,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 2053,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 2054,		"Name": "Chain Bind (Green) [Effect]"	},	{		"ModelType": 2055,		"Name": "Sadu's Door Model [Incorrect]"	},	{		"ModelType": 2056,		"Name": "Susanoo"	},	{		"ModelType": 2057,		"Name": "Treasure Chest (Copper)"	},	{		"ModelType": 2058,		"Name": "Scorpion Bug (Brown)"	},	{		"ModelType": 2059,		"Name": "Yol (Purple/Green)"	},	{		"ModelType": 2060,		"Name": "Training Dummy (Elite)"	},	{		"ModelType": 2061,		"Name": "Ixion"	},	{		"ModelType": 2062,		"Name": "X Slash [Effect]"	},	{		"ModelType": 2063,		"Name": "Wood Table"	},	{		"ModelType": 2064,		"Name": "Basket of Fish"	},	{		"ModelType": 2065,		"Name": "Inferno XL (Castrum Abania Final Boss)"	},	{		"ModelType": 2066,		"Name": "Koala",		"Type": "Minion"	},	{		"ModelType": 2067,		"Name": "Salt and Pepper Seal",		"Type": "Minion"	},	{		"ModelType": 2068,		"Name": "Mudkip",		"Type": "Minion"	},	{		"ModelType": 2069,		"Name": "Wind-Up Ixion"	},	{		"ModelType": 2070,		"Name": "Ultros"	},	{		"ModelType": 2071,		"Name": "Korpukkur (Mount)"	},	{		"ModelType": 2072,		"Name": "Magitek Avenger (Mount)"	},	{		"ModelType": 2073,		"Name": "Carbuncle (Mount)"	},	{		"ModelType": 2074,		"Name": "Marid (Mount)"	},	{		"ModelType": 2075,		"Name": "The Old One (Skalla 2nd Boss)"	},	{		"ModelType": 2076,		"Name": "Primelephas (Eureka)"	},	{		"ModelType": 2077,		"Name": "Val Guardian"	},	{		"ModelType": 2078,		"Name": "Shinryu"	},	{		"ModelType": 2079,		"Name": "Principia (Allagan Summoner Tome)"	},	{		"ModelType": 2080,		"Name": "Midgardsormr pet size"	},	{		"ModelType": 2081,		"Name": "Fox kit",		"Type": "Minion"	},	{		"ModelType": 2082,		"Name": "Ice-Skating Bitch (Mateus Add)"	},	{		"ModelType": 2083,		"Name": "Rofocale (Rabanastre 3rd Boss)"	},	{		"ModelType": 2084,		"Name": "Argath Thadalfus (Rabanastre Final Boss)"	},	{		"ModelType": 2085,		"Name": "Bombadeel (Eureka NM)"	},	{		"ModelType": 2086,		"Name": "Mirrorknight (Corrupted - Green/Purple)"	},	{		"ModelType": 2087,		"Name": "Fat Eye Ghost (Skalla) [Incorrect]"	},	{		"ModelType": 2088,		"Name": "Squib (Eureka)"	},	{		"ModelType": 2089,		"Name": "Lamashtu (Eureka NM)"	},	{		"ModelType": 2090,		"Name": "Block of ice"	},	{		"ModelType": 2091,		"Name": "Rolling Boulder"	},	{		"ModelType": 2092,		"Name": "Floating Water Bubble"	},	{		"ModelType": 2093,		"Name": "Archaeodemon (Rabanastre Trash)"	},	{		"ModelType": 2094,		"Name": "Little Snowman With Candy Cane"	},	{		"ModelType": 2095,		"Name": "Giant Cannon (Blue)"	},	{		"ModelType": 2096,		"Name": "Giant Cannon (Red)"	},	{		"ModelType": 2097,		"Name": "Rival Wings Mech #1 - Blue"	},	{		"ModelType": 2098,		"Name": "Rival Wings Mech #2 - Blue"	},	{		"ModelType": 2099,		"Name": "Rival Wings Mech #3 - Blue"	},	{		"ModelType": 2100,		"Name": "Rival Wings Mech #1 - Red"	},	{		"ModelType": 2101,		"Name": "Rival Wings Mech #2 - Red"	},	{		"ModelType": 2102,		"Name": "Rival Wings Mech #3 - Red"	},	{		"ModelType": 2103,		"Name": "Floating Sword"	},	{		"ModelType": 2104,		"Name": "Bangaa (EQ)"	},	{		"ModelType": 2105,		"Name": "Bangaa (EQ)"	},	{		"ModelType": 2106,		"Name": "Bangaa (EQ)"	},	{		"ModelType": 2107,		"Name": "Bangaa Guy"	},	{		"ModelType": 2108,		"Name": "Bangaa Guy - red"	},	{		"ModelType": 2109,		"Name": "Bangaa Guy - grey"	},	{		"ModelType": 2110,		"Name": "Flying Dragon"	},	{		"ModelType": 2111,		"Name": "Flying Dragon - White"	},	{		"ModelType": 2112,		"Name": "Flying Dragon - Super Saiyan Gold"	},	{		"ModelType": 2113,		"Name": "Flying Dragon - Green-ish"	},	{		"ModelType": 2114,		"Name": "Hecatoncheir (EQ)"	},	{		"ModelType": 2115,		"Name": "Chair Mount"	},	{		"ModelType": 2116,		"Name": "Green Doggo Mount"	},	{		"ModelType": 2117,		"Name": "Manta Ray Mount"	},	{		"ModelType": 2118,		"Name": "Magitek Claw"	},	{		"ModelType": 2119,		"Name": "Fancy Red Horse Mount"	},	{		"ModelType": 2120,		"Name": "Raubahn",		"Type": "Minion"	},	{		"ModelType": 2121,		"Name": "Byakko"	},	{		"ModelType": 2122,		"Name": "Weird Multicolored Sphere"	},	{		"ModelType": 2123,		"Name": "Bangaa (EQ)"	},	{		"ModelType": 2124,		"Name": "Tiny Dragon Minion Thing"	},	{		"ModelType": 2125,		"Name": "Topaz Carbuncle mount"	},	{		"ModelType": 2126,		"Name": "T-Rex Mount"	},	{		"ModelType": 2127,		"Name": "Genbu"	},	{		"ModelType": 2128,		"Name": "A Chicken"	},	{		"ModelType": 2130,		"Name": "Red Kojin (EQ)"	},	{		"ModelType": 2131,		"Name": "Argath Thadalfus? (Rabanastre Final Boss)"	},	{		"ModelType": 2132,		"Name": "??? (Saddle: Weapon on Floor)"	},	{		"ModelType": 2133,		"Name": "Wind-Up Kojin ( Purple - Minion)"	},	{		"ModelType": 2134,		"Name": "Motherbit (Fractal Cont. HM 1st Boss)"	},	{		"ModelType": 2135,		"Name": "Regalia but with smoke"	},	{		"ModelType": 2136,		"Name": "Phantom Train"	},	{		"ModelType": 2137,		"Name": "God Kefka"	},	{		"ModelType": 2138,		"Name": "Guardian (Omega 7)"	},	{		"ModelType": 2139,		"Name": "Ananta",		"Type": "Minion"	},	{		"ModelType": 2140,		"Name": "Moai Head",		"Type": "Minion"	},	{		"ModelType": 2141,		"Name": "Whittret",		"Type": "Minion"	},	{		"ModelType": 2142,		"Name": "Black checkered egg"	},	{		"ModelType": 2143,		"Name": "Kefka",		"Type": "Minion"	},	{		"ModelType": 2144,		"Name": "Magnai",		"Type": "Minion"	},	{		"ModelType": 2145,		"Name": "Otake-Maru (Hell's Lid 1st Boss)"	},	{		"ModelType": 2146,		"Name": "Kamaitachi (Hell's Lid 2nd Boss)"	},	{		"ModelType": 2147,		"Name": "Alpha (Chocobo from Omega)"	},	{		"ModelType": 2148,		"Name": "Sea Faerie? (Skalla Trash)"	},	{		"ModelType": 2149,		"Name": "Shinryu"	},	{		"ModelType": 2150,		"Name": "Pulsating blue ground field"	},	{		"ModelType": 2151,		"Name": "Allagan Bit (Motherbit Add)"	},	{		"ModelType": 2152,		"Name": "Crab from Hells Lid"	},	{		"ModelType": 2153,		"Name": "Phantom Train Ghost"	},	{		"ModelType": 2154,		"Name": "Gilgamesh"	},	{		"ModelType": 2155,		"Name": "Aurelia Polyp",		"Type": "Minion"	},	{		"ModelType": 2156,		"Name": "Byakko cub",		"Type": "Minion"	},	{		"ModelType": 2157,		"Name": "Shinryu",		"Type": "Minion"	},	{		"ModelType": 2158,		"Name": "Allagan Prototype Chimera (Fractal HM)"	},	{		"ModelType": 2159,		"Name": "Allagan Prototype Minotaur (Fractal HM)"	},	{		"ModelType": 2160,		"Name": "Chadarnook (Omega 6 Boss)"	},	{		"ModelType": 2161,		"Name": "Pazuzu (Eureka Anemos NM)"	},	{		"ModelType": 2162,		"Name": "Dadaluma (Omega 7 Add)"	},	{		"ModelType": 2163,		"Name": "Cat form Byakko"	},	{		"ModelType": 2164,		"Name": "Goddess Chadarnook (Omega 6 Add)"	},	{		"ModelType": 2165,		"Name": "Regular Kefka"	},	{		"ModelType": 2166,		"Name": "Airforce (Omega 7 Add)"	},	{		"ModelType": 2167,		"Name": "White Doggo Mount"	},	{		"ModelType": 2168,		"Name": "Wind-Up mithra",		"Type": "Minion"	},	{		"ModelType": 2169,		"Name": "Prince of Anemos",		"Type": "Minion"	},	{		"ModelType": 2170,		"Name": "Komainu",		"Type": "Minion"	},	{		"ModelType": 2171,		"Name": "Turtle",		"Type": "Minion"	},	{		"ModelType": 2172,		"Name": "Pagos Bunny"	},	{		"ModelType": 2173,		"Name": "Giant Tiger"	},	{		"ModelType": 2174,		"Name": "Air Force (Mount)"	},	{		"ModelType": 2175,		"Name": "Typhon [Frozen]"	},	{		"ModelType": 2176,		"Name": "Indigo Whale"	},	{		"ModelType": 2177,		"Name": "Glowing: Pulsating Green Sphere of Epilepsy"	},	{		"ModelType": 2178,		"Name": "Ananta (EQ)"	},	{		"ModelType": 2179,		"Name": "Left half of Heart Mount from valentines"	},	{		"ModelType": 2180,		"Name": "Right half of Heart Mount from valentines"	},	{		"ModelType": 2181,		"Name": "Floating Glowing Missile"	},	{		"ModelType": 2183,		"Name": "Floating Gold Needle"	},	{		"ModelType": 2184,		"Name": "Kefka Forsaken"	},	{		"ModelType": 2185,		"Name": "Creepy Floating Head with Scythes for arms and another head on top"	},	{		"ModelType": 2186,		"Name": "Zenos (Lewd)"	},	{		"ModelType": 2187,		"Name": "Otengu (Swallow's Compass 1st Boss)"	},	{		"ModelType": 2188,		"Name": "Kirin (ARR All Primal Mount)"	},	{		"ModelType": 2189,		"Name": "Eyeball Slime (Radioactive)"	},	{		"ModelType": 2190,		"Name": "Orb (Byakko's Balls)"	},	{		"ModelType": 2191,		"Name": "Gryphon mount"	},	{		"ModelType": 2192,		"Name": "Ferret minion thing"	},	{		"ModelType": 2193,		"Name": "Golem (Gougan)"	},	{		"ModelType": 2194,		"Name": "Dodo Bird"	},	{		"ModelType": 2195,		"Name": "Purple Doggo Mount"	},	{		"ModelType": 2196,		"Name": "Belias: the Constantly Fucking Going Invincible (Ridorana 2nd Boss)"	},	{		"ModelType": 2197,		"Name": "Famfrit: the Darkening Cloud (Ridorana 1st boss)"	},	{		"ModelType": 2199,		"Name": "A Tornado (literally)"	},	{		"ModelType": 2200,		"Name": "Phantom Train Markers"	},	{		"ModelType": 2202,		"Name": "Namazu Mount"	},	{		"ModelType": 2203,		"Name": "Rathalos (Monster Hunter)"	},	{		"ModelType": 2204,		"Name": "Palico from Monster Hunter"	},	{		"ModelType": 2205,		"Name": "Poogie? (Disappears Immediately)"	},	{		"ModelType": 2210,		"Name": "Tsukuyomi"	},	{		"ModelType": 2211,		"Name": "Wukong - Monkey King"	},	{		"ModelType": 2212,		"Name": "Math Construct boss from Ridorana"	},	{		"ModelType": 2213,		"Name": "Magitek Trooper FFXV"	},	{		"ModelType": 2214,		"Name": "MA-X FFXV"	},	{		"ModelType": 2215,		"Name": "Iseultalon FFXV"	},	{		"ModelType": 2216,		"Name": "Eureka Pagos NM Marlboro Stack"	},	{		"ModelType": 2217,		"Name": "Daidarabotchi (Swallow's Compass 1st Boss)"	},	{		"ModelType": 2218,		"Name": "Sai Taisui (Swallow's Compass)"	},	{		"ModelType": 2219,		"Name": "Flaming Wall monster from Hell's Lid"	},	{		"ModelType": 2221,		"Name": "Namazu",		"Type": "Minion"	},	{		"ModelType": 2222,		"Name": "Sabotender Emperatiz"	},	{		"ModelType": 2223,		"Name": "Decotitus"	},	{		"ModelType": 2224,		"Name": "Namazu"	},	{		"ModelType": 2225,		"Name": "Another type of Namazu"	},	{		"ModelType": 2226,		"Name": "Namazu with headband"	},	{		"ModelType": 2227,		"Name": "Another type of Namazu with headband"	},	{		"ModelType": 2228,		"Name": "Wise Namazu"	},	{		"ModelType": 2229,		"Name": "Wise Namazu with headband"	},	{		"ModelType": 2230,		"Name": "Flying Rathalos (Monster Hunter)"	},	{		"ModelType": 2231,		"Name": "Poroggo"	},	{		"ModelType": 2232,		"Name": "Ananta",		"Type": "Minion"	},	{		"ModelType": 2233,		"Name": "Shalloweye"	},	{		"ModelType": 2234,		"Name": "Red Demon Spinning Mask (Heaven-on-High)"	},	{		"ModelType": 2235,		"Name": "Blue Demon Spinning Mask (Heaven-on-High)"	},	{		"ModelType": 2236,		"Name": "Hiruku (HoH Floor 30 Boss)"	},	{		"ModelType": 2237,		"Name": "King Igloo (Eureka Pagos NM)"	},	{		"ModelType": 2238,		"Name": "Monkey king",		"Type": "Minion"	},	{		"ModelType": 2239,		"Name": "A wall lantern",		"Type": "Minion"	},	{		"ModelType": 2240,		"Name": "A lizard type of",		"Type": "Minion"	},	{		"ModelType": 2241,		"Name": "Wind up Cirina",		"Type": "Minion"	},	{		"ModelType": 2242,		"Name": "Wind up Sadu",		"Type": "Minion"	},	{		"ModelType": 2243,		"Name": "Malboro with skirt",		"Type": "Minion"	},	{		"ModelType": 2244,		"Name": "Wind up Tarutaru?",		"Type": "Minion"	},	{		"ModelType": 2245,		"Name": "Wind up Tsukuyomi",		"Type": "Minion"	},	{		"ModelType": 2246,		"Name": "Wind up Zhloe",		"Type": "Minion"	},	{		"ModelType": 2247,		"Name": "Math Construct",		"Type": "Minion"	},	{		"ModelType": 2248,		"Name": "A giant rock - grey"	},	{		"ModelType": 2249,		"Name": "A giant rock - white"	},	{		"ModelType": 2250,		"Name": "A giant rock - purplish/black"	},	{		"ModelType": 2251,		"Name": "Pure White Tsukuyomi"	},	{		"ModelType": 2252,		"Name": "Pure Black Tsukuyomi"	},	{		"ModelType": 2253,		"Name": "Battle Mode Tsukuyomi"	},	{		"ModelType": 2254,		"Name": "Battle Mode Pure White Tsukuyomi"	},	{		"ModelType": 2255,		"Name": "Battle Mode Pure Black Tsukuyomi"	},	{		"ModelType": 2256,		"Name": "Fallen Samurai (Mounted)"	},	{		"ModelType": 2257,		"Name": "Rathalos (Monster Hunter) [Frozen]"	},	{		"ModelType": 2258,		"Name": "Chair Mount (PVP)"	},	{		"ModelType": 2259,		"Name": "Suzaku - Human"	},	{		"ModelType": 2260,		"Name": "Bangaa Boss Guy"	},	{		"ModelType": 2261,		"Name": "Suzaku - Human"	},	{		"ModelType": 2262,		"Name": "Rusted Math Construct"	},	{		"ModelType": 2264,		"Name": "Ultima Weapon Ultimate"	},	{		"ModelType": 2265,		"Name": "Yukinko (Eureka Pagos)"	},	{		"ModelType": 2266,		"Name": "Louhi (Eureka Pagos NM)"	},	{		"ModelType": 2267,		"Name": "Yiazmat (Ridorana Final Boss)"	},	{		"ModelType": 2268,		"Name": "Grani Mount Shadowbringers Collector"	},	{		"ModelType": 2269,		"Name": "Ridorana Exploding Fire Bell Trash"	},	{		"ModelType": 2270,		"Name": "Cute monkey"	},	{		"ModelType": 2271,		"Name": "Ultima Weapon of some sort"	},	{		"ModelType": 2272,		"Name": "Yiazmat (Enraged)"	},	{		"ModelType": 2273,		"Name": "Dark Ewer (Famfrit Add)"	},	{		"ModelType": 2274,		"Name": "Odder Otter with asian hat"	},	{		"ModelType": 2275,		"Name": "Ash Dragon (Pagos)"	},	{		"ModelType": 2276,		"Name": "Garuda"	},	{		"ModelType": 2277,		"Name": "Ifrit"	},	{		"ModelType": 2278,		"Name": "Titan"	},	{		"ModelType": 2279,		"Name": "Golden King Crab"	},	{		"ModelType": 2280,		"Name": "Val Corpse (Eureka Pagos)"	},	{		"ModelType": 2281,		"Name": "A ball of fire"	},	{		"ModelType": 2283,		"Name": "A huge ring of green mirrors"	},	{		"ModelType": 2284,		"Name": "Palico from Monster hunter (different one)"	},	{		"ModelType": 2285,		"Name": "Poogie from Monster hunter"	},	{		"ModelType": 2286,		"Name": "Floating gold fan"	},	{		"ModelType": 2287,		"Name": "Dreadnaught"	},	{		"ModelType": 2289,		"Name": "8 Namazu carrying a platform with nothing on it"	},	{		"ModelType": 2290,		"Name": "Magitek Sky Armor"	},	{		"ModelType": 2291,		"Name": "Floating blue cloud of depression"	},	{		"ModelType": 2292,		"Name": "T-Pose Default Model"	},	{		"ModelType": 2293,		"Name": "Tsukuyomi again"	},	{		"ModelType": 2294,		"Name": "Withered Belladonna"	},	{		"ModelType": 2295,		"Name": "Dorpokkur"	},	{		"ModelType": 2296,		"Name": "Matamata"	},	{		"ModelType": 2297,		"Name": "Nullchu"	},	{		"ModelType": 2298,		"Name": "Magitek Predator (Mount)"	},	{		"ModelType": 2299,		"Name": "Fat Cat"	},	{		"ModelType": 2300,		"Name": "Deformed Mameshiba?"	},	{		"ModelType": 2301,		"Name": "Weird lion",		"Type": "Minion"	},	{		"ModelType": 2302,		"Name": "Defective Drone"	},	{		"ModelType": 2303,		"Name": "Fallen Samurai "	},	{		"ModelType": 2304,		"Name": "Horse Mount HOH"	},	{		"ModelType": 2306,		"Name": "Allagan PVP Mount"	},	{		"ModelType": 2307,		"Name": "PVP Recolored Chair Mount"	},	{		"ModelType": 2308,		"Name": "Spinning Gear"	},	{		"ModelType": 2309,		"Name": "Yojimbo"	},	{		"ModelType": 2310,		"Name": "Festive Namazu"	},	{		"ModelType": 2311,		"Name": "Omega - Midgardsormr"	},	{		"ModelType": 2312,		"Name": "Fat Cat Mount"	},	{		"ModelType": 2313,		"Name": "Frost Dragon"	},	{		"ModelType": 2314,		"Name": "Frost Dragon"	},	{		"ModelType": 2315,		"Name": "Immaculate Apa"	},	{		"ModelType": 2317,		"Name": "Spinning White Orb"	},	{		"ModelType": 2318,		"Name": "Moogle (EQ)"	},	{		"ModelType": 2320,		"Name": "Omega M"	},	{		"ModelType": 2321,		"Name": "Omega F"	},	{		"ModelType": 2322,		"Name": "Neo Omega"	},	{		"ModelType": 2323,		"Name": "Omega M | F Puddle"	},	{		"ModelType": 2324,		"Name": "Alpha"	},	{		"ModelType": 2325,		"Name": "Ghost"	},	{		"ModelType": 2326,		"Name": "Ghost"	},	{		"ModelType": 2327,		"Name": "Suzaku -",		"Type": "Minion"	},	{		"ModelType": 2328,		"Name": "OMG - Omega",		"Type": "Minion"	},	{		"ModelType": 2329,		"Name": "G'raha Tia",		"Type": "Minion"	},	{		"ModelType": 2330,		"Name": "Cloud",		"Type": "Minion"	},	{		"ModelType": 2331,		"Name": "Aerith",		"Type": "Minion"	},	{		"ModelType": 2332,		"Name": "Tifa",		"Type": "Minion"	},	{		"ModelType": 2333,		"Name": "Kukulkan"	},	{		"ModelType": 2334,		"Name": "Brown Slime"	},	{		"ModelType": 2335,		"Name": "Omega - Midgardsormr"	},	{		"ModelType": 2336,		"Name": "Slime"	},	{		"ModelType": 2337,		"Name": "Magitek Predator (EQ)"	},	{		"ModelType": 2338,		"Name": "Ceruleum Engine"	},	{		"ModelType": 2339,		"Name": "Mister Bright-Eyes"	},	{		"ModelType": 2340,		"Name": "Magic Carpet Mount"	},	{		"ModelType": 2341,		"Name": "Tokkapchi - Minon"	},	{		"ModelType": 2342,		"Name": "Capybara"	},	{		"ModelType": 2343,		"Name": "???",		"Type": "Minion"	},	{		"ModelType": 2344,		"Name": "Moogle",		"Type": "Minion"	},	{		"ModelType": 2345,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2346,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2347,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2348,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2349,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2350,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2351,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2352,		"Name": "Suzaku Indicator"	},	{		"ModelType": 2353,		"Name": "Blue Orb"	},	{		"ModelType": 2354,		"Name": "Red Orb"	},	{		"ModelType": 2355,		"Name": "Suzaku Orb"	},	{		"ModelType": 2356,		"Name": "Mist"	},	{		"ModelType": 2357,		"Name": "Tokkapchi"	},	{		"ModelType": 2358,		"Name": "Penthesilea"	},	{		"ModelType": 2359,		"Name": "Euphonius Kamuy"	},	{		"ModelType": 2360,		"Name": "Omega"	},	{		"ModelType": 2361,		"Name": "Magna Roader"	},	{		"ModelType": 2362,		"Name": "Magitek Sky Armor"	},	{		"ModelType": 2363,		"Name": "Gilgamesh"	},	{		"ModelType": 2364,		"Name": "Pillar"	},	{		"ModelType": 2365,		"Name": "Suzaku"	},	{		"ModelType": 2366,		"Name": "Suzaku - Dressed"	},	{		"ModelType": 2367,		"Name": "Hedetet - Pillar"	},	{		"ModelType": 2368,		"Name": "Suzaku - Feather"	},	{		"ModelType": 2369,		"Name": "Chakram - The Burn"	},	{		"ModelType": 2370,		"Name": "Noctis",		"Type": "Character"	},	{		"ModelType": 2371,		"Name": "Hedetet"	},	{		"ModelType": 2372,		"Name": "Pyros Mount"	},	{		"ModelType": 2373,		"Name": "Khalamari"	},	{		"ModelType": 2374,		"Name": "Omega Rocket Punch 1"	},	{		"ModelType": 2375,		"Name": "Omega Rocket Punch 2"	},	{		"ModelType": 2376,		"Name": "Desert Desman"	},	{		"ModelType": 2377,		"Name": "Omega - Chaos"	},	{		"ModelType": 2378,		"Name": "Omega- Floating Right Arm"	},	{		"ModelType": 2379,		"Name": "Omega- Floating Left Arm"	},	{		"ModelType": 2380,		"Name": "Omega 12 Structure?"	},	{		"ModelType": 2381,		"Name": "Gilgamesh"	},	{		"ModelType": 2382,		"Name": "Fran (Demihuman)"	},	{		"ModelType": 2384,		"Name": "Solus Zos Galvus",		"Type": "Character"	},	{		"ModelType": 2385,		"Name": "Fat Black Chocobo Mount"	},	{		"ModelType": 2387,		"Name": "Omega - M"	},	{		"ModelType": 2388,		"Name": "Omega - F (With Weapon)"	},	{		"ModelType": 2389,		"Name": "Omega - F (No Weapon)"	},	{		"ModelType": 2390,		"Name": "Floating Staff"	},	{		"ModelType": 2391,		"Name": "Floating Axe"	},	{		"ModelType": 2392,		"Name": "Generic Person - Holding Wood",		"Type": "Character"	},	{		"ModelType": 2393,		"Name": "Suzaku Effect"	},	{		"ModelType": 2394,		"Name": "Lakhamu"	},	{		"ModelType": 2395,		"Name": "Jar?"	},	{		"ModelType": 2396,		"Name": "Desert Armadillo"	},	{		"ModelType": 2397,		"Name": "Bunch of Sticks"	},	{		"ModelType": 2398,		"Name": "Ultima"	},	{		"ModelType": 2399,		"Name": "Absolute Virtue"	},	{		"ModelType": 2400,		"Name": "Hidden Gorge Machine"	},	{		"ModelType": 2401,		"Name": "Korpokkur"	},	{		"ModelType": 2402,		"Name": "Blood Angel (Ultima add)"	},	{		"ModelType": 2403,		"Name": "Seiryu"	},	{		"ModelType": 2404,		"Name": "Yojimbo"	},	{		"ModelType": 2405,		"Name": "Alpha"	},	{		"ModelType": 2406,		"Name": "Sabotender Emperador (Mount)"	},	{		"ModelType": 2407,		"Name": "Red and Blue Bitches (Ghimlyt)"	},	{		"ModelType": 2408,		"Name": "Wall of Snakes (Seiryu)"	},	{		"ModelType": 2409,		"Name": "Ozma"	},	{		"ModelType": 2410,		"Name": "The Thunder God (Orbonne-Not Fucked Up)"	},	{		"ModelType": 2411,		"Name": "Swearing Imp Thing"	},	{		"ModelType": 2412,		"Name": "Fran",		"Type": "Minion"	},	{		"ModelType": 2413,		"Name": "Wind-Up Tataru"	},	{		"ModelType": 2414,		"Name": "Seiryu",		"Type": "Minion"	},	{		"ModelType": 2415,		"Name": "Magitek Asshole",		"Type": "Minion"	},	{		"ModelType": 2416,		"Name": "Armored Weapon",		"Type": "Minion"	},	{		"ModelType": 2417,		"Name": "Furball Minion x3"	},	{		"ModelType": 2418,		"Name": "Mini Absolute Virtue"	},	{		"ModelType": 2419,		"Name": "Fate boss in Greatwoods"	},	{		"ModelType": 2420,		"Name": "Armor Boi (Ghimlyt)"	},	{		"ModelType": 2421,		"Name": "Agrias (Orbonne)"	},	{		"ModelType": 2422,		"Name": "Mustadio (Orbonne)"	},	{		"ModelType": 2423,		"Name": "Azulmagia"	},	{		"ModelType": 2424,		"Name": "Provenance Watcher"	},	{		"ModelType": 2425,		"Name": "Absolute Virtue Dragon Add"	},	{		"ModelType": 2426,		"Name": "Phoenix - Possibly Suzaku"	},	{		"ModelType": 2427,		"Name": "Midgardsormr Head (Omega)"	},	{		"ModelType": 2428,		"Name": "Chiliad Cama"	},	{		"ModelType": 2429,		"Name": "Ugly ass Red Chicken"	},	{		"ModelType": 2430,		"Name": "Amalj'aa???"	},	{		"ModelType": 2431,		"Name": "Wetland Warg"	},	{		"ModelType": 2432,		"Name": "Tempest mob?? Unknown"	},	{		"ModelType": 2433,		"Name": "Grey Draco"	},	{		"ModelType": 2434,		"Name": "Phillia (Holmister final boss)"	},	{		"ModelType": 2435,		"Name": "Eros (Ravel Final Boss)"	},	{		"ModelType": 2436,		"Name": "Omega Level Checker"	},	{		"ModelType": 2437,		"Name": "Eldthurs (Mount - Pyros)"	},	{		"ModelType": 2438,		"Name": "Eggplant",		"Type": "Minion"	},	{		"ModelType": 2439,		"Name": "Matmata"	},	{		"ModelType": 2440,		"Name": "Giant Autoturret (Orbonne Add)"	},	{		"ModelType": 2441,		"Name": "minion nu mou"	},	{		"ModelType": 2442,		"Name": "Hedgehog",		"Type": "Minion"	},	{		"ModelType": 2443,		"Name": "Pillow"	},	{		"ModelType": 2444,		"Name": "Fisherman Otter",		"Type": "Minion"	},	{		"ModelType": 2445,		"Name": "Gigantender"	},	{		"ModelType": 2446,		"Name": "Phenoix Add"	},	{		"ModelType": 2447,		"Name": "Korpokkur"	},	{		"ModelType": 2448,		"Name": "Harpy (Orbonne)"	},	{		"ModelType": 2451,		"Name": "Ultimate Kamuy/Wolf"	},	{		"ModelType": 2452,		"Name": "Seiryu Wolf (Mount)"	},	{		"ModelType": 2453,		"Name": "Ovni"	},	{		"ModelType": 2454,		"Name": "Sticks are alive!?"	},	{		"ModelType": 2455,		"Name": "Ran'jit"	},	{		"ModelType": 2456,		"Name": "Ran'jit with scythe"	},	{		"ModelType": 2457,		"Name": "Ran'jit pet"	},	{		"ModelType": 2458,		"Name": "Eden Mount!?"	},	{		"ModelType": 2459,		"Name": "Omega M | F Puddle"	},	{		"ModelType": 2460,		"Name": "Omega 11s Hands"	},	{		"ModelType": 2461,		"Name": "Soft Pillow"	},	{		"ModelType": 2462,		"Name": "Sin Eater Mob??"	},	{		"ModelType": 2463,		"Name": "Raiden"	},	{		"ModelType": 2464,		"Name": "Seiryu (Snake Form)"	},	{		"ModelType": 2465,		"Name": "Aye it's Diego (GNB Mount) Sabertooth"	},	{		"ModelType": 2466,		"Name": "Magitek Avenger A-1"	},	{		"ModelType": 2467,		"Name": "Magitek Roader (Mount - Gold)"	},	{		"ModelType": 2468,		"Name": "Hyrdatos Mount"	},	{		"ModelType": 2469,		"Name": "Garuda XV Event"	},	{		"ModelType": 2470,		"Name": "Trisiltia"	},	{		"ModelType": 2471,		"Name": "Alt Model (???)"	},	{		"ModelType": 2472,		"Name": "Alt Model (???)"	},	{		"ModelType": 2473,		"Name": "Ultima: The High Seraph (Orbonne)"	},	{		"ModelType": 2474,		"Name": "Titania"	},	{		"ModelType": 2475,		"Name": "Aenc Thon: Lord of the Lingering Gaze"	},	{		"ModelType": 2476,		"Name": "Griaule"	},	{		"ModelType": 2477,		"Name": "Lakelord Aenc Thon of the Long Gait"	},	{		"ModelType": 2478,		"Name": "Hades: first form "	},	{		"ModelType": 2479,		"Name": "Slime (Gold)"	},	{		"ModelType": 2481,		"Name": "Christmas Slime"	},	{		"ModelType": 2482,		"Name": "Fae Gwiber (Titania Mount)"	},	{		"ModelType": 2483,		"Name": "Black Hayate",		"Type": "Minion"	},	{		"ModelType": 2484,		"Name": "chameleon",		"Type": "Minion"	},	{		"ModelType": 2485,		"Name": "Y'shtola",		"Type": "Minion"	},	{		"ModelType": 2486,		"Name": "Ryne",		"Type": "Minion"	},	{		"ModelType": 2487,		"Name": "Ran'jit  - Frozen "	},	{		"ModelType": 2488,		"Name": "Masterless Talos"	},	{		"ModelType": 2489,		"Name": "Amphibious Talos"	},	{		"ModelType": 2491,		"Name": "Micro Gigantender",		"Type": "Minion"	},	{		"ModelType": 2492,		"Name": "Armadillo Bowler",		"Type": "Minion"	},	{		"ModelType": 2493,		"Name": "The Great Serpent of Ronka",		"Type": "Minion"	},	{		"ModelType": 2494,		"Name": "Clionid Larva minion "	},	{		"ModelType": 2495,		"Name": "Bitty Duckbill",		"Type": "Minion"	},	{		"ModelType": 2496,		"Name": "Gilgamesh"	},	{		"ModelType": 2497,		"Name": "T.G. Sword"	},	{		"ModelType": 2498,		"Name": "Ozma"	},	{		"ModelType": 2499,		"Name": "Owain's Hand"	},	{		"ModelType": 2500,		"Name": "Art's Spear"	},	{		"ModelType": 2501,		"Name": "Owain's Spear"	},	{		"ModelType": 2502,		"Name": "Ceto"	},	{		"ModelType": 2503,		"Name": "Art"	},	{		"ModelType": 2504,		"Name": "Owain"	},	{		"ModelType": 2506,		"Name": "Alt Model (???)"	},	{		"ModelType": 2507,		"Name": "Alt Model (???)"	},	{		"ModelType": 2508,		"Name": "Alt Model (???)"	},	{		"ModelType": 2509,		"Name": "Alt Model (???)"	},	{		"ModelType": 2510,		"Name": "The Thunder God (Orbonne)"	},	{		"ModelType": 2511,		"Name": "Regalia"	},	{		"ModelType": 2512,		"Name": "Ozma"	},	{		"ModelType": 2513,		"Name": "???Unsure sapling mob"	},	{		"ModelType": 2514,		"Name": "Vauthry"	},	{		"ModelType": 2515,		"Name": "Innocence"	},	{		"ModelType": 2516,		"Name": "Goblin/Lamebrix"	},	{		"ModelType": 2517,		"Name": "Goblin/Lamebrix"	},	{		"ModelType": 2520,		"Name": " Feo UI (Demimonster(Equipment change needed)"	},	{		"ModelType": 2521,		"Name": "Tusk"	},	{		"ModelType": 2522,		"Name": "Batsquatch"	},	{		"ModelType": 2523,		"Name": "Gukumatz "	},	{		"ModelType": 2524,		"Name": "Forgiven Jealousy (Sin Eater)"	},	{		"ModelType": 2525,		"Name": "Daen (??)"	},	{		"ModelType": 2526,		"Name": "Ultimate Kamuy (All Doggo/Wolf Mount)"	},	{		"ModelType": 2527,		"Name": "Eden's Leviathan"	},	{		"ModelType": 2528,		"Name": "Eden's Titan"	},	{		"ModelType": 2529,		"Name": "Eden's Titan 2nd Form"	},	{		"ModelType": 2530,		"Name": "Eden "	},	{		"ModelType": 2531,		"Name": "Terminus Bellweather"	},	{		"ModelType": 2532,		"Name": "Lozatl"	},	{		"ModelType": 2533,		"Name": "Hades: second form"	},	{		"ModelType": 2534,		"Name": "Lake Anemone"	},	{		"ModelType": 2535,		"Name": "Greater Armadillo"	},	{		"ModelType": 2536,		"Name": "Triceratops - Mount"	},	{		"ModelType": 2537,		"Name": "Giant Iguana"	},	{		"ModelType": 2538,		"Name": "Ultima Grandcross Crystal"	},	{		"ModelType": 2539,		"Name": "Amaro Mount"	},	{		"ModelType": 2540,		"Name": "The Fae Bismarck"	},	{		"ModelType": 2541,		"Name": "Rusted Golem (Orbonne Add)"	},	{		"ModelType": 2542,		"Name": "Prototype Magitek Armor (Ghimlyt Boss)"	},	{		"ModelType": 2543,		"Name": "Turtle Doll (Red)"	},	{		"ModelType": 2544,		"Name": "Fatty Kitty (Demihuman - Equipment must be changed)"	},	{		"ModelType": 2545,		"Name": "Ephemeral Warrior (Thunder God Add)"	},	{		"ModelType": 2546,		"Name": "Zenos"	},	{		"ModelType": 2547,		"Name": "Hashmal Junior"	},	{		"ModelType": 2548,		"Name": "Batraal Junior"	},	{		"ModelType": 2549,		"Name": "Famfrit Junior"	},	{		"ModelType": 2551,		"Name": "Daidarabochi Shikigami (Seiryu Add)"	},	{		"ModelType": 2553,		"Name": "Shining Pegasus?"	},	{		"ModelType": 2554,		"Name": "Zenos"	},	{		"ModelType": 2555,		"Name": "Zenos"	},	{		"ModelType": 2556,		"Name": "Zenos"	},	{		"ModelType": 2557,		"Name": "Construct 8 (Refurbished)"	},	{		"ModelType": 2558,		"Name": "Flower Basket"	},	{		"ModelType": 2559,		"Name": "Forgiven Conformity (Sin Eater)"	},	{		"ModelType": 2560,		"Name": "Sin Eater Bird (??) "	},	{		"ModelType": 2561,		"Name": "Sin Eater Dzo (??)"	},	{		"ModelType": 2562,		"Name": "Sin Eater Bear (??) "	},	{		"ModelType": 2563,		"Name": "The Tycoon"	},	{		"ModelType": 2564,		"Name": "Giant Beaver"	},	{		"ModelType": 2565,		"Name": "Suzaku",		"Type": "Minion"	},	{		"ModelType": 2566,		"Name": "Eden's",		"Type": "Minion"	},	{		"ModelType": 2567,		"Name": "Omega-M",		"Type": "Minion"	},	{		"ModelType": 2568,		"Name": "Omega-F minion "	},	{		"ModelType": 2569,		"Name": "Cube",		"Type": "Minion"	},	{		"ModelType": 2570,		"Name": "Forgiven Obsentity (Mt.Gulag Final Boss)"	},	{		"ModelType": 2571,		"Name": "Cladoselcahe"	},	{		"ModelType": 2572,		"Name": "Doliodus  "	},	{		"ModelType": 2573,		"Name": "Puck: Titania Add"	},	{		"ModelType": 2574,		"Name": "Moss Fungus"	},	{		"ModelType": 2575,		"Name": "The First's Construction"	},	{		"ModelType": 2576,		"Name": "Hades"	},	{		"ModelType": 2577,		"Name": "Looks like it came straight from Doom"	},	{		"ModelType": 2578,		"Name": "Horse can't see????"	},	{		"ModelType": 2579,		"Name": "Fire Bomber"	},	{		"ModelType": 2580,		"Name": "Ice Bomber"	},	{		"ModelType": 2582,		"Name": "Formidable"	},	{		"ModelType": 2583,		"Name": "Ironfrog Mover"	},	{		"ModelType": 2584,		"Name": "Innocent Gwiber"	},	{		"ModelType": 2585,		"Name": "Archaeotania "	},	{		"ModelType": 2586,		"Name": "Marquis Morbol "	},	{		"ModelType": 2587,		"Name": "Echevore"	},	{		"ModelType": 2588,		"Name": "Dagon"	},	{		"ModelType": 2589,		"Name": "Geodude"	},	{		"ModelType": 2590,		"Name": "Unsure: Tail-less Pieste (??)"	},	{		"ModelType": 2591,		"Name": "Unsure: Stone beast with large bulb  (??)"	},	{		"ModelType": 2592,		"Name": "The First Beast"	},	{		"ModelType": 2593,		"Name": "Aglaope"	},	{		"ModelType": 2594,		"Name": "Gunitt"	},	{		"ModelType": 2595,		"Name": "Garden Porxie"	},	{		"ModelType": 2596,		"Name": "Ronkan Dreamer"	},	{		"ModelType": 2597,		"Name": "Deacon"	},	{		"ModelType": 2598,		"Name": "Huracan"	},	{		"ModelType": 2599,		"Name": "A Rank O Poorest Pauldia"	},	{		"ModelType": 2600,		"Name": "Kuribu Sin Eater"	},	{		"ModelType": 2601,		"Name": "Evil Weapon"	},	{		"ModelType": 2602,		"Name": "Tiny Echevore",		"Type": "Minion"	},	{		"ModelType": 2604,		"Name": "Shoebill",		"Type": "Minion"	},	{		"ModelType": 2605,		"Name": "Butterfly Effect",		"Type": "Minion"	},	{		"ModelType": 2606,		"Name": "Ironfrog Ambler",		"Type": "Minion"	},	{		"ModelType": 2607,		"Name": "Forgiven Hate minion "	},	{		"ModelType": 2608,		"Name": "Tinker's bell",		"Type": "Minion"	},	{		"ModelType": 2609,		"Name": "Emet-Selch",		"Type": "Character"	},	{		"ModelType": 2610,		"Name": "Crystal Exarch",		"Type": "Character"	},	{		"ModelType": 2611,		"Name": "Forgiven Dissonance"	},	{		"ModelType": 2612,		"Name": "Mithridates "	},	{		"ModelType": 2613,		"Name": "Forgiven Cruelty "	},	{		"ModelType": 2614,		"Name": "Forgiven Rebellion"	},	{		"ModelType": 2615,		"Name": "sin eater cocoon"	},	{		"ModelType": 2616,		"Name": "Mustardseed: Titania add"	},	{		"ModelType": 2617,		"Name": "Peaceblossom: Titnia add"	},	{		"ModelType": 2618,		"Name": "Automation Queen (MCH ROBOT)"	},	{		"ModelType": 2619,		"Name": "Seraph"	},	{		"ModelType": 2620,		"Name": "Pyheonix"	},	{		"ModelType": 2622,		"Name": "Sin Eater Diremite (??) "	},	{		"ModelType": 2623,		"Name": "Sin Eater Diremite B (??)"	},	{		"ModelType": 2624,		"Name": "Tentacle"	},	{		"ModelType": 2625,		"Name": "Engendered Soma "	},	{		"ModelType": 2627,		"Name": "Eden's Voidwalker"	},	{		"ModelType": 2628,		"Name": "Eden's Voidwalker's hand add stuff"	},	{		"ModelType": 2629,		"Name": "Forgiven Extortion (Sin Eater fenrir)"	},	{		"ModelType": 2630,		"Name": "Forgiven Apathy"	},	{		"ModelType": 2631,		"Name": "Spikey"	},	{		"ModelType": 2632,		"Name": "Tesleen Sin Eater"	},	{		"ModelType": 2633,		"Name": "Forgiven Ambition"	},	{		"ModelType": 2634,		"Name": "Forgiven Violence"	},	{		"ModelType": 2635,		"Name": "Feather"	},	{		"ModelType": 2636,		"Name": "Tentacle Woman"	},	{		"ModelType": 2637,		"Name": "Darker Tentacle Woman"	},	{		"ModelType": 2638,		"Name": "Gate Final Mt.Gulag"	},	{		"ModelType": 2639,		"Name": "Gate Final Mt.Gulag"	},	{		"ModelType": 2640,		"Name": "CATASTROPHE"	},	{		"ModelType": 2641,		"Name": "Flying Head"	},	{		"ModelType": 2642,		"Name": "Sticks Sticks but ice"	},	{		"ModelType": 2643,		"Name": "Golemn"	},	{		"ModelType": 2644,		"Name": "Sword"	},	{		"ModelType": 2645,		"Name": "T-pose Halloween mount"	},	{		"ModelType": 2646,		"Name": "Bed Mount"	},	{		"ModelType": 2647,		"Name": "Sin Eater Demon wall"	},	{		"ModelType": 2648,		"Name": "Titania's Add"	},	{		"ModelType": 2649,		"Name": "Dodo"	},	{		"ModelType": 2650,		"Name": "Goobu"	},	{		"ModelType": 2651,		"Name": "Sea Anemone"	},	{		"ModelType": 2652,		"Name": "Etainmoth"	},	{		"ModelType": 2653,		"Name": "Phooka"	},	{		"ModelType": 2654,		"Name": "Sword"	},	{		"ModelType": 2655,		"Name": "Mark CXLIV Thermocoil Boilbuster"	},	{		"ModelType": 2656,		"Name": "Boulder in MSQ"	},	{		"ModelType": 2657,		"Name": "Trappy thing in 73 dgn"	},	{		"ModelType": 2658,		"Name": "Violet Triffid"	},	{		"ModelType": 2659,		"Name": "Ngozi"	},	{		"ModelType": 2660,		"Name": "Green Glider"	},	{		"ModelType": 2661,		"Name": "A rank in greatwoods?"	},	{		"ModelType": 2662,		"Name": "ShB S-rank goobue"	},	{		"ModelType": 2663,		"Name": "Serpent"	},	{		"ModelType": 2664,		"Name": "A rock"	},	{		"ModelType": 2665,		"Name": "???"	},	{		"ModelType": 2666,		"Name": "Looks Delicious: from Tempest"	},	{		"ModelType": 2667,		"Name": "Shinryu head?"	},	{		"ModelType": 2668,		"Name": "S-rank SHB"	},	{		"ModelType": 2669,		"Name": "Fate BONUS EXP"	},	{		"ModelType": 2670,		"Name": "Golden Construct"	},	{		"ModelType": 2671,		"Name": "Forgiven Whimsy"	},	{		"ModelType": 2672,		"Name": "Gnole"	},	{		"ModelType": 2673,		"Name": "Engedered Pteraketos"	},	{		"ModelType": 2674,		"Name": "Ancient Lizard"	},	{		"ModelType": 2675,		"Name": "???"	},	{		"ModelType": 2676,		"Name": "???"	},	{		"ModelType": 2677,		"Name": "???"	},	{		"ModelType": 2678,		"Name": "???"	},	{		"ModelType": 2679,		"Name": "???"	},	{		"ModelType": 2680,		"Name": "???"	},	{		"ModelType": 2681,		"Name": "???"	},	{		"ModelType": 2682,		"Name": "???"	},	{		"ModelType": 2683,		"Name": "???"	},	{		"ModelType": 2684,		"Name": "Cubus"	},	{		"ModelType": 2685,		"Name": "Flanborg"	},	{		"ModelType": 2686,		"Name": "Succubus"	},	{		"ModelType": 2687,		"Name": "Friendly Tempest Demihumans"	},	{		"ModelType": 2688,		"Name": "Thugs in Kholusa"	},	{		"ModelType": 2689,		"Name": "Thugs in Kholusa"	},	{		"ModelType": 2690,		"Name": "Thugs in Kholusa"	},	{		"ModelType": 2691,		"Name": "Demihuman?"	},	{		"ModelType": 2692,		"Name": "What kind of mutant is this?"	},	{		"ModelType": 2693,		"Name": "Nu Mou"	},	{		"ModelType": 2694,		"Name": "Friendly Tempest Demihumans"	},	{		"ModelType": 2695,		"Name": "Friendly Tempest Demihumans"	},	{		"ModelType": 2698,		"Name": "Dark orb"	},	{		"ModelType": 2699,		"Name": "Eden's Orb"	},	{		"ModelType": 2701,		"Name": "Eden"	},	{		"ModelType": 2702,		"Name": "Fist in Titana"	},	{		"ModelType": 2703,		"Name": "Golden Nimbus"	},	{		"ModelType": 2705,		"Name": "Glowy Orb"	},	{		"ModelType": 2707,		"Name": "Greatwoods Golem"	},	{		"ModelType": 2708,		"Name": "Eden's Titan Rocks"	},	{		"ModelType": 2709,		"Name": "Eden's Voidwalker's Adds"	},	{		"ModelType": 2710,		"Name": "Storge - Malikah's Well 3rd boss"	},	{		"ModelType": 2711,		"Name": "Feo Ul King Titania"	},	{		"ModelType": 2712,		"Name": "???"	},	{		"ModelType": 2713,		"Name": "Amaurotine",		"Type": "Character"	},	{		"ModelType": 2716,		"Name": "Red ugly bird"	},	{		"ModelType": 2717,		"Name": "Spriggan Mount"	},	{		"ModelType": 2718,		"Name": "Philia - Holminster Switch"	},	{		"ModelType": 2719,		"Name": "Dummy"	},	{		"ModelType": 2720,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2721,		"Name": "Chain/Stun/Whatever"	},	{		"ModelType": 2722,		"Name": "Golden Fuath (??)"	},	{		"ModelType": 2723,		"Name": "Golem boss that does water stuff"	},	{		"ModelType": 2724,		"Name": "Boy what the?? Chimera"	},	{		"ModelType": 2726,		"Name": "Giraffe?"	},	{		"ModelType": 2728,		"Name": "Sin Eater Mount"	},	{		"ModelType": 2729,		"Name": "Talos"	},	{		"ModelType": 2731,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2732,		"Name": "Amber Iguana"	},	{		"ModelType": 2733,		"Name": "Gunbreaker Armored Sabertooth Mount"	},	{		"ModelType": 2734,		"Name": "Froggo"	},	{		"ModelType": 2735,		"Name": "Therion"	},	{		"ModelType": 2736,		"Name": "Therion - Flying"	},	{		"ModelType": 2737,		"Name": "Sin Eater"	},	{		"ModelType": 2738,		"Name": "Cube in greatwoods"	},	{		"ModelType": 2739,		"Name": "Sin Eater cacoon"	},	{		"ModelType": 2740,		"Name": "Dark Orb"	},	{		"ModelType": 2741,		"Name": "Piglet"	},	{		"ModelType": 2742,		"Name": "Pixie Minion ??"	},	{		"ModelType": 2743,		"Name": "Engels"	},	{		"ModelType": 2744,		"Name": "Quetzalcoatl - Akadaemia"	},	{		"ModelType": 2745,		"Name": "Pegasus"	},	{		"ModelType": 2746,		"Name": "Dark Pegasus"	},	{		"ModelType": 2747,		"Name": "Fenrir"	},	{		"ModelType": 2748,		"Name": "Ugly ass bird"	},	{		"ModelType": 2749,		"Name": "Cute",		"Type": "Minion"	},	{		"ModelType": 2750,		"Name": "Dark Wizard!? Forgot what name this guy is?"	},	{		"ModelType": 2752,		"Name": "Morbol Mount"	},	{		"ModelType": 2753,		"Name": "Eden's Titan"	},	{		"ModelType": 2754,		"Name": "Eden Prime"	},	{		"ModelType": 2755,		"Name": "Meerkat"	},	{		"ModelType": 2756,		"Name": "Minion with a Knife"	},	{		"ModelType": 2757,		"Name": "Sin eater lion"	},	{		"ModelType": 2758,		"Name": "EDEN MOUNT!???"	},	{		"ModelType": 2759,		"Name": "lol Halloween mount?"	},	{		"ModelType": 2760,		"Name": "Piglet Mount"	},	{		"ModelType": 2761,		"Name": "PvP Mount"	},	{		"ModelType": 2762,		"Name": "PVP Mount"	},	{		"ModelType": 2763,		"Name": "Add in Twinning?"	},	{		"ModelType": 2764,		"Name": "Formidable"	},	{		"ModelType": 2766,		"Name": "Pixies - Demihumans"	},	{		"ModelType": 2767,		"Name": "Box"	},	{		"ModelType": 2768,		"Name": "Smaller Box"	},	{		"ModelType": 2769,		"Name": "Glider (Green)"	},	{		"ModelType": 2770,		"Name": "Glider (Blue)"	},	{		"ModelType": 2771,		"Name": "PvP mount"	},	{		"ModelType": 2772,		"Name": "Dragon Mount?"	},	{		"ModelType": 2773,		"Name": "White Horse",		"Type": "Minion"	},	{		"ModelType": 2774,		"Name": "Brute Justice",		"Type": "Minion"	},	{		"ModelType": 2775,		"Name": "Little Fish"	},	{		"ModelType": 2776,		"Name": "Maliktender (A Rank)"	},	{		"ModelType": 2777,		"Name": "Debitage"	},	{		"ModelType": 2778,		"Name": "Cliffmole"	},	{		"ModelType": 2779,		"Name": "Consort of Sin: Forgiven Obscenity"	},	{		"ModelType": 2780,		"Name": "Dagon"	},	{		"ModelType": 2781,		"Name": "Last boss in Mt.Gulag"	},	{		"ModelType": 2782,		"Name": "Alexander Prime (TEA version)"	},	{		"ModelType": 2783,		"Name": "Perfect Alexander (Golden)"	},	{		"ModelType": 2784,		"Name": "Perfect Alexander (Coloured)"	},	{		"ModelType": 2785,		"Name": "Seeker of Solitutde (Cosmos 1st Boss)"	},	{		"ModelType": 2786,		"Name": "Hobbes (Copied Factory 2nd Boss)"	},	{		"ModelType": 2787,		"Name": "Hobbes Armature"	},	{		"ModelType": 2788,		"Name": "Hobbes Armature 2"	},	{		"ModelType": 2789,		"Name": "Ludus (Cosmos Final Boss)"	},	{		"ModelType": 2790,		"Name": "Leannan Sith Seed"	},	{		"ModelType": 2791,		"Name": "Serial-jointed Command Model (Copied Factory 1st Boss)"	},	{		"ModelType": 2792,		"Name": "9S-operated Walking Fortress (Copied Factory Final Boss)"	},	{		"ModelType": 2793,		"Name": "Lord Tolthewil (Cosmos Mini-Boss)"	},	{		"ModelType": 2794,		"Name": "Hades Extreme (???)"	},	{		"ModelType": 2795,		"Name": "9S in Flier"	},	{		"ModelType": 2796,		"Name": "2P in Flier"	},	{		"ModelType": 2797,		"Name": "Garuda, Heritor of the Vortex"	},	{		"ModelType": 2799,		"Name": "Peacock Mount"	},	{		"ModelType": 2800,		"Name": "Little Leannan",		"Type": "Minion"	},	{		"ModelType": 2801,		"Name": "Dress-Up Estinien",		"Type": "Minion"	},	{		"ModelType": 2802,		"Name": "Wind-Up Hobgoblin",		"Type": "Minion"	},	{		"ModelType": 2804,		"Name": "Destrudo (Pixie Quest Boss)"	},	{		"ModelType": 2805,		"Name": "PROBABLY Engels (absolutely massive)"	},	{		"ModelType": 2806,		"Name": "Arch Ultima"	},	{		"ModelType": 2807,		"Name": "Creepy face bug man"	},	{		"ModelType": 2808,		"Name": "Golden Heart"	},	{		"ModelType": 2809,		"Name": "Nier Orbs"	},	{		"ModelType": 2810,		"Name": "2P",		"Type": "Character"	},	{		"ModelType": 2811,		"Name": "Red orb (???)"	},	{		"ModelType": 2812,		"Name": "Blue square (???)"	},	{		"ModelType": 2813,		"Name": "Magicked Broom sweeping"	},	{		"ModelType": 2814,		"Name": "Ruby Weapon"	},	{		"ModelType": 2816,		"Name": "Sppoky demon Bird"	},	{		"ModelType": 2817,		"Name": "Leannan Sith (Cosmos 2nd Boss)"	},	{		"ModelType": 2818,		"Name": "Pod 054",		"Type": "Minion"	},	{		"ModelType": 2819,		"Name": "Pod 316"	},	{		"ModelType": 2820,		"Name": "9S",		"Type": "Character"	},	{		"ModelType": 2821,		"Name": "Goliath Tank ?? (Nier Raid)"	},	{		"ModelType": 2822,		"Name": "Nier Add"	},	{		"ModelType": 2823,		"Name": "Nier Add 2"	},	{		"ModelType": 2824,		"Name": "Nier Add 3"	},	{		"ModelType": 2825,		"Name": "Nier Add 4"	},	{		"ModelType": 2826,		"Name": "Nier Add 5"	},	{		"ModelType": 2827,		"Name": "Nier Add 6"	},	{		"ModelType": 2828,		"Name": "Nier Goliath Tank"	},	{		"ModelType": 2829,		"Name": "Nier Reverse-Jointed Goliath"	},	{		"ModelType": 2830,		"Name": "Zombie Behemoth"	},	{		"ModelType": 2831,		"Name": "Sand Mandagora ??"	},	{		"ModelType": 2832,		"Name": "Thordan - New Model Variant"	},	{		"ModelType": 2838,		"Name": "Ufiti (Mount)"	},	{		"ModelType": 2839,		"Name": "Pod (Nier Raid)"	},	{		"ModelType": 2840,		"Name": "Crystal Scorpion?"	},	{		"ModelType": 2841,		"Name": "Arch Ultima no pilot"	},	{		"ModelType": 2842,		"Name": "Nier Flier no pilot"	},	{		"ModelType": 2843,		"Name": "Nier Walking Fortress no pilot"	},	{		"ModelType": 2845,		"Name": "Nier Missiles"	},	{		"ModelType": 2846,		"Name": "Marx Support"	},	{		"ModelType": 2848,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2849,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2850,		"Name": "Bacon Bits",		"Type": "Minion"	},	{		"ModelType": 2851,		"Name": "Ezel II"	},	{		"ModelType": 2852,		"Name": "Serial-jointed Command Model (Copied Factory 1st Boss)"	},	{		"ModelType": 2853,		"Name": "Gaia"	},	{		"ModelType": 2854,		"Name": "Eden 7 Birds"	},	{		"ModelType": 2855,		"Name": "Sungold Talos",		"Type": "Minion"	},	{		"ModelType": 2856,		"Name": "T-Rex",		"Type": "Minion"	},	{		"ModelType": 2857,		"Name": "Little Leafman",		"Type": "Minion"	},	{		"ModelType": 2858,		"Name": "Silver Dasher",		"Type": "Minion"	},	{		"ModelType": 2860,		"Name": "Peacock Mount (T Pose)"	},	{		"ModelType": 2861,		"Name": "Great Vessel of Ronka (Mount)"	},	{		"ModelType": 2862,		"Name": "Pterodactyl (Mount)"	},	{		"ModelType": 2863,		"Name": "Ruby Gwiber (Mount)"	},	{		"ModelType": 2864,		"Name": "Kyklops (Anamensis 2nd Boss)"	},	{		"ModelType": 2865,		"Name": "Kukshs Dheem (Anamensis Final Boss)"	},	{		"ModelType": 2866,		"Name": "Ramuh, Heritor of Levin"	},	{		"ModelType": 2867,		"Name": "Mochi Minotaur"	},	{		"ModelType": 2868,		"Name": "Generic Person",		"Type": "Character"	},	{		"ModelType": 2869,		"Name": "Insatiable Flame: Lugus"	},	{		"ModelType": 2870,		"Name": "Small Stubby (Nier)"	},	{		"ModelType": 2872,		"Name": "Ruby Weapon Add (???)"	},	{		"ModelType": 2873,		"Name": "Unknown (Anamensis 1st Boss)"	},	{		"ModelType": 2874,		"Name": "Eden Ramuh Horse Add"	},	{		"ModelType": 2875,		"Name": "Eden Ramuh Black"	},	{		"ModelType": 2876,		"Name": "Bozja Walking Cannon"	},	{		"ModelType": 2877,		"Name": "Flying Hairy Eyeball"	},	{		"ModelType": 2878,		"Name": "Kukshs Dheem Add"	},	{		"ModelType": 2879,		"Name": "Ruby Weapon - Nael van Darnus phase"	},	{		"ModelType": 2880,		"Name": "Eden Idol of Darkness"	},	{		"ModelType": 2881,		"Name": "Sapphire Weapon Gundam"	},	{		"ModelType": 2883,		"Name": "Eden Ifrit"	},	{		"ModelType": 2884,		"Name": "Trench Amemone"	},	{		"ModelType": 2885,		"Name": "Lo ousia"	},	{		"ModelType": 2886,		"Name": "Glowing Evil Bird"	},	{		"ModelType": 2887,		"Name": "Nael Heads(Red)"	},	{		"ModelType": 2888,		"Name": "Nael Heads(Blue)"	},	{		"ModelType": 2889,		"Name": "Eden Raktapaksa"	},	{		"ModelType": 2890,		"Name": "Eden Raktapaksa"	},	{		"ModelType": 2891,		"Name": "Behatted Serpent of Ronka",		"Type": "Minion"	},	{		"ModelType": 2892,		"Name": "Paissa Patissier",		"Type": "Minion"	},	{		"ModelType": 2893,		"Name": "Paissa Threadpuller",		"Type": "Minion"	},	{		"ModelType": 2894,		"Name": "Ancient One",		"Type": "Minion"	},	{		"ModelType": 2895,		"Name": "The Major-General",		"Type": "Minion"	},	{		"ModelType": 2896,		"Name": "Wind-Up Dulia-Chai",		"Type": "Minion"	},	{		"ModelType": 2897,		"Name": "Amaro",		"Type": "Minion"	},	{		"ModelType": 2898,		"Name": "Laladile",		"Type": "Minion"	},	{		"ModelType": 2899,		"Name": "Unlucky Rabbit",		"Type": "Minion"	},	{		"ModelType": 2900,		"Name": "Hybodus (Mount)"	},	{		"ModelType": 2901,		"Name": "Eden Ramuh (Mount)"	},	{		"ModelType": 2902,		"Name": "Eden Verse Shiva"	},	{		"ModelType": 2903,		"Name": "Eden Verse Shiva (Hydaelyn Form)"	},	{		"ModelType": 2904,		"Name": "Elidibus (Warrior of Light)"	},	{		"ModelType": 2905,		"Name": "Eden Verse Idol of Darkness"	},	{		"ModelType": 2906,		"Name": "Eden Bird Adds"	},	{		"ModelType": 2908,		"Name": "Eden Verse Idol of Darkness"	},	{		"ModelType": 2909,		"Name": "Zenos"	},	{		"ModelType": 2910,		"Name": "Eden Verse Shiva (Hraesvelgr Form)"	},	{		"ModelType": 2911,		"Name": "Ruby Weapon Orbs"	},	{		"ModelType": 2912,		"Name": "Eden Verse Idol of Darkness Birds"	},	{		"ModelType": 2913,		"Name": "Ruby Carbuncle (Mount???)"	},	{		"ModelType": 2915,		"Name": "Huaca"	},	{		"ModelType": 2917,		"Name": "BLU Blue X"	},	{		"ModelType": 2918,		"Name": "BLU Red X"	},	{		"ModelType": 2919,		"Name": "BLU Green X"	},	{		"ModelType": 2920,		"Name": "Garuda's Feathers"	},	{		"ModelType": 2921,		"Name": "Aqua Orb"	},	{		"ModelType": 2922,		"Name": "Lightning Spark"	},	{		"ModelType": 2924,		"Name": "Earthen Golem"	},	{		"ModelType": 2925,		"Name": "Bozja HUGE MECH"	},	{		"ModelType": 2926,		"Name": "Bozja Aces High"	},	{		"ModelType": 2927,		"Name": "Bozja Spider Tank"	},	{		"ModelType": 2928,		"Name": "Bozja Voltron Cat"	},	{		"ModelType": 2929,		"Name": "Bozja flying tank thing"	},	{		"ModelType": 2930,		"Name": "Alebrije monster thing"	},	{		"ModelType": 2931,		"Name": "Stack of blue cubes"	},	{		"ModelType": 2932,		"Name": "Void Octopus thing"	},	{		"ModelType": 2933,		"Name": "Pod (Nier raid)"	},	{		"ModelType": 2934,		"Name": "Eden Shiva (Naked: Transformation)"	},	{		"ModelType": 2935,		"Name": "Ruby Weapon (Nael van Darnus only)"	},	{		"ModelType": 2936,		"Name": "Ruby Weapon (Shell)"	},	{		"ModelType": 2937,		"Name": "Ramuh's Beard"	},	{		"ModelType": 2938,		"Name": "Animated Artisan",		"Type": "Character"	},	{		"ModelType": 2939,		"Name": "Black Parasol"	},	{		"ModelType": 2940,		"Name": "Blue Parasol"	},	{		"ModelType": 2941,		"Name": "Venat",		"Type": "Character"	},	{		"ModelType": 2942,		"Name": "Ifirit Orb"	},	{		"ModelType": 2943,		"Name": "Orb"	},	{		"ModelType": 2944,		"Name": "Eden Shiva (Hydaelyn Form)"	},	{		"ModelType": 2945,		"Name": "Griffon Lion? (Mount)"	},	{		"ModelType": 2947,		"Name": "Eden Idol of Darkness Birds"	},	{		"ModelType": 2948,		"Name": "Generic Person - Holding Baby",		"Type": "Character"	},	{		"ModelType": 2953,		"Name": "Gaia"	},	{		"ModelType": 2954,		"Name": "Eden Idol of Darkness Birds"	},	{		"ModelType": 2955,		"Name": "Eden Idol of Darkness Birds"	},	{		"ModelType": 2956,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2957,		"Name": "813P-operated Aegis Unit",		"Type": "Monster"	},	{		"ModelType": 2958,		"Name": "724P-operated Superior Flight Unit",		"Type": "Monster"	},	{		"ModelType": 2959,		"Name": "905P-operated Heavy Artillery Unit",		"Type": "Monster"	},	{		"ModelType": 2960,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2961,		"Name": "that one blue shark bitch from anyder/maps",		"Type": "Unknown"	},	{		"ModelType": 2962,		"Name": "second boss from bonk i think?",		"Type": "Unknown"	},	{		"ModelType": 2963,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2964,		"Name": "Compound 2P",		"Type": "Monster"	},	{		"ModelType": 2965,		"Name": "white pod (minion/npc/flying model?)",		"Type": "Unknown"	},	{		"ModelType": 2966,		"Name": "Emerald Weapon",		"Type": "Unknown"	},	{		"ModelType": 2967,		"Name": "Eden 12 Boss",		"Type": "Unknown"	},	{		"ModelType": 2968,		"Name": "Spectral Berserker",		"Type": "Monster"	},	{		"ModelType": 2969,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2970,		"Name": "4C6F6E67696E67: The Compound",		"Type": "Monster"	},	{		"ModelType": 2971,		"Name": "Elddragon",		"Type": "Monster"	},	{		"ModelType": 2972,		"Name": "Broken Pod",		"Type": "Unknown"	},	{		"ModelType": 2973,		"Name": "Zul ",		"Type": "Unknown"	},	{		"ModelType": 2974,		"Name": "Jibanyan Couch (static)",		"Type": "Mount"	},	{		"ModelType": 2975,		"Name": "Ell Tou (static)",		"Type": "Mount"	},	{		"ModelType": 2976,		"Name": "Gwiber of Light (static)",		"Type": "Mount"	},	{		"ModelType": 2977,		"Name": "Lalinator 5.H0",		"Type": "Minion"	},	{		"ModelType": 2978,		"Name": "Wind-Up Mystel",		"Type": "Minion"	},	{		"ModelType": 2979,		"Name": "Wind-Up Ardbert",		"Type": "Minion"	},	{		"ModelType": 2980,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2981,		"Name": "Weatherproof Gaelicat",		"Type": "Minion"	},	{		"ModelType": 2982,		"Name": "Ephemeral Necromancer",		"Type": "Minion"	},	{		"ModelType": 2983,		"Name": "Allagan Melon",		"Type": "Minion"	},	{		"ModelType": 2984,		"Name": "Sand Fox",		"Type": "Minion"	},	{		"ModelType": 2985,		"Name": "Petit Pteranodon",		"Type": "Minion"	},	{		"ModelType": 2986,		"Name": "Voltron Cat? (Minion)",		"Type": "Unknown"	},	{		"ModelType": 2987,		"Name": "Lord Enma",		"Type": "Minion"	},	{		"ModelType": 2988,		"Name": "Lord Ananta",		"Type": "Minion"	},	{		"ModelType": 2989,		"Name": "Zazel",		"Type": "Minion"	},	{		"ModelType": 2990,		"Name": "Demona",		"Type": "Minion"	},	{		"ModelType": 2991,		"Name": "2B Automaton",		"Type": "Minion"	},	{		"ModelType": 2992,		"Name": "2P Automaton",		"Type": "Minion"	},	{		"ModelType": 2993,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2994,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2995,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 2996,		"Name": "Spectral Necromancer",		"Type": "Monster"	},	{		"ModelType": 2997,		"Name": "Water Orb",		"Type": "Effect"	},	{		"ModelType": 2998,		"Name": "Fire Orb",		"Type": "Effect"	},	{		"ModelType": 2999,		"Name": "Ball of feathers",		"Type": "Effect"	},	{		"ModelType": 3000,		"Name": "Investigate",		"Type": "Unknown"	},	{		"ModelType": 3001,		"Name": "Flight Unit Empty",		"Type": "Monster"	},	{		"ModelType": 3003,		"Name": "Floor Mine",		"Type": "Unknown"	},	{		"ModelType": 3004,		"Name": "Red Orb of ouch",		"Type": "Unknown"	},	{		"ModelType": 3005,		"Name": "Magitek Hyperconveyor",		"Type": "Mount"	},	{		"ModelType": 3006,		"Name": "Incitatus",		"Type": "Mount"	},	{		"ModelType": 3007,		"Name": "Red Parasol",		"Type": "Effect"	},	{		"ModelType": 3008,		"Name": "Purple Parasol",		"Type": "Effect"	},	{		"ModelType": 3009,		"Name": "Yellow Parasol",		"Type": "Effect"	},	{		"ModelType": 3010,		"Name": "Blue Checkered Parasol",		"Type": "Effect"	},	{		"ModelType": 3011,		"Name": "Red Checkered Parasol",		"Type": "Effect"	},	{		"ModelType": 3012,		"Name": "Black and White Checkered Parasol",		"Type": "Effect"	},	{		"ModelType": 3014,		"Name": "Pile of Androids",		"Type": "Monster"	},	{		"ModelType": 3015,		"Name": "Android",		"Type": "Character"	},	{		"ModelType": 3017,		"Name": "Robo Tree Thing",		"Type": "Unknown"	},	{		"ModelType": 3018,		"Name": "Flight Unit with Android",		"Type": "Monster"	},	{		"ModelType": 3019,		"Name": "Construct X (used various places)",		"Type": "Monster"	},	{		"ModelType": 3020,		"Name": "Compound 2P (Black)",		"Type": "Monster"	},	{		"ModelType": 3021,		"Name": "Fatebreaker",		"Type": "Monster"	},	{		"ModelType": 3022,		"Name": "Cloud of Darkness (Eden)",		"Type": "Monster"	},	{		"ModelType": 3023,		"Name": "Shadowkeeper",		"Type": "Monster"	},	{		"ModelType": 3024,		"Name": "Gukumatz (Fatebreaker)",		"Type": "Monster"	},	{		"ModelType": 3025,		"Name": "Cerberus (Delibrum Reginae)",		"Type": "Monster"	},	{		"ModelType": 3026,		"Name": "White Orange Unicorn",		"Type": "Unknown"	},	{		"ModelType": 3027,		"Name": "Trinity Avowed",		"Type": "Monster"	},	{		"ModelType": 3028,		"Name": "Ironfrog Mover",		"Type": "Mount"	},	{		"ModelType": 3029,		"Name": "Sapphire Weapon",		"Type": "Monster"	},	{		"ModelType": 3030,		"Name": "Shiny Orb",		"Type": "Unknown"	},	{		"ModelType": 3031,		"Name": "Sultana Portrait",		"Type": "Unknown"	},	{		"ModelType": 3032,		"Name": "Much-coveted Mora",		"Type": "Minion"	},	{		"ModelType": 3033,		"Name": "Syldrion-class Insubmersible",		"Type": "Minion"	},	{		"ModelType": 3034,		"Name": "Wind-up Gaia",		"Type": "Minion"	},	{		"ModelType": 3035,		"Name": "Wind-up Palom",		"Type": "Minion"	},	{		"ModelType": 3037,		"Name": "Wind-up Edge",		"Type": "Minion"	},	{		"ModelType": 3038,		"Name": "Wind-up Rydia",		"Type": "Minion"	},	{		"ModelType": 3039,		"Name": "Wind-up Rosa",		"Type": "Minion"	},	{		"ModelType": 3040,		"Name": "Save the Princess",		"Type": "Minion"	},	{		"ModelType": 3041,		"Name": "Leshy",		"Type": "Monster"	},	{		"ModelType": 3042,		"Name": "Angel Wings",		"Type": "Effect"	},	{		"ModelType": 3043,		"Name": "Snowman (Mount)",		"Type": "Mount"	},	{		"ModelType": 3044,		"Name": "Lunar Whale (Mount)",		"Type": "Mount"	},	{		"ModelType": 3045,		"Name": "Eden (Mount)",		"Type": "Mount"	},	{		"ModelType": 3046,		"Name": "Cerberus (Mount)",		"Type": "Mount"	},	{		"ModelType": 3047,		"Name": "Big Shell",		"Type": "Mount"	},	{		"ModelType": 3048,		"Name": "Shadowkeeper (Standing)",		"Type": "Monster"	},	{		"ModelType": 3049,		"Name": "Emerald Weapon (Right Manipulator)",		"Type": "Monster"	},	{		"ModelType": 3050,		"Name": "Emerald Weapon (Left Manipulator)",		"Type": "Monster"	},	{		"ModelType": 3051,		"Name": "Trinity Seeker",		"Type": "Unknown"	},	{		"ModelType": 3052,		"Name": "Trinity Seeker (Swords)",		"Type": "Unknown"	},	{		"ModelType": 3053,		"Name": "Trinity Seeker (Katanas)",		"Type": "Monster"	},	{		"ModelType": 3054,		"Name": "Mother Porxie",		"Type": "Monster"	},	{		"ModelType": 3055,		"Name": "Queen's Warrior",		"Type": "Monster"	},	{		"ModelType": 3056,		"Name": "Diamond Weapon",		"Type": "Monster"	},	{		"ModelType": 3057,		"Name": "Oracle of Darkness",		"Type": "Monster"	},	{		"ModelType": 3058,		"Name": "Gogo, Master of Mimicry",		"Type": "Monster"	},	{		"ModelType": 3059,		"Name": "Beastly Sculpture",		"Type": "Monster"	},	{		"ModelType": 3060,		"Name": "Chiseled Sculpture",		"Type": "Monster"	},	{		"ModelType": 3061,		"Name": "Emerald Weapon (with Manipulators, gold)",		"Type": "Monster"	},	{		"ModelType": 3062,		"Name": "Magitek Mine (Emerald Weapon)",		"Type": "Monster"	},	{		"ModelType": 3063,		"Name": "Lunar Bahamut",		"Type": "Monster"	},	{		"ModelType": 3064,		"Name": "(Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3065,		"Name": "(Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3066,		"Name": "(Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3067,		"Name": "Sonny of Ziggy",		"Type": "Monster"	},	{		"ModelType": 3068,		"Name": "(Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3069,		"Name": "(Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3070,		"Name": "Emerald Weapon add (gold)",		"Type": "Monster"	},	{		"ModelType": 3071,		"Name": "Green Golem",		"Type": "Monster"	},	{		"ModelType": 3072,		"Name": "Gold Minotaur",		"Type": "Monster"	},	{		"ModelType": 3073,		"Name": "Grey Minotaur",		"Type": "Monster"	},	{		"ModelType": 3074,		"Name": "Mud Ball (Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3075,		"Name": "Mudman (Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3076,		"Name": "Hot & Cold Fire 1 Arrow",		"Type": "Unknown"	},	{		"ModelType": 3077,		"Name": "Hot & Cold Fire 2 Arrow",		"Type": "Unknown"	},	{		"ModelType": 3078,		"Name": "Hot & Cold Blizzard 1 Arrow",		"Type": "Unknown"	},	{		"ModelType": 3079,		"Name": "Hot & Cold Blizzard 2 Arrow",		"Type": "Effect"	},	{		"ModelType": 3080,		"Name": "Diamond Weapon (Armourless)",		"Type": "Monster"	},	{		"ModelType": 3081,		"Name": "Amhuluk",		"Type": "Monster"	},	{		"ModelType": 3082,		"Name": "Lunar Bahamut Nail",		"Type": "Effect"	},	{		"ModelType": 3084,		"Name": "Drone?",		"Type": "Unknown"	},	{		"ModelType": 3085,		"Name": "Queen's Soldier",		"Type": "Unknown"	},	{		"ModelType": 3086,		"Name": "Moogle",		"Type": "Unknown"	},	{		"ModelType": 3087,		"Name": "Cloud of Darknes (Eden, Clone)",		"Type": "Monster"	},	{		"ModelType": 3088,		"Name": "Queen's Knight",		"Type": "Monster"	},	{		"ModelType": 3089,		"Name": "Hot & Cold Fire 2",		"Type": "Effect"	},	{		"ModelType": 3090,		"Name": "Hot & Cold Blizzard 2",		"Type": "Effect"	},	{		"ModelType": 3091,		"Name": "(Delibrum Reginae)",		"Type": "Unknown"	},	{		"ModelType": 3092,		"Name": "(Delibrum Reginae)",		"Type": "Effect"	},	{		"ModelType": 3093,		"Name": "(Delibrum Reginae)",		"Type": "Effect"	},	{		"ModelType": 3094,		"Name": "Shadowkeeper Shadow",		"Type": "Effect"	},	{		"ModelType": 3095,		"Name": "Thunder Ring (Turn of the Heavens)",		"Type": "Effect"	},	{		"ModelType": 3096,		"Name": "Thunder Ring (Turn of the Heavens)",		"Type": "Effect"	},	{		"ModelType": 3097,		"Name": "Fire Mirror (Sundered Sky)",		"Type": "Effect"	},	{		"ModelType": 3098,		"Name": "Thunder Mirror (Sundered Sky)",		"Type": "Effect"	},	{		"ModelType": 3100,		"Name": "Emerald Gwiber",		"Type": "Mount"	},	{		"ModelType": 3101,		"Name": "Prototype Roader",		"Type": "Mount"	},	{		"ModelType": 3102,		"Name": "Chocorpokur",		"Type": "Mount"	},	{		"ModelType": 3103,		"Name": "Gabriel Mark III (Mount)",		"Type": "Mount"	},	{		"ModelType": 3104,		"Name": "Antelope Doe (Mount)",		"Type": "Mount"	},	{		"ModelType": 3105,		"Name": "Antelope Stag (Mount)",		"Type": "Mount"	},	{		"ModelType": 3106,		"Name": "Drippy",		"Type": "Minion"	},	{		"ModelType": 3107,		"Name": "Trike",		"Type": "Minion"	},	{		"ModelType": 3108,		"Name": "Gull",		"Type": "Minion"	},	{		"ModelType": 3109,		"Name": "Anteater",		"Type": "Minion"	},	{		"ModelType": 3110,		"Name": "Dolphin Calf",		"Type": "Minion"	},	{		"ModelType": 3111,		"Name": "Magitek Predator F1",		"Type": "Minion"	},	{		"ModelType": 3112,		"Name": "Emerald Weapon (with Manipulators, green, open)",		"Type": "Monster"	},	{		"ModelType": 3113,		"Name": "Emerald Weapon (Right Manipulator, gold, sword)",		"Type": "Monster"	},	{		"ModelType": 3114,		"Name": "Emerald Weapon (Right Manipulator, gold, sword)",		"Type": "Monster"	},	{		"ModelType": 3115,		"Name": "Landerwaffe",		"Type": "Mount"	},	{		"ModelType": 3116,		"Name": "Emerald Weapon Right Claw",		"Type": "Monster"	},	{		"ModelType": 3117,		"Name": "Emerald Weapon Left Claw",		"Type": "Monster"	},	{		"ModelType": 3118,		"Name": "Shadowkeeper (shadow clone)",		"Type": "Effect"	},	{		"ModelType": 3119,		"Name": "Shadowkeeper (standing shadow clone)",		"Type": "Effect"	},	{		"ModelType": 3121,		"Name": "Her Inflorescence",		"Type": "Monster"	},	{		"ModelType": 3125,		"Name": "Lunar Ifrit",		"Type": "Monster"	},	{		"ModelType": 3126,		"Name": "Umbral Orb (Trio)",		"Type": "Effect"	},	{		"ModelType": 3127,		"Name": "False Idol",		"Type": "Monster"	},	{		"ModelType": 3130,		"Name": "Gretel",		"Type": "Monster"	},	{		"ModelType": 3131,		"Name": "Hansel",		"Type": "Monster"	},	{		"ModelType": 3148,		"Name": "Merlwyb",		"Type": "Character"	},	{		"ModelType": 3149,		"Name": "Umbral Orb (Solo)",		"Type": "Effect"	},	{		"ModelType": 3150,		"Name": "Eden's Promise",		"Type": "Monster"	},	{		"ModelType": 3151,		"Name": "Eden's Promise",		"Type": "Mount"	},	{		"ModelType": 3152,		"Name": "Senorita Sabotender",		"Type": "Minion"	},	{		"ModelType": 3153,		"Name": "Benben Stone",		"Type": "Minion"	},	{		"ModelType": 3154,		"Name": "Wanderer's Campfire",		"Type": "Minion"	},	{		"ModelType": 3155,		"Name": "Smaller Stubby",		"Type": "Minion"	},	{		"ModelType": 3156,		"Name": "Golden Beaver",		"Type": "Minion"	},	{		"ModelType": 3157,		"Name": "Ascian Prime (Mitron/Loghrif)",		"Type": "Monster"	},	{		"ModelType": 3158,		"Name": "Sephirot-Egi (no leaves)",		"Type": "Monster"	},	{		"ModelType": 3159,		"Name": "Emerald Weapon (green, closed)",		"Type": "Monster"	},	{		"ModelType": 3166,		"Name": "Pleasant Dot Parasol",		"Type": "Effect"	},	{		"ModelType": 3167,		"Name": "Prim Dot Parasol",		"Type": "Effect"	},	{		"ModelType": 3168,		"Name": "Pastoral Dot Parasol",		"Type": "Effect"	},	{		"ModelType": 3169,		"Name": "Gold Parasaucer",		"Type": "Effect"	},	{		"ModelType": 3170,		"Name": "Conflagration Strike",		"Type": "Effect"	},	{		"ModelType": 3172,		"Name": "Cruise Chaser (Mount)",		"Type": "Mount"	},	{		"ModelType": 3174,		"Name": "Eden's Promise",		"Type": "Monster"	},	{		"ModelType": 3175,		"Name": "Construct VI-S Core",		"Type": "Mount"	},	{		"ModelType": 3176,		"Name": "Red Frog (Matoya's Relict)",		"Type": "Monster"	},	{		"ModelType": 3177,		"Name": "Rook Autoturret (Delibrum Reginae)",		"Type": "Monster"	},	{		"ModelType": 3178,		"Name": "Bishop Autoturret (Delibrum Reginae)",		"Type": "Monster"	},	{		"ModelType": 3179,		"Name": "Red Girl",		"Type": "Monster"	},	{		"ModelType": 3179,		"Name": "Red Girl (Creepy)",		"Type": "Monster"	},	{		"ModelType": 3180,		"Name": "Red Girl (Giant)",		"Type": "Monster"	},	{		"ModelType": 3181,		"Name": "Xun-Zi / Meng-Zi",		"Type": "Monster"	},	{		"ModelType": 3186,		"Name": "White Pylon",		"Type": "Monster"	},	{		"ModelType": 3187,		"Name": "Black Pylon",		"Type": "Monster"	},	{		"ModelType": 3188,		"Name": "Red Sphere",		"Type": "Effect"	},	{		"ModelType": 3189,		"Name": "White Hacking Droid",		"Type": "Monster"	},	{		"ModelType": 3190,		"Name": "Black Hacking Droid",		"Type": "Monster"	},	{		"ModelType": 3192,		"Name": "Magitek Core (Paglth'an)",		"Type": "Monster"	},	{		"ModelType": 3203,		"Name": "Tiamat + Estinien",		"Type": "Monster"	},	{		"ModelType": 3204,		"Name": "Spheroid (The Tower at Paradigm's Breach)",		"Type": "Monster"	},	{		"ModelType": 3214,		"Name": "Wind-up Lyna",		"Type": "Minion"	},	{		"ModelType": 3215,		"Name": "Wind-up Runar",		"Type": "Minion"	},	{		"ModelType": 3217,		"Name": "9S Automaton",		"Type": "Minion"	},	{		"ModelType": 3235,		"Name": "Diamond Gwiber",		"Type": "Mount"	},	{		"ModelType": 3236,		"Name": "Polar Bear",		"Type": "Mount"	},	{		"ModelType": 3237,		"Name": "Gilded Mikoshi",		"Type": "Mount"	},	{		"ModelType": 3238,		"Name": "Resplendent Vessel Of Ronka",		"Type": "Mount"	},	{		"ModelType": 3242,		"Name": "Directional Orb (The Tower at Paradigm's Breach)",		"Type": "Effect"	},	{		"ModelType": 3243,		"Name": "White Lance (Red Girl)",		"Type": "Effect"	},	{		"ModelType": 3244,		"Name": "Black Lance (Red Girl)",		"Type": "Effect"	},	{		"ModelType": 3245,		"Name": "Latitudinal Marker (The Tower at Paradigm's Breach)",		"Type": "Effect"	},	{		"ModelType": 3246,		"Name": "Longitudinal Marker (The Tower at Paradigm's Breach)",		"Type": "Effect"	},	{		"ModelType": 3248,		"Name": "Energy Orb (The Tower at Paradigm's Breach)",		"Type": "Effect"	},	{		"ModelType": 3256,		"Name": "Floating Right Hand (Diamond Weapon)",		"Type": "Effect"	},	{		"ModelType": 3257,		"Name": "Floating Left Hand (Diamond Weapon)",		"Type": "Effect"	},	{		"ModelType": 3262,		"Name": "Diamond Weapon",		"Type": "Monster"	},	{		"ModelType": 3286,		"Name": "Fat Cat Parasol",		"Type": "Effect"	},	{		"ModelType": 3287,		"Name": "Great Paraserpent",		"Type": "Effect"	},	{		"ModelType": 3288,		"Name": "Parasol (Meteor)",		"Type": "Effect"	},	{		"ModelType": 3292,		"Name": "Electric orb (Paglth'an, Amhuluk fight)",		"Type": "Effect"	},	{		"ModelType": 3295,		"Name": "Hatchingtide 2021 Chicken",		"Type": "Monster"	},	{		"ModelType": 3316,		"Name": "Dolphin Calf",		"Type": "Minion"	},	{		"ModelType": 3326,		"Name": "Gull",		"Type": "Minion"	}]
+﻿[
+	{
+		"ModelType": 0,
+		"Name": "Player",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1,
+		"Name": "Chocobo",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2,
+		"Name": "Magitek Reaper",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3,
+		"Name": "Amalj'aa",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 4,
+		"Name": "Ixal",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 5,
+		"Name": "Kobold",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 6,
+		"Name": "Goblin",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 7,
+		"Name": "Sylph",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 8,
+		"Name": "Moogle",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 9,
+		"Name": "Sahagin",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 10,
+		"Name": "Mamool Ja Warrior",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 11,
+		"Name": "Hecatonchier",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 12,
+		"Name": "Giant",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 13,
+		"Name": "Gigas",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 14,
+		"Name": "Qiqirn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 15,
+		"Name": "Delivery Moogle",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 16,
+		"Name": "Lamia",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 17,
+		"Name": "Skeleton",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 18,
+		"Name": "Succubus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 18,
+		"Name": "Halicarnassus",
+		"Type": "Monster",
+		"Body": 2
+	},
+	{
+		"ModelType": 19,
+		"Name": "Demon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 20,
+		"Name": "Miteling",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 21,
+		"Name": "Diremite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 22,
+		"Name": "Banemite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 23,
+		"Name": "Graffias",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 24,
+		"Name": "Rat",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 25,
+		"Name": "Squirrel",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 26,
+		"Name": "Marmot",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 27,
+		"Name": "Dormouse",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 28,
+		"Name": "Funguar",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 29,
+		"Name": "Myconid",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 30,
+		"Name": "Funguar (Blue)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 31,
+		"Name": "Galago",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 32,
+		"Name": "Lemur",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 33,
+		"Name": "Galago (collared)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 34,
+		"Name": "Ochu",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 35,
+		"Name": "Microchu",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 36,
+		"Name": "Chigoe",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 37,
+		"Name": "Djigga",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 38,
+		"Name": "Flea",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 39,
+		"Name": "Buzzard",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 40,
+		"Name": "Condor",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 41,
+		"Name": "Bateleur",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 42,
+		"Name": "Kite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 43,
+		"Name": "Falcon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 44,
+		"Name": "Hog",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 45,
+		"Name": "Boar",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 46,
+		"Name": "Hog (lighter)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 47,
+		"Name": "Kamapuaa",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 48,
+		"Name": "Roseling",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 49,
+		"Name": "Flytrap",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 50,
+		"Name": "Slug",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 51,
+		"Name": "Sea Hare",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 52,
+		"Name": "Dark Matter Slug",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 53,
+		"Name": "Gnat",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 54,
+		"Name": "Ked",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 55,
+		"Name": "Magitek Bit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 56,
+		"Name": "Weevil",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 57,
+		"Name": "Ladybug",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 58,
+		"Name": "Midge Swarm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 59,
+		"Name": "Syrphid Swarm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 60,
+		"Name": "Bee Swarm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 61,
+		"Name": "Antelope Doe",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 62,
+		"Name": "Antelope Stag",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 63,
+		"Name": "Imp",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 64,
+		"Name": "Devilet",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 65,
+		"Name": "Coeurl",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 66,
+		"Name": "Torama",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 67,
+		"Name": "Panther",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 68,
+		"Name": "Dark Matter Coeurl",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 69,
+		"Name": "Coeurl Pup",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 70,
+		"Name": "Coeurl",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 71,
+		"Name": "Mindflayer",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 72,
+		"Name": "Psycheflayer",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 73,
+		"Name": "Mindflayer (The Hunt)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 74,
+		"Name": "Piscodemon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 75,
+		"Name": "Sand Yarzon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 76,
+		"Name": "Bog Yarzon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 78,
+		"Name": "Firefly",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 79,
+		"Name": "Wisp",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 80,
+		"Name": "Plasmoid",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 81,
+		"Name": "Mudestone Golem",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 82,
+		"Name": "Chert Golem",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 83,
+		"Name": "Temple Guardian",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 84,
+		"Name": "Mudestone Golem (spike)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 85,
+		"Name": "Chert Golem (spike)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 86,
+		"Name": "Temple Guardian (spike)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 87,
+		"Name": "Dark Matter Golem",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 88,
+		"Name": "Spriggolem",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 89,
+		"Name": "Tonberry",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 90,
+		"Name": "Tonberry (darker)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 91,
+		"Name": "Tonberry King",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 92,
+		"Name": "Tonberry Scholar",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 93,
+		"Name": "Tonberry Black Mage",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 94,
+		"Name": "Tortoise",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 95,
+		"Name": "Adamantoise",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 96,
+		"Name": "Raptor",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 97,
+		"Name": "Anole",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 98,
+		"Name": "Bat",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 99,
+		"Name": "Kalong",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 100,
+		"Name": "Bomb",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 101,
+		"Name": "Grenade",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 102,
+		"Name": "Shrapnel",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 103,
+		"Name": "Bomb (flaming)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 104,
+		"Name": "Treant",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 105,
+		"Name": "Treant (Greenwrath)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 106,
+		"Name": "Dryad",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 107,
+		"Name": "Spriggan (Yellow-eyed/Lightning Rock)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 108,
+		"Name": "Spriggan (Yellow-eyed/Earth Rock)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 109,
+		"Name": "Spriggan (Yellow-eyed/Mythril Ore)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 110,
+		"Name": "Spriggan (Yellow-eyed/Copper Ore)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 111,
+		"Name": "Spriggan (Red-eyed/Lightning Rock)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 112,
+		"Name": "Spriggan (Red-eyed/Earth Rock)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 113,
+		"Name": "Spriggan (Red-eyed/Mythril Ore)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 114,
+		"Name": "Spriggan (Red-eyed/Copper Ore)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 115,
+		"Name": "Spriggan (Yellow-eyed/Pristine Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 116,
+		"Name": "Spriggan (Yellow-eyed/Chocobo Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 117,
+		"Name": "Spriggan (Yellow-eyed/Midnight Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 118,
+		"Name": "Spriggan (Yellow-eyed/Brilliant Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 119,
+		"Name": "Spriggan (Yellow-eyed/Vibrant Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 120,
+		"Name": "Spriggan (Yellow-eyed/Motley Egg)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 121,
+		"Name": "Dullahan (clean)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 122,
+		"Name": "Dullahan (shiny)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 123,
+		"Name": "Dullahan (rusty)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 124,
+		"Name": "Face of the Hero",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 125,
+		"Name": "Dullahan (clean)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 126,
+		"Name": "Gigantoad",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 127,
+		"Name": "Nix",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 128,
+		"Name": "Poison Nix",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 129,
+		"Name": "Gigantoad (green)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 130,
+		"Name": "Puk",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 131,
+		"Name": "Pteroc",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 132,
+		"Name": "Puk (yellow)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 133,
+		"Name": "Hippocerf",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 134,
+		"Name": "Hippogryph",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 135,
+		"Name": "Basilisk",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 136,
+		"Name": "Peiste",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 137,
+		"Name": "Wadjet",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 138,
+		"Name": "Buffalo",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 139,
+		"Name": "Aurochs",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 140,
+		"Name": "Wisent",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 141,
+		"Name": "Cactuar",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 142,
+		"Name": "Sabotender",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 143,
+		"Name": "Flowertender",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 144,
+		"Name": "Cactuar (yellow)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 145,
+		"Name": "Morbol",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 146,
+		"Name": "Great Morbol",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 147,
+		"Name": "Miser's Mistress",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 148,
+		"Name": "Clipper",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 149,
+		"Name": "Snipper",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 150,
+		"Name": "Nahn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 151,
+		"Name": "Salamander",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 152,
+		"Name": "Eft",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 153,
+		"Name": "Eft (orange)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 154,
+		"Name": "Blueback",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 155,
+		"Name": "Sableback",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 156,
+		"Name": "Violetback",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 157,
+		"Name": "Yellowback",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 158,
+		"Name": "Dark Matter Pelican",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 159,
+		"Name": "Wolf",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 160,
+		"Name": "Jackal",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 161,
+		"Name": "White Wolf",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 162,
+		"Name": "Tao Quan",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 163,
+		"Name": "Watchwolf",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 164,
+		"Name": "Scurvy Dog",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 165,
+		"Name": "Behemoth",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 166,
+		"Name": "Kaiser Behemoth",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 167,
+		"Name": "Floating Eye",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 168,
+		"Name": "Ahriman",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 169,
+		"Name": "Arimaspi",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 170,
+		"Name": "Ahriman (red)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 171,
+		"Name": "Dirty Eye",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 172,
+		"Name": "Ahriman",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 173,
+		"Name": "Dodo",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 174,
+		"Name": "Cockatrice",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 175,
+		"Name": "Cockatrice (Blue)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 176,
+		"Name": "Coblyn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 177,
+		"Name": "Doblyn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 178,
+		"Name": "Crystal Coblyn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 179,
+		"Name": "Drake",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 180,
+		"Name": "Biast",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 181,
+		"Name": "Battle Drake",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 182,
+		"Name": "Elbst",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 183,
+		"Name": "Aldgoat Billy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 184,
+		"Name": "Aldgoat Nanny",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 185,
+		"Name": "Mosshorn",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 186,
+		"Name": "Magitek Juggernaut",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 187,
+		"Name": "Ogre",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 188,
+		"Name": "Hapalit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 189,
+		"Name": "Hrimthurs",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 190,
+		"Name": "Apkallu",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 192,
+		"Name": "Antling Soldier",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 193,
+		"Name": "Antling Princess",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 194,
+		"Name": "Antling Worker",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 195,
+		"Name": "Antling Marshal",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 196,
+		"Name": "Antling Queen",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 197,
+		"Name": "Chimera",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 198,
+		"Name": "Goobbue",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 199,
+		"Name": "Highland Goobbue",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 200,
+		"Name": "Goobbue",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 201,
+		"Name": "Marshmallow (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 202,
+		"Name": "Gelato (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 203,
+		"Name": "Flan (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 204,
+		"Name": "Custard (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 205,
+		"Name": "Pudding (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 206,
+		"Name": "Bavarois (White-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 207,
+		"Name": "Marshmallow (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 208,
+		"Name": "Gelato (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 209,
+		"Name": "Flan (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 210,
+		"Name": "Custard (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 211,
+		"Name": "Pudding (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 212,
+		"Name": "Bavarois (Black-eyed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 213,
+		"Name": "Magitek Vanguard",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 214,
+		"Name": "Magitek Vanguard H",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 215,
+		"Name": "Magitek Vanguard F",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 216,
+		"Name": "Lesser Gargoyle",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 217,
+		"Name": "Greater Gargoyle",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 218,
+		"Name": "Batraal",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 219,
+		"Name": "Cyclops",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 220,
+		"Name": "Elder Cyclops",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 221,
+		"Name": "Mammet (Red Helmet)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 222,
+		"Name": "Mammet (Blue Helmet)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 223,
+		"Name": "Mammet (Black Helmet)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 224,
+		"Name": "Wyvern",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 225,
+		"Name": "Aery Wyvern",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 226,
+		"Name": "Twintania",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 227,
+		"Name": "Atomos",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 228,
+		"Name": "Shadow Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 229,
+		"Name": "Thunder Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 230,
+		"Name": "Moss Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 231,
+		"Name": "Ice Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 232,
+		"Name": "Zombie Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 233,
+		"Name": "Deathgaze",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 234,
+		"Name": "Blue Cobra",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 235,
+		"Name": "Red Cobra",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 236,
+		"Name": "Coeurlregina",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 237,
+		"Name": "Rock Gaol",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 238,
+		"Name": "Sandworm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 239,
+		"Name": "Brineworm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 240,
+		"Name": "Giant Tunnel Worm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 241,
+		"Name": "Abyss Worm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 242,
+		"Name": "Gigaworm",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 243,
+		"Name": "Siren",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 244,
+		"Name": "Five-Headed Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 245,
+		"Name": "Hydra",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 246,
+		"Name": "Three-Headed (blue)"
+	},
+	{
+		"ModelType": 247,
+		"Name": "Three-Headed (yellow)"
+	},
+	{
+		"ModelType": 248,
+		"Name": "Fenrir",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 249,
+		"Name": "Granite Gaol",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 250,
+		"Name": "Phlegethon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 251,
+		"Name": "Amon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 252,
+		"Name": "Cait Sith",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 253,
+		"Name": "Magitek Colossus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 254,
+		"Name": "Rubricatus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 255,
+		"Name": "Mark II Magitek Colossus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 256,
+		"Name": "Demon Wall",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 257,
+		"Name": "Demon Wall (copy)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 258,
+		"Name": "Demon Wall (copy)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 259,
+		"Name": "Demon Wall (copy)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 260,
+		"Name": "Demon Wall (copy)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 261,
+		"Name": "Typhon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 262,
+		"Name": "Typhon [Investigate]",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 263,
+		"Name": "Magic Pot",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 264,
+		"Name": "Bogy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 265,
+		"Name": "Revenant",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 266,
+		"Name": "Phurble",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 267,
+		"Name": "Snurble",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 268,
+		"Name": "Angler",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 269,
+		"Name": "Remora",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 270,
+		"Name": "Orobon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 271,
+		"Name": "Fire Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 272,
+		"Name": "Lightning Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 273,
+		"Name": "Water Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 274,
+		"Name": "Elemental (brown)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 275,
+		"Name": "Elemental (red)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 276,
+		"Name": "Ice Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 277,
+		"Name": "Wind Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 278,
+		"Name": "Earth Elemental",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 279,
+		"Name": "Aurelia",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 280,
+		"Name": "Sea Wasp",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 281,
+		"Name": "Dark Matter Aurelia",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 282,
+		"Name": "Mole",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 283,
+		"Name": "Hedgemole",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 284,
+		"Name": "Ram (bell)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 285,
+		"Name": "Ram",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 286,
+		"Name": "Ewe (bell)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 287,
+		"Name": "Ewe",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 288,
+		"Name": "Karakul Ram (bell)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 289,
+		"Name": "Karakul Ram",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 290,
+		"Name": "Karakul Ewe (bell)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 291,
+		"Name": "Karakul Ewe",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 292,
+		"Name": "Slime",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 293,
+		"Name": "Slime (yellow)"
+	},
+	{
+		"ModelType": 294,
+		"Name": "Slime (purple)"
+	},
+	{
+		"ModelType": 295,
+		"Name": "Rheum",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 296,
+		"Name": "Dark Matter Slime",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 297,
+		"Name": "Mandragora",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 298,
+		"Name": "Infernal Nail",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 299,
+		"Name": "Field Generator A",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 300,
+		"Name": "Field Generator B",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 301,
+		"Name": "Monolith",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 302,
+		"Name": "Garuda's Plume",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 303,
+		"Name": "Garuda",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 304,
+		"Name": "Ifrit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 305,
+		"Name": "Leviathan",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 306,
+		"Name": "Titan",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 307,
+		"Name": "Ultima Weapon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 308,
+		"Name": "Ultima Weapon (no wings)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 309,
+		"Name": "Ultima Weapon (copy)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 310,
+		"Name": "Ultima Weapon (no wings/copy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 311,
+		"Name": "Sleipnir",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 312,
+		"Name": "Shiva (weapons)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 313,
+		"Name": "Vishap",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 314,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 315,
+		"Name": "Shadowlurker",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 316,
+		"Name": "ADS (Black/Red)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 317,
+		"Name": "ADS (Black/White)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 318,
+		"Name": "ADS (Black/Purple)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 319,
+		"Name": "ADS (Black/Blue)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 320,
+		"Name": "ADS (Black/Teal)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 321,
+		"Name": "ADS (Black/Green)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 322,
+		"Name": "ADS (Black/Yellow)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 323,
+		"Name": "ADS (Black/Orange)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 324,
+		"Name": "Proto Ultima Arm Unit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 325,
+		"Name": "BUGGED - DO NOT CLICK",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 326,
+		"Name": "Exdeath",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 327,
+		"Name": "Omega",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 328,
+		"Name": "Morbol Seedling",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 329,
+		"Name": "Kraken",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 330,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 331,
+		"Name": "Magitek Death Claw",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 332,
+		"Name": "Allagan Death Claw",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 333,
+		"Name": "Diabolos",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 334,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 335,
+		"Name": "Bahamut",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 336,
+		"Name": "Bahamut (blue)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 337,
+		"Name": "Phoenix",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 338,
+		"Name": "Nidhogg (Hraesvelgr's left eye)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 339,
+		"Name": "Hraesvelgr",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 340,
+		"Name": "Beta Zaghnal",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 341,
+		"Name": "FFXIII Behemoth (white)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 342,
+		"Name": "FFXIII Behemoth (red)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 343,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 344,
+		"Name": "Temple Mummy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 345,
+		"Name": "Ramuh",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 346,
+		"Name": "Diabolos (Sc�thach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 347,
+		"Name": "Glasya Labolas",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 348,
+		"Name": "Scylla",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 349,
+		"Name": "Xande",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 350,
+		"Name": "Cerberus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 351,
+		"Name": "Angra�Mainyu",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 352,
+		"Name": "Cloud of Darkness",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 353,
+		"Name": "Gilgamesh (six weapons)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 354,
+		"Name": "Ultros",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 355,
+		"Name": "Stoneshell",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 356,
+		"Name": "Pugil",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 357,
+		"Name": "Dark Matter Pugil",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 358,
+		"Name": "Bulb",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 359,
+		"Name": "Hornet",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 360,
+		"Name": "Colibri",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 361,
+		"Name": "Clockwork Dreadnaught",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 362,
+		"Name": "Dragonfly",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 363,
+		"Name": "Vodoriga",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 364,
+		"Name": "Uragnite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 365,
+		"Name": "Taurus",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 366,
+		"Name": "Adjudicator",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 367,
+		"Name": "Qarn Face",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 368,
+		"Name": "Qarn Face (copy)"
+	},
+	{
+		"ModelType": 369,
+		"Name": "Qarn Face (copy)"
+	},
+	{
+		"ModelType": 370,
+		"Name": "Qarn Face (copy)"
+	},
+	{
+		"ModelType": 371,
+		"Name": "Shield Dragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 372,
+		"Name": "Baritine Croc",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 373,
+		"Name": "Feral Croc",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 374,
+		"Name": "Killer Mantis",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 375,
+		"Name": "Dark Matter Mantis",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 376,
+		"Name": "Preying Mantis",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 377,
+		"Name": "Aevis",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 378,
+		"Name": "Mirrorknight",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 379,
+		"Name": "Dreadknight",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 380,
+		"Name": "Rook",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 381,
+		"Name": "Fire Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 382,
+		"Name": "Ice Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 383,
+		"Name": "Wind Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 384,
+		"Name": "Lightning Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 385,
+		"Name": "Water Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 386,
+		"Name": "Earth Sprite",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 387,
+		"Name": "Clockwork Soldier",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 388,
+		"Name": "Clockwork Knight",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 389,
+		"Name": "Orb (Lightning / White Center)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 390,
+		"Name": "Orb (Blue / Guildhest Water Bubble?)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 391,
+		"Name": "Orb (Purple / Guildhest Water Bubble?)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 392,
+		"Name": "Bubble (ground)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 393,
+		"Name": "Maelstrom Cannon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 394,
+		"Name": "Adder Cannon [Investigate]",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 395,
+		"Name": "Flame Cannon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 396,
+		"Name": "Gremlin",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 397,
+		"Name": "Gremlin (red)"
+	},
+	{
+		"ModelType": 398,
+		"Name": "Gremlin (green)"
+	},
+	{
+		"ModelType": 399,
+		"Name": "Gremlin (yellow)"
+	},
+	{
+		"ModelType": 400,
+		"Name": "FFXIII Bahamut",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 401,
+		"Name": "Anubys"
+	},
+	{
+		"ModelType": 402,
+		"Name": "Fallen Neurolink"
+	},
+	{
+		"ModelType": 403,
+		"Name": "Flying Ice Dragon"
+	},
+	{
+		"ModelType": 404,
+		"Name": "Missile Carrier Claw (Castrum)"
+	},
+	{
+		"ModelType": 405,
+		"Name": "Missile Launcher (Castrum)"
+	},
+	{
+		"ModelType": 406,
+		"Name": "FFXI Shantotto"
+	},
+	{
+		"ModelType": 407,
+		"Name": "Eos"
+	},
+	{
+		"ModelType": 408,
+		"Name": "Selene"
+	},
+	{
+		"ModelType": 409,
+		"Name": "Emerald Carbuncle"
+	},
+	{
+		"ModelType": 410,
+		"Name": "Ruby Carbuncle"
+	},
+	{
+		"ModelType": 411,
+		"Name": "Sapphire Carbuncle"
+	},
+	{
+		"ModelType": 412,
+		"Name": "Topaz Carbuncle"
+	},
+	{
+		"ModelType": 413,
+		"Name": "Diamond Carbuncle"
+	},
+	{
+		"ModelType": 414,
+		"Name": "Obsidian Carbuncle"
+	},
+	{
+		"ModelType": 415,
+		"Name": "Ifrit-Egi"
+	},
+	{
+		"ModelType": 416,
+		"Name": "Titan-Egi"
+	},
+	{
+		"ModelType": 417,
+		"Name": "Garuda-Egi"
+	},
+	{
+		"ModelType": 418,
+		"Name": "Ramuh-Egi"
+	},
+	{
+		"ModelType": 419,
+		"Name": "Mammet 001",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 420,
+		"Name": "Mammet 003L",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 421,
+		"Name": "Mammet 003G",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 422,
+		"Name": "Mammet 003U",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 423,
+		"Name": "Wayward Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 424,
+		"Name": "Storm Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 425,
+		"Name": "Serpent Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 426,
+		"Name": "Flame Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 427,
+		"Name": "Cherry Bomb",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 428,
+		"Name": "Baby Behemoth",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 429,
+		"Name": "Morbol Seedling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 430,
+		"Name": "Cait Sith Doll",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 431,
+		"Name": "Tiny Rat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 432,
+		"Name": "Baby Bun",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 433,
+		"Name": "Chigoe Larva",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 434,
+		"Name": "Bluebird",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 435,
+		"Name": "Wide-eyed Fawn",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 436,
+		"Name": "Infant Imp",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 437,
+		"Name": "Coeurl Kitten",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 438,
+		"Name": "Black Coeurl",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 440,
+		"Name": "Gravel Golem",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 441,
+		"Name": "Wind-Up Tonberry",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 442,
+		"Name": "Tiny Tortoise",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 443,
+		"Name": "Baby Raptor",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 444,
+		"Name": "Baby Bat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 445,
+		"Name": "Tiny Bulb",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 446,
+		"Name": "Dust Bunny",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 447,
+		"Name": "Wind-Up Dullahan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 448,
+		"Name": "Gigantpole",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 449,
+		"Name": "Pudgy Puk",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 450,
+		"Name": "Buffalo Calf",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 451,
+		"Name": "Cactuar Cutting",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 452,
+		"Name": "Smallshell",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 453,
+		"Name": "Wolf Pup",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 454,
+		"Name": "Beady Eye",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 455,
+		"Name": "Fledgling Dodo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 456,
+		"Name": "Coblyn Larva",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 457,
+		"Name": "Wind-Up Aldgoat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 458,
+		"Name": "Fledgling Apkallu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 459,
+		"Name": "Goobbue Sproutling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 460,
+		"Name": "Bite-sized Pudding",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 461,
+		"Name": "Model Vanguard",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 462,
+		"Name": "Demon Brick",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 463,
+		"Name": "Mini Mole",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 464,
+		"Name": "Tender Lamb",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 465,
+		"Name": "Slime Puddle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 466,
+		"Name": "Kidragora",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 467,
+		"Name": "Wind-Up Goblin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 468,
+		"Name": "Wind-Up Sylph",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 469,
+		"Name": "Wind-Up Cursor",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 470,
+		"Name": "Wind-Up Airship",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 471,
+		"Name": "Wind-Up Qiqirn",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 472,
+		"Name": "Wind-Up Dalamud",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 474,
+		"Name": "Chocobo Carriage"
+	},
+	{
+		"ModelType": 477,
+		"Name": "Gaius van Baelsar - X Slash"
+	},
+	{
+		"ModelType": 478,
+		"Name": "Tornado"
+	},
+	{
+		"ModelType": 485,
+		"Name": "Spider egg covered by plant"
+	},
+	{
+		"ModelType": 486,
+		"Name": "Spider egg covered by plant - different model"
+	},
+	{
+		"ModelType": 487,
+		"Name": "Weird plant"
+	},
+	{
+		"ModelType": 488,
+		"Name": "Brown Crate"
+	},
+	{
+		"ModelType": 489,
+		"Name": "Sandbag"
+	},
+	{
+		"ModelType": 490,
+		"Name": "Barrel with 3 wine bottles"
+	},
+	{
+		"ModelType": 491,
+		"Name": "Giant bird's nest"
+	},
+	{
+		"ModelType": 492,
+		"Name": "Box crate"
+	},
+	{
+		"ModelType": 493,
+		"Name": "Brown chest"
+	},
+	{
+		"ModelType": 494,
+		"Name": "Brown Drawer"
+	},
+	{
+		"ModelType": 495,
+		"Name": "Brown shipping crate with rope on it"
+	},
+	{
+		"ModelType": 496,
+		"Name": "Metal container"
+	},
+	{
+		"ModelType": 497,
+		"Name": "Jar with tied fabric lid"
+	},
+	{
+		"ModelType": 498,
+		"Name": "Campfire"
+	},
+	{
+		"ModelType": 503,
+		"Name": "Fancy pillar"
+	},
+	{
+		"ModelType": 505,
+		"Name": "Black Chocobo Chick",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 506,
+		"Name": "Tonberry Scholar (+ Darkness Effect)"
+	},
+	{
+		"ModelType": 507,
+		"Name": "Batraal (b) (Copy)"
+	},
+	{
+		"ModelType": 508,
+		"Name": "Clockwork Bug"
+	},
+	{
+		"ModelType": 509,
+		"Name": "Dark Matter Pteroc"
+	},
+	{
+		"ModelType": 511,
+		"Name": "Orb (Red / Lightning)"
+	},
+	{
+		"ModelType": 512,
+		"Name": "Orb (Twintania's Hatch)"
+	},
+	{
+		"ModelType": 513,
+		"Name": "Orb (Green / Bright Lightning)"
+	},
+	{
+		"ModelType": 514,
+		"Name": "Orb (Watery / Music Symbol)"
+	},
+	{
+		"ModelType": 515,
+		"Name": "Floor Circle (Twintania's Conflagration)"
+	},
+	{
+		"ModelType": 516,
+		"Name": "Floor Circle (Ice)"
+	},
+	{
+		"ModelType": 517,
+		"Name": "Floor Circle (Twintania's Liquid Hell)"
+	},
+	{
+		"ModelType": 518,
+		"Name": "Bertha Cannon"
+	},
+	{
+		"ModelType": 519,
+		"Name": "FFXIII Odin"
+	},
+	{
+		"ModelType": 520,
+		"Name": "Lightning (FFXIII Character)"
+	},
+	{
+		"ModelType": 521,
+		"Name": "Mythril Verge"
+	},
+	{
+		"ModelType": 523,
+		"Name": "Dreadknight Bind"
+	},
+	{
+		"ModelType": 524,
+		"Name": "Barrel of Cannonballs"
+	},
+	{
+		"ModelType": 525,
+		"Name": "Small Device"
+	},
+	{
+		"ModelType": 527,
+		"Name": "Wind-Up Shantotto",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 528,
+		"Name": "Box with Maps"
+	},
+	{
+		"ModelType": 529,
+		"Name": "Box"
+	},
+	{
+		"ModelType": 530,
+		"Name": "Crate"
+	},
+	{
+		"ModelType": 531,
+		"Name": "Standard w/ Torch"
+	},
+	{
+		"ModelType": 532,
+		"Name": "Book Glow (Green) (?)"
+	},
+	{
+		"ModelType": 533,
+		"Name": "Bomb Decoration (?)"
+	},
+	{
+		"ModelType": 534,
+		"Name": "Unicorn",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 535,
+		"Name": "Small Void Gate"
+	},
+	{
+		"ModelType": 536,
+		"Name": "Large Void Gate"
+	},
+	{
+		"ModelType": 537,
+		"Name": "Belias-Egi"
+	},
+	{
+		"ModelType": 538,
+		"Name": "Gungnir"
+	},
+	{
+		"ModelType": 539,
+		"Name": "Black Circle"
+	},
+	{
+		"ModelType": 540,
+		"Name": "Glowing Circle"
+	},
+	{
+		"ModelType": 541,
+		"Name": "Purple (Book Glow?)"
+	},
+	{
+		"ModelType": 542,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 543,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 544,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 545,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 546,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 547,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 548,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 549,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 550,
+		"Name": "Spotlight"
+	},
+	{
+		"ModelType": 551,
+		"Name": "Garuda's Plume (Blue Aether)"
+	},
+	{
+		"ModelType": 552,
+		"Name": "Garuda's Plume (Pink Aether)"
+	},
+	{
+		"ModelType": 553,
+		"Name": "Garuda's Plume (No Aether)"
+	},
+	{
+		"ModelType": 554,
+		"Name": "Titan"
+	},
+	{
+		"ModelType": 555,
+		"Name": "Ancient Wyvern (- Neurolinks)"
+	},
+	{
+		"ModelType": 556,
+		"Name": "Floor Circle (Conflagration)"
+	},
+	{
+		"ModelType": 557,
+		"Name": "Floor Circle (Conflagration)"
+	},
+	{
+		"ModelType": 558,
+		"Name": "Caduceus"
+	},
+	{
+		"ModelType": 559,
+		"Name": "Blue Cobra (Glowing)"
+	},
+	{
+		"ModelType": 560,
+		"Name": "Red Cobra (Glowing)"
+	},
+	{
+		"ModelType": 562,
+		"Name": "Rat (2)"
+	},
+	{
+		"ModelType": 563,
+		"Name": "Catoblepas"
+	},
+	{
+		"ModelType": 564,
+		"Name": "Nandi"
+	},
+	{
+		"ModelType": 565,
+		"Name": "Catoblepas C (Yellow w/ Magenta)"
+	},
+	{
+		"ModelType": 566,
+		"Name": "Celphie"
+	},
+	{
+		"ModelType": 567,
+		"Name": "Archdemon"
+	},
+	{
+		"ModelType": 568,
+		"Name": "Archdemon (II) (Copy)"
+	},
+	{
+		"ModelType": 569,
+		"Name": "Archdemon (III) (Copy)"
+	},
+	{
+		"ModelType": 570,
+		"Name": "Okeanis A (Blue/Orange)"
+	},
+	{
+		"ModelType": 571,
+		"Name": "Ceremony Chocobo"
+	},
+	{
+		"ModelType": 572,
+		"Name": "Okeanis C (Red/Purple)"
+	},
+	{
+		"ModelType": 573,
+		"Name": "Okeanis D (Yellow)"
+	},
+	{
+		"ModelType": 574,
+		"Name": "Gold Bear"
+	},
+	{
+		"ModelType": 575,
+		"Name": "Tiger"
+	},
+	{
+		"ModelType": 576,
+		"Name": "Earthen Brickman (Dragon Quest)"
+	},
+	{
+		"ModelType": 577,
+		"Name": "Wind-Up Brickman",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 578,
+		"Name": "Minute Mindflayer",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 579,
+		"Name": "Tight-beaked Parrot",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 580,
+		"Name": "Wind-Up Amalj'aa",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 581,
+		"Name": "Wind-Up Ixal",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 582,
+		"Name": "Wind-Up Kobolder",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 583,
+		"Name": "Wind-Up Sea Devil",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 584,
+		"Name": "Wind-Up Edvya",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 585,
+		"Name": "Wind-Up Sun",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 586,
+		"Name": "Plush Cushion",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 587,
+		"Name": "Minion of Light (Minion) (Warrior)"
+	},
+	{
+		"ModelType": 588,
+		"Name": "Behemoth (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 589,
+		"Name": "Stone Brickman (Dragon Quest)"
+	},
+	{
+		"ModelType": 590,
+		"Name": "Golden Brickman (Dragon Quest)"
+	},
+	{
+		"ModelType": 591,
+		"Name": "Imp (On Fire)"
+	},
+	{
+		"ModelType": 592,
+		"Name": "Cavalry Drake",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 593,
+		"Name": "Laurel Goobbue",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 594,
+		"Name": "Nightmare",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 595,
+		"Name": "Zu Cockerel"
+	},
+	{
+		"ModelType": 596,
+		"Name": "Zu Pullet"
+	},
+	{
+		"ModelType": 597,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 598,
+		"Name": "Spotted Zu Egg"
+	},
+	{
+		"ModelType": 599,
+		"Name": "White Zu Egg"
+	},
+	{
+		"ModelType": 600,
+		"Name": "Leech"
+	},
+	{
+		"ModelType": 601,
+		"Name": "Bhoot"
+	},
+	{
+		"ModelType": 602,
+		"Name": "Sandman"
+	},
+	{
+		"ModelType": 603,
+		"Name": "Manticore"
+	},
+	{
+		"ModelType": 604,
+		"Name": "Zu"
+	},
+	{
+		"ModelType": 605,
+		"Name": "Dullahan (NNYNB) (Purple)"
+	},
+	{
+		"ModelType": 606,
+		"Name": "Zombie War Hound"
+	},
+	{
+		"ModelType": 607,
+		"Name": "Floating Eye (+ Void Effect)"
+	},
+	{
+		"ModelType": 608,
+		"Name": "Corrupted Flan"
+	},
+	{
+		"ModelType": 609,
+		"Name": "Iron Giant"
+	},
+	{
+		"ModelType": 610,
+		"Name": "Corrupted Slime"
+	},
+	{
+		"ModelType": 611,
+		"Name": "Garuda's Plume (Green Aether)"
+	},
+	{
+		"ModelType": 612,
+		"Name": "Corrupted Sprite"
+	},
+	{
+		"ModelType": 613,
+		"Name": "Pharos Aether Cloud"
+	},
+	{
+		"ModelType": 614,
+		"Name": "Orb (Green / Lighting w/ Purple Outline)"
+	},
+	{
+		"ModelType": 615,
+		"Name": "Amalj'aa Beacon"
+	},
+	{
+		"ModelType": 616,
+		"Name": "Sylph Shroom"
+	},
+	{
+		"ModelType": 617,
+		"Name": "Snowman"
+	},
+	{
+		"ModelType": 618,
+		"Name": "Granite Gaoler"
+	},
+	{
+		"ModelType": 619,
+		"Name": "Voidsent Energy Spear"
+	},
+	{
+		"ModelType": 620,
+		"Name": "Voidsent Energy Scythe"
+	},
+	{
+		"ModelType": 621,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 622,
+		"Name": "Void Portal"
+	},
+	{
+		"ModelType": 623,
+		"Name": "Minion of Light (Minion) (White Mage)"
+	},
+	{
+		"ModelType": 624,
+		"Name": "Minion of Light (Minion) (Black Mage)"
+	},
+	{
+		"ModelType": 625,
+		"Name": "Wind-Up Leader (Minion) (Raubahn)"
+	},
+	{
+		"ModelType": 626,
+		"Name": "Wind-Up Leader (Minion) (Merlwyb)"
+	},
+	{
+		"ModelType": 627,
+		"Name": "Wind-Up Leader (Minion) (Kan-E-Senna)"
+	},
+	{
+		"ModelType": 628,
+		"Name": "Starlight Treant"
+	},
+	{
+		"ModelType": 629,
+		"Name": "Rock (Gray)"
+	},
+	{
+		"ModelType": 630,
+		"Name": "Spear stuck in ground"
+	},
+	{
+		"ModelType": 631,
+		"Name": "Fancy pillar"
+	},
+	{
+		"ModelType": 632,
+		"Name": "Fancy circular relic"
+	},
+	{
+		"ModelType": 633,
+		"Name": "Clockwork Spider"
+	},
+	{
+		"ModelType": 634,
+		"Name": "Princely Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 635,
+		"Name": "Wind"
+	},
+	{
+		"ModelType": 636,
+		"Name": "Gilgamesh (Bradamante)"
+	},
+	{
+		"ModelType": 637,
+		"Name": "Jandelaine",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 638,
+		"Name": "Vassago"
+	},
+	{
+		"ModelType": 639,
+		"Name": "Green Toad (Battle on the Big Bridge)"
+	},
+	{
+		"ModelType": 640,
+		"Name": "Decaying Gourmand"
+	},
+	{
+		"ModelType": 641,
+		"Name": "Gobmachine G-VI"
+	},
+	{
+		"ModelType": 642,
+		"Name": "Leviathan's Tail"
+	},
+	{
+		"ModelType": 643,
+		"Name": "Fat Chocobo",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 644,
+		"Name": "Bomb Palanquin",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 645,
+		"Name": "Wamouracampa"
+	},
+	{
+		"ModelType": 646,
+		"Name": "Wamoura/Silkmoth"
+	},
+	{
+		"ModelType": 647,
+		"Name": "Nael deus Darnus"
+	},
+	{
+		"ModelType": 648,
+		"Name": "Mimic"
+	},
+	{
+		"ModelType": 649,
+		"Name": "Orb (Diabolos Nightmare)"
+	},
+	{
+		"ModelType": 650,
+		"Name": "Key"
+	},
+	{
+		"ModelType": 652,
+		"Name": "Enkidu (Chicken)"
+	},
+	{
+		"ModelType": 653,
+		"Name": "Arioch"
+	},
+	{
+		"ModelType": 654,
+		"Name": "Damselfly"
+	},
+	{
+		"ModelType": 655,
+		"Name": "Rafflesia"
+	},
+	{
+		"ModelType": 656,
+		"Name": "Dark Matter Bulb"
+	},
+	{
+		"ModelType": 657,
+		"Name": "Dark Matter Hornet"
+	},
+	{
+		"ModelType": 658,
+		"Name": "The Avatar"
+	},
+	{
+		"ModelType": 659,
+		"Name": "Down Wyvern"
+	},
+	{
+		"ModelType": 660,
+		"Name": "Fire Dragon"
+	},
+	{
+		"ModelType": 661,
+		"Name": "Dalamud Spawn"
+	},
+	{
+		"ModelType": 662,
+		"Name": "Flying Thunder Dragon"
+	},
+	{
+		"ModelType": 663,
+		"Name": "Flying Moss Dragon"
+	},
+	{
+		"ModelType": 664,
+		"Name": "Flying Fire Dragon"
+	},
+	{
+		"ModelType": 665,
+		"Name": "Flying Zombie Dragon"
+	},
+	{
+		"ModelType": 666,
+		"Name": "Rock (White)"
+	},
+	{
+		"ModelType": 667,
+		"Name": "Rock (White) (II)"
+	},
+	{
+		"ModelType": 668,
+		"Name": "Rock (White) (III)"
+	},
+	{
+		"ModelType": 669,
+		"Name": "N/A"
+	},
+	{
+		"ModelType": 670,
+		"Name": "Goblin Bomb"
+	},
+	{
+		"ModelType": 671,
+		"Name": "Goblin Bomb (Skull)"
+	},
+	{
+		"ModelType": 672,
+		"Name": "Goblin Bomb (Spiked)"
+	},
+	{
+		"ModelType": 673,
+		"Name": "Magitek Vangob"
+	},
+	{
+		"ModelType": 674,
+		"Name": "Pyracmon"
+	},
+	{
+		"ModelType": 675,
+		"Name": "Direwolf",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 676,
+		"Name": "Orb (Yellow / Bubble)"
+	},
+	{
+		"ModelType": 677,
+		"Name": "Brown crate"
+	},
+	{
+		"ModelType": 678,
+		"Name": "Bomb Incubator (Red)"
+	},
+	{
+		"ModelType": 679,
+		"Name": "Whelk Ballista"
+	},
+	{
+		"ModelType": 681,
+		"Name": "Wind Cylinder"
+	},
+	{
+		"ModelType": 682,
+		"Name": "Zu Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 683,
+		"Name": "Wind-Up Odin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 684,
+		"Name": "Wind-Up Warrior of Light",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 685,
+		"Name": "Wind-Up Bahamut",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 686,
+		"Name": "Baby Opo-opo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 687,
+		"Name": "Magic Broom",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 688,
+		"Name": "Wind-Up Moogle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 689,
+		"Name": "Cavalry Elbst",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 690,
+		"Name": "Hecteyes"
+	},
+	{
+		"ModelType": 691,
+		"Name": "Imp C (Green)"
+	},
+	{
+		"ModelType": 692,
+		"Name": "Gilgamesh (Unarmed)"
+	},
+	{
+		"ModelType": 693,
+		"Name": "Wamouracampa (II) (Copy)"
+	},
+	{
+		"ModelType": 694,
+		"Name": "Wamoura (II) (Copy)"
+	},
+	{
+		"ModelType": 695,
+		"Name": "Dark Matter Roselet"
+	},
+	{
+		"ModelType": 696,
+		"Name": "Crate"
+	},
+	{
+		"ModelType": 697,
+		"Name": "Spiked Balls"
+	},
+	{
+		"ModelType": 698,
+		"Name": "Dark Matter Slug (Honey)"
+	},
+	{
+		"ModelType": 699,
+		"Name": "Wind-Up Kobld",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 700,
+		"Name": "Wind-Up Sahagin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 701,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 702,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 703,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 704,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 705,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 706,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 707,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 708,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 709,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 710,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 711,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 712,
+		"Name": "Default Model"
+	},
+	{
+		"ModelType": 713,
+		"Name": "Aithon",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 714,
+		"Name": "Xanthos",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 715,
+		"Name": "Markab",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 716,
+		"Name": "Einbarr",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 717,
+		"Name": "Persona"
+	},
+	{
+		"ModelType": 718,
+		"Name": "Battle Bear",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 719,
+		"Name": "Warbear",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 720,
+		"Name": "Golden Lion mount [Incorrect]"
+	},
+	{
+		"ModelType": 721,
+		"Name": "Warlion",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 722,
+		"Name": "Sallet Crab"
+	},
+	{
+		"ModelType": 723,
+		"Name": "Leg Trap"
+	},
+	{
+		"ModelType": 724,
+		"Name": "Narbrooi"
+	},
+	{
+		"ModelType": 725,
+		"Name": "Kraken's Arm"
+	},
+	{
+		"ModelType": 726,
+		"Name": "Kraken's Tentacle"
+	},
+	{
+		"ModelType": 727,
+		"Name": "Harpeia"
+	},
+	{
+		"ModelType": 728,
+		"Name": "Ninki Nanka (w/ Nankas)"
+	},
+	{
+		"ModelType": 729,
+		"Name": "Ninki Nanka"
+	},
+	{
+		"ModelType": 730,
+		"Name": "Diresaur"
+	},
+	{
+		"ModelType": 731,
+		"Name": "Gorynich"
+	},
+	{
+		"ModelType": 732,
+		"Name": "Adamantoise Dragon"
+	},
+	{
+		"ModelType": 733,
+		"Name": "Allagan Naga"
+	},
+	{
+		"ModelType": 734,
+		"Name": "Avere Bravearm"
+	},
+	{
+		"ModelType": 735,
+		"Name": "Sasquatch"
+	},
+	{
+		"ModelType": 736,
+		"Name": "Floor Circle (Water / Hullbreaker)"
+	},
+	{
+		"ModelType": 737,
+		"Name": "Bubble (Hullbreaker)"
+	},
+	{
+		"ModelType": 738,
+		"Name": "Large Red Frog"
+	},
+	{
+		"ModelType": 739,
+		"Name": "Shield Dragonling"
+	},
+	{
+		"ModelType": 740,
+		"Name": "Nanka"
+	},
+	{
+		"ModelType": 741,
+		"Name": "Ogrebon"
+	},
+	{
+		"ModelType": 742,
+		"Name": "Onion Prince",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 743,
+		"Name": "Eggplant Knight",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 744,
+		"Name": "Garlic Jester",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 745,
+		"Name": "Tomato King",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 746,
+		"Name": "Mandragora Queen",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 747,
+		"Name": "Treasure Box",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 748,
+		"Name": "Wind-Up Succubus",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 749,
+		"Name": "Wind-Up Onion Knight",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 750,
+		"Name": "Wind-Up Y'shtola",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 751,
+		"Name": "Wind-Up Nanamo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 752,
+		"Name": "Nana Bear",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 753,
+		"Name": "Miniature Minecart",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 754,
+		"Name": "Tiny Tapir",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 755,
+		"Name": "Nutkin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 756,
+		"Name": "Wind-Up Gilgamesh",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 757,
+		"Name": "Onion Prince"
+	},
+	{
+		"ModelType": 758,
+		"Name": "Eggplant Knight"
+	},
+	{
+		"ModelType": 759,
+		"Name": "Garlic Prince"
+	},
+	{
+		"ModelType": 760,
+		"Name": "Tomato King"
+	},
+	{
+		"ModelType": 761,
+		"Name": "Mandragora Queen"
+	},
+	{
+		"ModelType": 763,
+		"Name": "Enkidu (Primal)"
+	},
+	{
+		"ModelType": 764,
+		"Name": "Icicle"
+	},
+	{
+		"ModelType": 766,
+		"Name": "Interceptor Drone (PVP)"
+	},
+	{
+		"ModelType": 767,
+		"Name": "Yeti"
+	},
+	{
+		"ModelType": 768,
+		"Name": "Scylla's Staff"
+	},
+	{
+		"ModelType": 769,
+		"Name": "Main Meteor Target"
+	},
+	{
+		"ModelType": 770,
+		"Name": "Dullahan (YYYYB) (Blue)"
+	},
+	{
+		"ModelType": 771,
+		"Name": "Dullahan (NNYYB) (Red)"
+	},
+	{
+		"ModelType": 772,
+		"Name": "Okeanis B (Green/Blue)"
+	},
+	{
+		"ModelType": 773,
+		"Name": "Allagan Mamool Ja Warrior"
+	},
+	{
+		"ModelType": 774,
+		"Name": "Kum Kum"
+	},
+	{
+		"ModelType": 775,
+		"Name": "Clockwork Bit"
+	},
+	{
+		"ModelType": 776,
+		"Name": "Gomory"
+	},
+	{
+		"ModelType": 777,
+		"Name": "Tursus"
+	},
+	{
+		"ModelType": 778,
+		"Name": "Azer"
+	},
+	{
+		"ModelType": 779,
+		"Name": "Ice Gaol"
+	},
+	{
+		"ModelType": 780,
+		"Name": "Interceptor Node (PVP)"
+	},
+	{
+		"ModelType": 781,
+		"Name": "Abaia"
+	},
+	{
+		"ModelType": 782,
+		"Name": "Aevis B (White)"
+	},
+	{
+		"ModelType": 783,
+		"Name": "Orb (Red / Syrcus Fire)"
+	},
+	{
+		"ModelType": 784,
+		"Name": "Orb (Blue / Syrcus Ice)"
+	},
+	{
+		"ModelType": 785,
+		"Name": "Orb (Purple / Syrcus Lightning)"
+	},
+	{
+		"ModelType": 786,
+		"Name": "Orb (Purple / Aether Lines)"
+	},
+	{
+		"ModelType": 787,
+		"Name": "Orb (Purple / Tam-Tara HM?)"
+	},
+	{
+		"ModelType": 788,
+		"Name": "Orb (Dark Blue)"
+	},
+	{
+		"ModelType": 789,
+		"Name": "Orb (Purple)"
+	},
+	{
+		"ModelType": 790,
+		"Name": "Hunters Moon Disc (Syrcus)"
+	},
+	{
+		"ModelType": 791,
+		"Name": "Aetherochemical Explosion Marker (Syrcus)"
+	},
+	{
+		"ModelType": 792,
+		"Name": "Varis zos Galvus"
+	},
+	{
+		"ModelType": 793,
+		"Name": "Archbishop Thordan VII"
+	},
+	{
+		"ModelType": 794,
+		"Name": "Endymion"
+	},
+	{
+		"ModelType": 795,
+		"Name": "Boogeyman"
+	},
+	{
+		"ModelType": 796,
+		"Name": "Wind-Up Thancred",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 797,
+		"Name": "Wind-Up Minfilia",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 798,
+		"Name": "Mummy's Little Mummy",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 799,
+		"Name": "Wind-Up Ultros",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 800,
+		"Name": "Heavy Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 801,
+		"Name": "Littlefoot",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 802,
+		"Name": "Fat Cat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 803,
+		"Name": "Hoary the Snowman",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 805,
+		"Name": "Demon Box",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 807,
+		"Name": "Assassin Fry",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 808,
+		"Name": "Naughty Nanka",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 809,
+		"Name": "Wind-Up Delivery Moogle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 810,
+		"Name": "Small Red Frog"
+	},
+	{
+		"ModelType": 811,
+		"Name": "Warsteed (Maelstrom)"
+	},
+	{
+		"ModelType": 812,
+		"Name": "Warsteed (Adders)"
+	},
+	{
+		"ModelType": 813,
+		"Name": "Warsteed (Flames)"
+	},
+	{
+		"ModelType": 814,
+		"Name": "Postmoogle"
+	},
+	{
+		"ModelType": 815,
+		"Name": "Field Generator B (Allagan)"
+	},
+	{
+		"ModelType": 816,
+		"Name": "Wind-Up Panda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 817,
+		"Name": "Gullfaxi",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 818,
+		"Name": "Boreas",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 819,
+		"Name": "Small Meteor Target"
+	},
+	{
+		"ModelType": 820,
+		"Name": "Moonfire Elbst (2014)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 821,
+		"Name": "Fireworks Launcher"
+	},
+	{
+		"ModelType": 822,
+		"Name": "Kaliya"
+	},
+	{
+		"ModelType": 824,
+		"Name": "Karlabos"
+	},
+	{
+		"ModelType": 825,
+		"Name": "Ice Commander"
+	},
+	{
+		"ModelType": 826,
+		"Name": "Battle Biast"
+	},
+	{
+		"ModelType": 827,
+		"Name": "Gaelicat"
+	},
+	{
+		"ModelType": 828,
+		"Name": "Sentient Inkhorn"
+	},
+	{
+		"ModelType": 829,
+		"Name": "ADS (Cuboid - Black - Red)"
+	},
+	{
+		"ModelType": 830,
+		"Name": "ADS (Ovoid - Black - Red)"
+	},
+	{
+		"ModelType": 831,
+		"Name": "Byblos"
+	},
+	{
+		"ModelType": 832,
+		"Name": "Gnath"
+	},
+	{
+		"ModelType": 833,
+		"Name": "Imdugud"
+	},
+	{
+		"ModelType": 834,
+		"Name": "Opken"
+	},
+	{
+		"ModelType": 835,
+		"Name": "White Gaol"
+	},
+	{
+		"ModelType": 836,
+		"Name": "Water Imp (Dragon's Neck)"
+	},
+	{
+		"ModelType": 837,
+		"Name": "Manxome�Molaa�Ja�Ja"
+	},
+	{
+		"ModelType": 838,
+		"Name": "Frumious Koheel Ja (on Wivre)"
+	},
+	{
+		"ModelType": 839,
+		"Name": "Crawler"
+	},
+	{
+		"ModelType": 840,
+		"Name": "Bitoso"
+	},
+	{
+		"ModelType": 841,
+		"Name": "Deepeye"
+	},
+	{
+		"ModelType": 842,
+		"Name": "Reptoid"
+	},
+	{
+		"ModelType": 843,
+		"Name": "Vicegerent's Right Hand"
+	},
+	{
+		"ModelType": 844,
+		"Name": "Vicegerent's Left Hand"
+	},
+	{
+		"ModelType": 845,
+		"Name": "Captain Madison (Monster)"
+	},
+	{
+		"ModelType": 846,
+		"Name": "Daughter of Imdugud"
+	},
+	{
+		"ModelType": 847,
+		"Name": "Son of Imdugud"
+	},
+	{
+		"ModelType": 848,
+		"Name": "Orb (Phoenix's Blackfire)"
+	},
+	{
+		"ModelType": 849,
+		"Name": "Floor Fire (Phoenix)"
+	},
+	{
+		"ModelType": 850,
+		"Name": "Orb (Phoenix's Redfire)"
+	},
+	{
+		"ModelType": 851,
+		"Name": "Bennu (Small)"
+	},
+	{
+		"ModelType": 852,
+		"Name": "Bennu (Medium)"
+	},
+	{
+		"ModelType": 853,
+		"Name": "Bennu (Large)"
+	},
+	{
+		"ModelType": 854,
+		"Name": "Phoenix (Glowing)"
+	},
+	{
+		"ModelType": 855,
+		"Name": "The Blood of Meracydia"
+	},
+	{
+		"ModelType": 856,
+		"Name": "The Pain of Meracydia (Neurolinked)"
+	},
+	{
+		"ModelType": 857,
+		"Name": "The Gust of Meracydia"
+	},
+	{
+		"ModelType": 858,
+		"Name": "The Shadow of Meracydia"
+	},
+	{
+		"ModelType": 859,
+		"Name": "The Sin of Meracydia (Neurolinked)"
+	},
+	{
+		"ModelType": 860,
+		"Name": "Vicegerent's Head"
+	},
+	{
+		"ModelType": 861,
+		"Name": "Sastasha Pugil"
+	},
+	{
+		"ModelType": 862,
+		"Name": "Belah'dian Knight"
+	},
+	{
+		"ModelType": 863,
+		"Name": "Steinbock Doe"
+	},
+	{
+		"ModelType": 864,
+		"Name": "Snoll"
+	},
+	{
+		"ModelType": 865,
+		"Name": "Spriggan (Blue-eyed: Ice Rock)"
+	},
+	{
+		"ModelType": 866,
+		"Name": "Sleipnir (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 867,
+		"Name": "Snowball?"
+	},
+	{
+		"ModelType": 868,
+		"Name": "Temple Mummy (Lalafell)"
+	},
+	{
+		"ModelType": 869,
+		"Name": "Temple Mummy (Roegadyn)"
+	},
+	{
+		"ModelType": 870,
+		"Name": "Polar Bear"
+	},
+	{
+		"ModelType": 871,
+		"Name": "Vine (Purple)"
+	},
+	{
+		"ModelType": 872,
+		"Name": "Vine"
+	},
+	{
+		"ModelType": 873,
+		"Name": "Sabotender Empiratriz"
+	},
+	{
+		"ModelType": 874,
+		"Name": "Sabotender Guardia"
+	},
+	{
+		"ModelType": 875,
+		"Name": "Sabotender Guardia (+ Shield)"
+	},
+	{
+		"ModelType": 876,
+		"Name": "Vicegerent to the Warden"
+	},
+	{
+		"ModelType": 877,
+		"Name": "Sentient Tome"
+	},
+	{
+		"ModelType": 878,
+		"Name": "Wind-Up Yda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 879,
+		"Name": "Wind-Up Papalymo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 880,
+		"Name": "Wind-Up Urianger",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 881,
+		"Name": "Wind-Up Louisoix",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 882,
+		"Name": "Wind-Up Gentleman",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 883,
+		"Name": "Midgardsormr",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 884,
+		"Name": "Wind-Up Alphinaud",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 885,
+		"Name": "Wind-Up Alisaie",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 886,
+		"Name": "Water Imp",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 887,
+		"Name": "Model Enterprise",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 888,
+		"Name": "Enkidu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 889,
+		"Name": "Wind-Up Gundu Warrior",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 890,
+		"Name": "Unicolt",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 891,
+		"Name": "Wind-Up Cid",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 892,
+		"Name": "Wind-Up Tataru",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 893,
+		"Name": "Owlet",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 894,
+		"Name": "Atrophied Atomos",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 895,
+		"Name": "Lesser Panda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 896,
+		"Name": "Clockwork Barrow",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 897,
+		"Name": "Griffin Hatchling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 898,
+		"Name": "Iron Dwarf",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 899,
+		"Name": "Ugly Duckling",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 900,
+		"Name": "Page 63",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 901,
+		"Name": "Wind-Up Violet",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 902,
+		"Name": "Wind-Up Founder",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 903,
+		"Name": "Wind-Up Dezul Qualan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 904,
+		"Name": "Skatene"
+	},
+	{
+		"ModelType": 905,
+		"Name": "Paissa"
+	},
+	{
+		"ModelType": 906,
+		"Name": "Typhon's FUNGAH!"
+	},
+	{
+		"ModelType": 907,
+		"Name": "A Tornado"
+	},
+	{
+		"ModelType": 908,
+		"Name": "4-tonze Weight"
+	},
+	{
+		"ModelType": 909,
+		"Name": "Damaged Adjudicator"
+	},
+	{
+		"ModelType": 910,
+		"Name": "Orb (Sandy / Qarn HM?)"
+	},
+	{
+		"ModelType": 911,
+		"Name": "Shiva (No Weapons)"
+	},
+	{
+		"ModelType": 912,
+		"Name": "Feridad"
+	},
+	{
+		"ModelType": 913,
+		"Name": "Bandersnatch"
+	},
+	{
+		"ModelType": 914,
+		"Name": "Miacid"
+	},
+	{
+		"ModelType": 915,
+		"Name": "Syricta"
+	},
+	{
+		"ModelType": 916,
+		"Name": "Empuse"
+	},
+	{
+		"ModelType": 917,
+		"Name": "Midgardsormr (Head)"
+	},
+	{
+		"ModelType": 918,
+		"Name": "Page 64/128/256"
+	},
+	{
+		"ModelType": 919,
+		"Name": "Okeanis E (Blue/Red)"
+	},
+	{
+		"ModelType": 920,
+		"Name": "Imp (b)"
+	},
+	{
+		"ModelType": 921,
+		"Name": "Bat (b) (Copy)"
+	},
+	{
+		"ModelType": 922,
+		"Name": "Floating Eye (b)"
+	},
+	{
+		"ModelType": 923,
+		"Name": "Bogy (b) (Copy)"
+	},
+	{
+		"ModelType": 924,
+		"Name": "Vodoriga (b)"
+	},
+	{
+		"ModelType": 925,
+		"Name": "Everliving Bibliotaph"
+	},
+	{
+		"ModelType": 926,
+		"Name": "Midgardsormr (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 927,
+		"Name": "Megalotragus"
+	},
+	{
+		"ModelType": 928,
+		"Name": "Orb (Purple/Blue)"
+	},
+	{
+		"ModelType": 929,
+		"Name": "Manacutter (White)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 930,
+		"Name": "Magitek Gunship"
+	},
+	{
+		"ModelType": 931,
+		"Name": "Orb (Green)"
+	},
+	{
+		"ModelType": 932,
+		"Name": "Ultros (One Lump)"
+	},
+	{
+		"ModelType": 933,
+		"Name": "Ultros (Two Lumps)"
+	},
+	{
+		"ModelType": 934,
+		"Name": "Ulros (Three Lumps)"
+	},
+	{
+		"ModelType": 935,
+		"Name": "Vodoriga (Slumbering)"
+	},
+	{
+		"ModelType": 936,
+		"Name": "Mamool Ja sacred Standard"
+	},
+	{
+		"ModelType": 937,
+		"Name": "Mamool Ja sacred Standard"
+	},
+	{
+		"ModelType": 941,
+		"Name": "Gungnir"
+	},
+	{
+		"ModelType": 942,
+		"Name": "Archaeosaur"
+	},
+	{
+		"ModelType": 943,
+		"Name": "Bladed Vinegaroon"
+	},
+	{
+		"ModelType": 944,
+		"Name": "Archaeornis"
+	},
+	{
+		"ModelType": 945,
+		"Name": "Falak"
+	},
+	{
+		"ModelType": 946,
+		"Name": "Waukkeon"
+	},
+	{
+		"ModelType": 947,
+		"Name": "Spear"
+	},
+	{
+		"ModelType": 948,
+		"Name": "Wivre"
+	},
+	{
+		"ModelType": 949,
+		"Name": "Tarantula Hawk"
+	},
+	{
+		"ModelType": 950,
+		"Name": "Brobinyak"
+	},
+	{
+		"ModelType": 951,
+		"Name": "Yak"
+	},
+	{
+		"ModelType": 952,
+		"Name": "Vouivre"
+	},
+	{
+		"ModelType": 953,
+		"Name": "Nunyenunc"
+	},
+	{
+		"ModelType": 954,
+		"Name": "Harmachis"
+	},
+	{
+		"ModelType": 955,
+		"Name": "Griffin"
+	},
+	{
+		"ModelType": 956,
+		"Name": "Anchag"
+	},
+	{
+		"ModelType": 957,
+		"Name": "Mylodon"
+	},
+	{
+		"ModelType": 958,
+		"Name": "Kirin",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 959,
+		"Name": "Kaliya (II) (Copy)"
+	},
+	{
+		"ModelType": 960,
+		"Name": "Orb (Blue)"
+	},
+	{
+		"ModelType": 962,
+		"Name": "Oppressor"
+	},
+	{
+		"ModelType": 963,
+		"Name": "Manipulator"
+	},
+	{
+		"ModelType": 964,
+		"Name": "SDS Fenrir",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 965,
+		"Name": "Parade Chocobo",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 966,
+		"Name": "Chocobo (II)"
+	},
+	{
+		"ModelType": 967,
+		"Name": "Sacrificed Allagan Mamool Ja Warrior"
+	},
+	{
+		"ModelType": 968,
+		"Name": "Garm"
+	},
+	{
+		"ModelType": 969,
+		"Name": "Queen Scylla"
+	},
+	{
+		"ModelType": 970,
+		"Name": "Atomos Avatar"
+	},
+	{
+		"ModelType": 971,
+		"Name": "Sacrificed Soldier"
+	},
+	{
+		"ModelType": 972,
+		"Name": "Dragonfire Fly"
+	},
+	{
+		"ModelType": 973,
+		"Name": "Triad Table"
+	},
+	{
+		"ModelType": 974,
+		"Name": "Einhander"
+	},
+	{
+		"ModelType": 975,
+		"Name": "Bismarck"
+	},
+	{
+		"ModelType": 976,
+		"Name": "Ravana (Four Small Swords)"
+	},
+	{
+		"ModelType": 977,
+		"Name": "Tioman"
+	},
+	{
+		"ModelType": 978,
+		"Name": "Steam Doll (Faust)"
+	},
+	{
+		"ModelType": 979,
+		"Name": "Magitek Gobwidow"
+	},
+	{
+		"ModelType": 980,
+		"Name": "Proto-Ultima"
+	},
+	{
+		"ModelType": 981,
+		"Name": "Cloud of Darkness (- Clouds)"
+	},
+	{
+		"ModelType": 982,
+		"Name": "White Knight"
+	},
+	{
+		"ModelType": 983,
+		"Name": "Fire Dragonet"
+	},
+	{
+		"ModelType": 984,
+		"Name": "Oliphaunt"
+	},
+	{
+		"ModelType": 985,
+		"Name": "Alpha Groundskeeper"
+	},
+	{
+		"ModelType": 986,
+		"Name": "Demon Tome"
+	},
+	{
+		"ModelType": 987,
+		"Name": "Adamantoise (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 988,
+		"Name": "Gaelikitten",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 989,
+		"Name": "Wind-Up Kain",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 990,
+		"Name": "Chocobo Chick Courier",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 991,
+		"Name": "Broken Mooglebox",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 992,
+		"Name": "Griffin (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 993,
+		"Name": "Waitress",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 994,
+		"Name": "Mirage Dragon (Thunder)"
+	},
+	{
+		"ModelType": 995,
+		"Name": "Mirage Dragon (Ice)"
+	},
+	{
+		"ModelType": 996,
+		"Name": "Astraea"
+	},
+	{
+		"ModelType": 997,
+		"Name": "Ceruleum Tank"
+	},
+	{
+		"ModelType": 998,
+		"Name": "Ceruleum Tank"
+	},
+	{
+		"ModelType": 999,
+		"Name": "Generator (Keeper of the Lake)"
+	},
+	{
+		"ModelType": 1000,
+		"Name": "Atomos Prime"
+	},
+	{
+		"ModelType": 1001,
+		"Name": "Dragon Head (Gilgamesh)"
+	},
+	{
+		"ModelType": 1002,
+		"Name": "Snare (Steps of Faith)"
+	},
+	{
+		"ModelType": 1003,
+		"Name": "Exploding Barrels (Steps of Faith)"
+	},
+	{
+		"ModelType": 1004,
+		"Name": "Xande's Clone"
+	},
+	{
+		"ModelType": 1005,
+		"Name": "Two-Headed Dragon"
+	},
+	{
+		"ModelType": 1006,
+		"Name": "Dark Sprite"
+	},
+	{
+		"ModelType": 1007,
+		"Name": "Orb (White / Five-headed Dragon?)"
+	},
+	{
+		"ModelType": 1008,
+		"Name": "Orb (Blue Static)"
+	},
+	{
+		"ModelType": 1009,
+		"Name": "Cloud of Darkness' Dark Storm"
+	},
+	{
+		"ModelType": 1010,
+		"Name": "Orb (Binding Chains)"
+	},
+	{
+		"ModelType": 1011,
+		"Name": "Gobwalker",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1012,
+		"Name": "Vinegaroon"
+	},
+	{
+		"ModelType": 1013,
+		"Name": "Piston Lubricant"
+	},
+	{
+		"ModelType": 1014,
+		"Name": "Gear Lubricant"
+	},
+	{
+		"ModelType": 1015,
+		"Name": "Orb (Lightning)"
+	},
+	{
+		"ModelType": 1016,
+		"Name": "Model Magitek Bit",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1017,
+		"Name": "Puff of Darkness",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1018,
+		"Name": "Mandragora (b) (Gardening Copy)"
+	},
+	{
+		"ModelType": 1019,
+		"Name": "Midgardsormr (Head)"
+	},
+	{
+		"ModelType": 1020,
+		"Name": "Midgardsormr (Head)"
+	},
+	{
+		"ModelType": 1021,
+		"Name": "ADS (Enormous Egg) (Hartching-tide 2015)"
+	},
+	{
+		"ModelType": 1022,
+		"Name": "Spriggan (Yellow-eyed w/ Red Egg)"
+	},
+	{
+		"ModelType": 1023,
+		"Name": "Spriggan (Yellow-eyed w/ Yellow Egg)"
+	},
+	{
+		"ModelType": 1024,
+		"Name": "Generic Person - Carrying Crate",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1025,
+		"Name": "Cloud of Darkness - Dark Cloud"
+	},
+	{
+		"ModelType": 1026,
+		"Name": "Fenrir (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1027,
+		"Name": "Rook Autoturret"
+	},
+	{
+		"ModelType": 1028,
+		"Name": "Bishop Autoturret"
+	},
+	{
+		"ModelType": 1029,
+		"Name": "Logistics System"
+	},
+	{
+		"ModelType": 1030,
+		"Name": "Magitek Gunship B (Blue)"
+	},
+	{
+		"ModelType": 1031,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1032,
+		"Name": "Hecteyes (II) (Slightly Lighter Copy)"
+	},
+	{
+		"ModelType": 1033,
+		"Name": "Lily of the Saint"
+	},
+	{
+		"ModelType": 1034,
+		"Name": "Corpse Flower"
+	},
+	{
+		"ModelType": 1035,
+		"Name": "Icetrap"
+	},
+	{
+		"ModelType": 1036,
+		"Name": "Melia"
+	},
+	{
+		"ModelType": 1037,
+		"Name": "Frostbitten War Hound"
+	},
+	{
+		"ModelType": 1038,
+		"Name": "Gastornis"
+	},
+	{
+		"ModelType": 1039,
+		"Name": "Zoblyn"
+	},
+	{
+		"ModelType": 1040,
+		"Name": "Hropken"
+	},
+	{
+		"ModelType": 1041,
+		"Name": "Minotaur"
+	},
+	{
+		"ModelType": 1042,
+		"Name": "Elder Wyvern"
+	},
+	{
+		"ModelType": 1043,
+		"Name": "Endymion B (Rainbow)"
+	},
+	{
+		"ModelType": 1044,
+		"Name": "Meracydian Vouivre"
+	},
+	{
+		"ModelType": 1045,
+		"Name": "Sankchinni"
+	},
+	{
+		"ModelType": 1046,
+		"Name": "Korrigan"
+	},
+	{
+		"ModelType": 1047,
+		"Name": "Ascian Prime"
+	},
+	{
+		"ModelType": 1048,
+		"Name": "Nidhogg (Hraesvelgr's Left Eye / Fresh Scars)"
+	},
+	{
+		"ModelType": 1049,
+		"Name": "Nidhogg (No Eyes / Fresh Left Scar)"
+	},
+	{
+		"ModelType": 1050,
+		"Name": "Hraesvelgr (One Eye)"
+	},
+	{
+		"ModelType": 1051,
+		"Name": "Tiamat"
+	},
+	{
+		"ModelType": 1052,
+		"Name": "Tulihand"
+	},
+	{
+		"ModelType": 1053,
+		"Name": "Bifericeras"
+	},
+	{
+		"ModelType": 1054,
+		"Name": "Vanu Totem"
+	},
+	{
+		"ModelType": 1055,
+		"Name": "Ratel"
+	},
+	{
+		"ModelType": 1056,
+		"Name": "Sun Leech"
+	},
+	{
+		"ModelType": 1057,
+		"Name": "Clay Claw"
+	},
+	{
+		"ModelType": 1058,
+		"Name": "Sanuwa"
+	},
+	{
+		"ModelType": 1060,
+		"Name": "Living Liquid (Vessel)"
+	},
+	{
+		"ModelType": 1061,
+		"Name": "Living Liquid (Anthromorph)"
+	},
+	{
+		"ModelType": 1062,
+		"Name": "Living Liquid (Chiromorph Right)"
+	},
+	{
+		"ModelType": 1063,
+		"Name": "Living Liquid (Chiromorph Left)"
+	},
+	{
+		"ModelType": 1064,
+		"Name": "Dhalmel"
+	},
+	{
+		"ModelType": 1065,
+		"Name": "Pegasus (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1066,
+		"Name": "Matoya"
+	},
+	{
+		"ModelType": 1067,
+		"Name": "King Thordan"
+	},
+	{
+		"ModelType": 1068,
+		"Name": "Topaz Carbuncle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1070,
+		"Name": "Cloth Scraps?"
+	},
+	{
+		"ModelType": 1071,
+		"Name": "Dragonkiller Cannon"
+	},
+	{
+		"ModelType": 1072,
+		"Name": "Raskovnik"
+	},
+	{
+		"ModelType": 1073,
+		"Name": "Gallimimus"
+	},
+	{
+		"ModelType": 1074,
+		"Name": "Bit C (Red)"
+	},
+	{
+		"ModelType": 1075,
+		"Name": "Poroggo"
+	},
+	{
+		"ModelType": 1076,
+		"Name": "Biohazard"
+	},
+	{
+		"ModelType": 1078,
+		"Name": "Rheum of the Mountain"
+	},
+	{
+		"ModelType": 1079,
+		"Name": "Blood of the Mountain"
+	},
+	{
+		"ModelType": 1080,
+		"Name": "Black Knight"
+	},
+	{
+		"ModelType": 1081,
+		"Name": "Clockwork Spider B (Violet Glow)"
+	},
+	{
+		"ModelType": 1082,
+		"Name": "Gobtank"
+	},
+	{
+		"ModelType": 1083,
+		"Name": "Eruca"
+	},
+	{
+		"ModelType": 1084,
+		"Name": "Oppressor 0.5"
+	},
+	{
+		"ModelType": 1085,
+		"Name": "Ravana (Glowing Red: Two Large Swords)"
+	},
+	{
+		"ModelType": 1086,
+		"Name": "Ravana (Shadowed)"
+	},
+	{
+		"ModelType": 1087,
+		"Name": "Ravana (Two Large Swords)"
+	},
+	{
+		"ModelType": 1088,
+		"Name": "Beta Groundskeeper"
+	},
+	{
+		"ModelType": 1089,
+		"Name": "Enforcement Droid"
+	},
+	{
+		"ModelType": 1090,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1092,
+		"Name": "Cultured Shabti"
+	},
+	{
+		"ModelType": 1093,
+		"Name": "Shabti"
+	},
+	{
+		"ModelType": 1094,
+		"Name": "Biblioklept"
+	},
+	{
+		"ModelType": 1095,
+		"Name": "Phantom Ray"
+	},
+	{
+		"ModelType": 1096,
+		"Name": "Moon Gana"
+	},
+	{
+		"ModelType": 1097,
+		"Name": "Spirit Gana"
+	},
+	{
+		"ModelType": 1098,
+		"Name": "Steam Bit"
+	},
+	{
+		"ModelType": 1099,
+		"Name": "Iksalion"
+	},
+	{
+		"ModelType": 1100,
+		"Name": "The Curator"
+	},
+	{
+		"ModelType": 1101,
+		"Name": "Vanu Vanu"
+	},
+	{
+		"ModelType": 1102,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1103,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1104,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1105,
+		"Name": "Chandrahas"
+	},
+	{
+		"ModelType": 1106,
+		"Name": "Amphiptere"
+	},
+	{
+		"ModelType": 1107,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Red)"
+	},
+	{
+		"ModelType": 1108,
+		"Name": "Azys Lla ADS (Spheroid - Silver - White)"
+	},
+	{
+		"ModelType": 1109,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Violet)"
+	},
+	{
+		"ModelType": 1110,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Lavender)"
+	},
+	{
+		"ModelType": 1111,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Aqua)"
+	},
+	{
+		"ModelType": 1112,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Green)"
+	},
+	{
+		"ModelType": 1113,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Yellow)"
+	},
+	{
+		"ModelType": 1114,
+		"Name": "Azys Lla ADS (Spheroid - Silver - Orange)"
+	},
+	{
+		"ModelType": 1115,
+		"Name": "Azys Lla ADS (Spheroid - White - Red)"
+	},
+	{
+		"ModelType": 1116,
+		"Name": "Azys Lla ADS (Spheroid - White - White)"
+	},
+	{
+		"ModelType": 1117,
+		"Name": "Azys Lla ADS (Spheroid - White - Violet)"
+	},
+	{
+		"ModelType": 1118,
+		"Name": "Azys Lla ADS (Spheroid - White - Lavender)"
+	},
+	{
+		"ModelType": 1119,
+		"Name": "Azys Lla ADS (Spheroid - White - Aqua)"
+	},
+	{
+		"ModelType": 1120,
+		"Name": "Azys Lla ADS (Spheroid - White - Green)"
+	},
+	{
+		"ModelType": 1121,
+		"Name": "Azys Lla ADS (Spheroid - White - Yellow)"
+	},
+	{
+		"ModelType": 1122,
+		"Name": "Azys Lla ADS (Spheroid - White - Orange)"
+	},
+	{
+		"ModelType": 1123,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Red)"
+	},
+	{
+		"ModelType": 1124,
+		"Name": "Azys Lla ADS (Cuboid - Silver - White)"
+	},
+	{
+		"ModelType": 1125,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Violet)"
+	},
+	{
+		"ModelType": 1126,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Lavender)"
+	},
+	{
+		"ModelType": 1127,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Aqua)"
+	},
+	{
+		"ModelType": 1128,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Green)"
+	},
+	{
+		"ModelType": 1129,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Yellow)"
+	},
+	{
+		"ModelType": 1130,
+		"Name": "Azys Lla ADS (Cuboid - Silver - Orange)"
+	},
+	{
+		"ModelType": 1131,
+		"Name": "Azys Lla ADS (Cuboid - White - Red)"
+	},
+	{
+		"ModelType": 1132,
+		"Name": "Azys Lla ADS (Cuboid - White - White)"
+	},
+	{
+		"ModelType": 1133,
+		"Name": "Azys Lla ADS (Cuboid - White - Violet)"
+	},
+	{
+		"ModelType": 1134,
+		"Name": "Azys Lla ADS (Cuboid - White - Lavender)"
+	},
+	{
+		"ModelType": 1135,
+		"Name": "Azys Lla ADS (Cuboid - White - Aqua)"
+	},
+	{
+		"ModelType": 1136,
+		"Name": "Azys Lla ADS (Cuboid - White - Green)"
+	},
+	{
+		"ModelType": 1137,
+		"Name": "Azys Lla ADS (Cuboid - White - Yellow)"
+	},
+	{
+		"ModelType": 1138,
+		"Name": "Azys Lla ADS (Cuboid - White - Orange)"
+	},
+	{
+		"ModelType": 1139,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Red)"
+	},
+	{
+		"ModelType": 1140,
+		"Name": "Azys Lla ADS (Ovoid - Silver - White)"
+	},
+	{
+		"ModelType": 1141,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Violet)"
+	},
+	{
+		"ModelType": 1142,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Lavender)"
+	},
+	{
+		"ModelType": 1143,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Aqua)"
+	},
+	{
+		"ModelType": 1144,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Green)"
+	},
+	{
+		"ModelType": 1145,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Yellow)"
+	},
+	{
+		"ModelType": 1146,
+		"Name": "Azys Lla ADS (Ovoid - Silver - Orange)"
+	},
+	{
+		"ModelType": 1147,
+		"Name": "Azys Lla ADS (Ovoid - White - Red)"
+	},
+	{
+		"ModelType": 1148,
+		"Name": "Azys Lla ADS (Ovoid - White - White)"
+	},
+	{
+		"ModelType": 1149,
+		"Name": "Azys Lla ADS (Ovoid - White - Violet)"
+	},
+	{
+		"ModelType": 1150,
+		"Name": "Azys Lla ADS (Ovoid - White - Lavender)"
+	},
+	{
+		"ModelType": 1151,
+		"Name": "Azys Lla ADS (Ovoid - White - Aqua)"
+	},
+	{
+		"ModelType": 1152,
+		"Name": "Azys Lla ADS (Ovoid - White - Green)"
+	},
+	{
+		"ModelType": 1153,
+		"Name": "Azys Lla ADS (Ovoid - White - Yellow)"
+	},
+	{
+		"ModelType": 1154,
+		"Name": "Azys Lla ADS (Ovoid - White - Orange)"
+	},
+	{
+		"ModelType": 1155,
+		"Name": "Toco Toco"
+	},
+	{
+		"ModelType": 1156,
+		"Name": "Cathedral Gargoyle"
+	},
+	{
+		"ModelType": 1157,
+		"Name": "Sphinx"
+	},
+	{
+		"ModelType": 1158,
+		"Name": "Pterygotus"
+	},
+	{
+		"ModelType": 1159,
+		"Name": "Griffin B (Brown)"
+	},
+	{
+		"ModelType": 1160,
+		"Name": "Sanguiptere"
+	},
+	{
+		"ModelType": 1161,
+		"Name": "Sanuwa (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1162,
+		"Name": "Behemoth Heir",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1163,
+		"Name": "Accompanyment Node",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1164,
+		"Name": "Steam-powered Gobwalker G-VII",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1165,
+		"Name": "Wind-Up Iceheart",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1166,
+		"Name": "Wind-Up Gestahl",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1167,
+		"Name": "Wind-Up Yugiri",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1168,
+		"Name": "Emerald Carbuncle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1169,
+		"Name": "Bug minion with army hat"
+	},
+	{
+		"ModelType": 1170,
+		"Name": "Paissa Brat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1171,
+		"Name": "Wind-Up Illuminatus",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1172,
+		"Name": "Pumpkin Butler",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1173,
+		"Name": "Hunting Hawk",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1174,
+		"Name": "Shalloweye",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1175,
+		"Name": "Penguin Prince",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1176,
+		"Name": "Wind-Up Relm",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1181,
+		"Name": "Nunyenunc's Shadow"
+	},
+	{
+		"ModelType": 1182,
+		"Name": "Bit D (Black & Gold)"
+	},
+	{
+		"ModelType": 1183,
+		"Name": "Steam Bit B (Purple)"
+	},
+	{
+		"ModelType": 1184,
+		"Name": "Panther",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1185,
+		"Name": "Graoully"
+	},
+	{
+		"ModelType": 1186,
+		"Name": "Vidofnir"
+	},
+	{
+		"ModelType": 1187,
+		"Name": "Coeurlregina (Darkened)"
+	},
+	{
+		"ModelType": 1188,
+		"Name": "So'sanuwa"
+	},
+	{
+		"ModelType": 1189,
+		"Name": "Ul'sanuwa"
+	},
+	{
+		"ModelType": 1190,
+		"Name": "Ice Dragonet"
+	},
+	{
+		"ModelType": 1191,
+		"Name": "Moss Dragonet"
+	},
+	{
+		"ModelType": 1192,
+		"Name": "Dragon Statue (Aery)"
+	},
+	{
+		"ModelType": 1193,
+		"Name": "Crystals"
+	},
+	{
+		"ModelType": 1194,
+		"Name": "Drakespur"
+	},
+	{
+		"ModelType": 1195,
+		"Name": "Garuda's Plume (Many Feathers)"
+	},
+	{
+		"ModelType": 1196,
+		"Name": "Orb (Blue Fire)"
+	},
+	{
+		"ModelType": 1197,
+		"Name": "Orb (Green Wind)"
+	},
+	{
+		"ModelType": 1198,
+		"Name": "Orb (Red/Blue)"
+	},
+	{
+		"ModelType": 1199,
+		"Name": "Orb (Green Cloud)"
+	},
+	{
+		"ModelType": 1200,
+		"Name": "Orb (Fire)"
+	},
+	{
+		"ModelType": 1201,
+		"Name": "Circle (Vertical Purple Effect)"
+	},
+	{
+		"ModelType": 1202,
+		"Name": "Orb (Sky Blue)"
+	},
+	{
+		"ModelType": 1203,
+		"Name": "Orb (Golden Electricity)"
+	},
+	{
+		"ModelType": 1204,
+		"Name": "Orb (Bubble)"
+	},
+	{
+		"ModelType": 1205,
+		"Name": "Wind Circle"
+	},
+	{
+		"ModelType": 1206,
+		"Name": "Water Circle"
+	},
+	{
+		"ModelType": 1207,
+		"Name": "Landmine (Pulsing)"
+	},
+	{
+		"ModelType": 1208,
+		"Name": "Orb (Darkness)"
+	},
+	{
+		"ModelType": 1209,
+		"Name": "Gaius van Baelsar X Slash"
+	},
+	{
+		"ModelType": 1210,
+		"Name": "Elder Syricta"
+	},
+	{
+		"ModelType": 1211,
+		"Name": "Poroggo (+ Blue Hat)"
+	},
+	{
+		"ModelType": 1212,
+		"Name": "Gold Rush Minecart",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1213,
+		"Name": "Black Fat Cat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1214,
+		"Name": "Senmurv"
+	},
+	{
+		"ModelType": 1215,
+		"Name": "The Pale Rider"
+	},
+	{
+		"ModelType": 1216,
+		"Name": "Gandarewa"
+	},
+	{
+		"ModelType": 1217,
+		"Name": "Bird of Paradise"
+	},
+	{
+		"ModelType": 1218,
+		"Name": "Leucrotta"
+	},
+	{
+		"ModelType": 1219,
+		"Name": "Mirka"
+	},
+	{
+		"ModelType": 1220,
+		"Name": "Pylraster"
+	},
+	{
+		"ModelType": 1221,
+		"Name": "Bune"
+	},
+	{
+		"ModelType": 1222,
+		"Name": "Agathos"
+	},
+	{
+		"ModelType": 1223,
+		"Name": "Campacti"
+	},
+	{
+		"ModelType": 1224,
+		"Name": "Stench Blossom"
+	},
+	{
+		"ModelType": 1225,
+		"Name": "Alteci"
+	},
+	{
+		"ModelType": 1226,
+		"Name": "Thextera"
+	},
+	{
+		"ModelType": 1227,
+		"Name": "The Scarecrow"
+	},
+	{
+		"ModelType": 1228,
+		"Name": "Tonberry Marauder"
+	},
+	{
+		"ModelType": 1229,
+		"Name": "Gobtank G-IV"
+	},
+	{
+		"ModelType": 1230,
+		"Name": "Magic Broom 2",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1231,
+		"Name": "Flying Shark"
+	},
+	{
+		"ModelType": 1232,
+		"Name": "Sword"
+	},
+	{
+		"ModelType": 1234,
+		"Name": "Cuchulainn"
+	},
+	{
+		"ModelType": 1235,
+		"Name": "Drum Bit A (Red)"
+	},
+	{
+		"ModelType": 1236,
+		"Name": "Bit E (Blue & Orange)"
+	},
+	{
+		"ModelType": 1237,
+		"Name": "Field Generator A (Allagan)"
+	},
+	{
+		"ModelType": 1238,
+		"Name": "Vedrfolnir"
+	},
+	{
+		"ModelType": 1239,
+		"Name": "Boomtype Magitek Gobwalker G-VII"
+	},
+	{
+		"ModelType": 1240,
+		"Name": "Sentient Inkhorn 2 (Flightless)"
+	},
+	{
+		"ModelType": 1241,
+		"Name": "King Thordan (b)"
+	},
+	{
+		"ModelType": 1242,
+		"Name": "Knight of the Round"
+	},
+	{
+		"ModelType": 1243,
+		"Name": "Knight of the Round (2)"
+	},
+	{
+		"ModelType": 1244,
+		"Name": "Orb (Spinning Discs?)"
+	},
+	{
+		"ModelType": 1245,
+		"Name": "Cone (Spinning Discs?)"
+	},
+	{
+		"ModelType": 1246,
+		"Name": "Orb (White / Five Heade Dragon?)"
+	},
+	{
+		"ModelType": 1249,
+		"Name": "Twintania (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1250,
+		"Name": "Knight of the Round (b)"
+	},
+	{
+		"ModelType": 1251,
+		"Name": "Wyvern"
+	},
+	{
+		"ModelType": 1252,
+		"Name": "Thunder Dragon (b)"
+	},
+	{
+		"ModelType": 1253,
+		"Name": "Moss Dragon (b)"
+	},
+	{
+		"ModelType": 1254,
+		"Name": "Ice Dragon (b)"
+	},
+	{
+		"ModelType": 1255,
+		"Name": "Fire Dragon (b)"
+	},
+	{
+		"ModelType": 1256,
+		"Name": "Zombie Dragon (b)"
+	},
+	{
+		"ModelType": 1257,
+		"Name": "Vidofnir (b)"
+	},
+	{
+		"ModelType": 1258,
+		"Name": "Flying Thunder Dragon (b)"
+	},
+	{
+		"ModelType": 1259,
+		"Name": "Flying Moss Dragon (b)"
+	},
+	{
+		"ModelType": 1260,
+		"Name": "Flying Ice Dragon (b)"
+	},
+	{
+		"ModelType": 1261,
+		"Name": "Flying Fire Dragon (b)"
+	},
+	{
+		"ModelType": 1262,
+		"Name": "Flying Zombie Dragon (Grounded)"
+	},
+	{
+		"ModelType": 1263,
+		"Name": "Ice Dragonet (b)"
+	},
+	{
+		"ModelType": 1264,
+		"Name": "Midgardsormr (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1265,
+		"Name": "Generic Person"
+	},
+	{
+		"ModelType": 1266,
+		"Name": "Fallen Debris (Dusk Vigil)"
+	},
+	{
+		"ModelType": 1267,
+		"Name": "Fallen Debris (Dusk Vigil)"
+	},
+	{
+		"ModelType": 1268,
+		"Name": "Fallen Debris (Dusk Vigil)"
+	},
+	{
+		"ModelType": 1269,
+		"Name": "Purple Wyrm with pink eyes"
+	},
+	{
+		"ModelType": 1270,
+		"Name": "Belladonna"
+	},
+	{
+		"ModelType": 1271,
+		"Name": "Hybodus"
+	},
+	{
+		"ModelType": 1272,
+		"Name": "Echidna"
+	},
+	{
+		"ModelType": 1273,
+		"Name": "Blackguard"
+	},
+	{
+		"ModelType": 1274,
+		"Name": "Queen Hawk"
+	},
+	{
+		"ModelType": 1275,
+		"Name": "Sawtooth"
+	},
+	{
+		"ModelType": 1276,
+		"Name": "Hellhound"
+	},
+	{
+		"ModelType": 1277,
+		"Name": "Darkscale"
+	},
+	{
+		"ModelType": 1278,
+		"Name": "Flying Graoully"
+	},
+	{
+		"ModelType": 1279,
+		"Name": "Manipulator (Four Short Legs)"
+	},
+	{
+		"ModelType": 1280,
+		"Name": "Shiva (Sword)"
+	},
+	{
+		"ModelType": 1281,
+		"Name": "Rose Garden"
+	},
+	{
+		"ModelType": 1283,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1288,
+		"Name": "Holder with 3 banners in it"
+	},
+	{
+		"ModelType": 1289,
+		"Name": "Banner"
+	},
+	{
+		"ModelType": 1290,
+		"Name": "Glowing Purple Crystal"
+	},
+	{
+		"ModelType": 1291,
+		"Name": "Bird's Nest / Rosebear"
+	},
+	{
+		"ModelType": 1292,
+		"Name": "Brown drawer"
+	},
+	{
+		"ModelType": 1293,
+		"Name": "Living Rock"
+	},
+	{
+		"ModelType": 1294,
+		"Name": "Living Rock (II) (Copy)"
+	},
+	{
+		"ModelType": 1295,
+		"Name": "Poroggo C (Purple w/ Blue Hat)"
+	},
+	{
+		"ModelType": 1296,
+		"Name": "Vodoriga (II) (Slightly Lighter Copy)"
+	},
+	{
+		"ModelType": 1297,
+		"Name": "Grizzly Host"
+	},
+	{
+		"ModelType": 1298,
+		"Name": "Progenitrix"
+	},
+	{
+		"ModelType": 1299,
+		"Name": "Progenitor"
+	},
+	{
+		"ModelType": 1300,
+		"Name": "Water Tornado (Neverreap? Alexander?)"
+	},
+	{
+		"ModelType": 1301,
+		"Name": "Biloko"
+	},
+	{
+		"ModelType": 1302,
+		"Name": "Triceratops"
+	},
+	{
+		"ModelType": 1303,
+		"Name": "Brachiosaur"
+	},
+	{
+		"ModelType": 1304,
+		"Name": "Construct 8"
+	},
+	{
+		"ModelType": 1305,
+		"Name": "Ligeia"
+	},
+	{
+		"ModelType": 1306,
+		"Name": "Meracydian Falak"
+	},
+	{
+		"ModelType": 1307,
+		"Name": "Falak (II) (Copy)"
+	},
+	{
+		"ModelType": 1308,
+		"Name": "Grey Bomb"
+	},
+	{
+		"ModelType": 1309,
+		"Name": "Remedy Bomb"
+	},
+	{
+		"ModelType": 1310,
+		"Name": "Diplocaulus"
+	},
+	{
+		"ModelType": 1311,
+		"Name": "Foobar"
+	},
+	{
+		"ModelType": 1312,
+		"Name": "Dexter (Mob-Left Frill)"
+	},
+	{
+		"ModelType": 1313,
+		"Name": "Bismarck (Broken Chitin)"
+	},
+	{
+		"ModelType": 1314,
+		"Name": "Gana C (Purple/Yellow)"
+	},
+	{
+		"ModelType": 1315,
+		"Name": "Korpokkur"
+	},
+	{
+		"ModelType": 1316,
+		"Name": "FFXI Beetle"
+	},
+	{
+		"ModelType": 1317,
+		"Name": "Ghrah Lumiary (Sphere)"
+	},
+	{
+		"ModelType": 1318,
+		"Name": "Wind-Up Ifrit",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1319,
+		"Name": "Clockwork Twintania",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1320,
+		"Name": "Korpokkur Kid",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1321,
+		"Name": "Wind-Up Firion",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1322,
+		"Name": "Wind-Up Echidna",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1323,
+		"Name": "Barghest"
+	},
+	{
+		"ModelType": 1324,
+		"Name": "Plague Purge"
+	},
+	{
+		"ModelType": 1326,
+		"Name": "Witch's Broom",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1327,
+		"Name": "Ascian Prime (Not Glowing)"
+	},
+	{
+		"ModelType": 1328,
+		"Name": "Sinister (Mob-Right Frill)"
+	},
+	{
+		"ModelType": 1330,
+		"Name": "Wind up Garuda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1331,
+		"Name": "Wind up Titan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1332,
+		"Name": "Midgardsormr",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1333,
+		"Name": "Wind up Yshtola",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1334,
+		"Name": "Wind-Up Haurchefant",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1335,
+		"Name": "Wind-Up Nero",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1336,
+		"Name": "Wind-Up Krile",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1337,
+		"Name": "Little bird",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1338,
+		"Name": "Pteranodon"
+	},
+	{
+		"ModelType": 1339,
+		"Name": "Irminsul (Small)"
+	},
+	{
+		"ModelType": 1340,
+		"Name": "Irminsul (Large)"
+	},
+	{
+		"ModelType": 1341,
+		"Name": "Sawbones (Head Vine)"
+	},
+	{
+		"ModelType": 1342,
+		"Name": "Echidna (Lamia)"
+	},
+	{
+		"ModelType": 1343,
+		"Name": "Army hat bug",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1344,
+		"Name": "Boomtype Magitek Gobwalker G-VII (b)"
+	},
+	{
+		"ModelType": 1345,
+		"Name": "Sephirot"
+	},
+	{
+		"ModelType": 1346,
+		"Name": "Cetus"
+	},
+	{
+		"ModelType": 1347,
+		"Name": "Corruption (Sphere)"
+	},
+	{
+		"ModelType": 1348,
+		"Name": "Corruption (Doll)"
+	},
+	{
+		"ModelType": 1349,
+		"Name": "Corruption (Vulture)"
+	},
+	{
+		"ModelType": 1350,
+		"Name": "Corruption (Spider)"
+	},
+	{
+		"ModelType": 1351,
+		"Name": "Diabolos (b)"
+	},
+	{
+		"ModelType": 1352,
+		"Name": "Onslaughter (Alexander)"
+	},
+	{
+		"ModelType": 1353,
+		"Name": "Blaster (Alexander)"
+	},
+	{
+		"ModelType": 1354,
+		"Name": "Vortexer (Alexander)"
+	},
+	{
+		"ModelType": 1355,
+		"Name": "Swindler (Alexander)"
+	},
+	{
+		"ModelType": 1356,
+		"Name": "Brawler (Alexander)"
+	},
+	{
+		"ModelType": 1357,
+		"Name": "Brute Justice?"
+	},
+	{
+		"ModelType": 1358,
+		"Name": "Glowing Brute Justice?"
+	},
+	{
+		"ModelType": 1359,
+		"Name": "Void Ark Scrap"
+	},
+	{
+		"ModelType": 1360,
+		"Name": "The Pagan's Knot"
+	},
+	{
+		"ModelType": 1361,
+		"Name": "Pharos HM Generator"
+	},
+	{
+		"ModelType": 1362,
+		"Name": "Rose Hip"
+	},
+	{
+		"ModelType": 1363,
+		"Name": "Hunched Goblin"
+	},
+	{
+		"ModelType": 1364,
+		"Name": "Weird flying bug"
+	},
+	{
+		"ModelType": 1365,
+		"Name": "Scary Floating Demon"
+	},
+	{
+		"ModelType": 1366,
+		"Name": "Piloted Sky Armor"
+	},
+	{
+		"ModelType": 1367,
+		"Name": "Rose Bud"
+	},
+	{
+		"ModelType": 1368,
+		"Name": "Bomb Incubator (Blue)"
+	},
+	{
+		"ModelType": 1369,
+		"Name": "Ghrah Lumiary (Doll)"
+	},
+	{
+		"ModelType": 1371,
+		"Name": "Spider"
+	},
+	{
+		"ModelType": 1372,
+		"Name": "Orb (Red/Black)"
+	},
+	{
+		"ModelType": 1373,
+		"Name": "Orb (Gold)"
+	},
+	{
+		"ModelType": 1374,
+		"Name": "Gyretower"
+	},
+	{
+		"ModelType": 1375,
+		"Name": "Calcabrina"
+	},
+	{
+		"ModelType": 1376,
+		"Name": "Calca"
+	},
+	{
+		"ModelType": 1377,
+		"Name": "Brina"
+	},
+	{
+		"ModelType": 1378,
+		"Name": "Bloated Bulb"
+	},
+	{
+		"ModelType": 1379,
+		"Name": "Manacutter (Silver)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1380,
+		"Name": "Manacutter (Black)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1381,
+		"Name": "Knight Hawk"
+	},
+	{
+		"ModelType": 1382,
+		"Name": "Sephirot (different form)"
+	},
+	{
+		"ModelType": 1385,
+		"Name": "Tiny eye"
+	},
+	{
+		"ModelType": 1386,
+		"Name": "Little monkey",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1387,
+		"Name": "Dwarf rabbit",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1388,
+		"Name": "Giraffe",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1390,
+		"Name": "Jibanyan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1391,
+		"Name": "Komasan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1392,
+		"Name": "Whisper",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1393,
+		"Name": "Blizzaria",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1394,
+		"Name": "Kyuubi",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1395,
+		"Name": "Komajiro",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1396,
+		"Name": "Manjimutt",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1397,
+		"Name": "Noko",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1398,
+		"Name": "Venoct",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1399,
+		"Name": "Shogunyan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1400,
+		"Name": "Hovernyan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1401,
+		"Name": "Robonyan F-Type",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1402,
+		"Name": "USApyon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1403,
+		"Name": "Valkyrie boss from Amdapor"
+	},
+	{
+		"ModelType": 1404,
+		"Name": "Magitek Hexadrone"
+	},
+	{
+		"ModelType": 1405,
+		"Name": "Flying bug from Amdapor"
+	},
+	{
+		"ModelType": 1406,
+		"Name": "Nidhogg (Both Eyes / No Scars)"
+	},
+	{
+		"ModelType": 1407,
+		"Name": "Elemental F (White)"
+	},
+	{
+		"ModelType": 1408,
+		"Name": "Animus Elemental"
+	},
+	{
+		"ModelType": 1409,
+		"Name": "Second boss from Amdapor Hard"
+	},
+	{
+		"ModelType": 1410,
+		"Name": "The Strongman (Heavensturn 2016)"
+	},
+	{
+		"ModelType": 1411,
+		"Name": "Kongamato",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1412,
+		"Name": "Wyvern (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1413,
+		"Name": "Magitek Reaper (Glowing)"
+	},
+	{
+		"ModelType": 1414,
+		"Name": "Gobblydegroper (Alexander 8 Add)"
+	},
+	{
+		"ModelType": 1415,
+		"Name": "Ark Ked"
+	},
+	{
+		"ModelType": 1416,
+		"Name": "Soldier Hawk"
+	},
+	{
+		"ModelType": 1417,
+		"Name": "Incinerator (Alexander 11 Trash)"
+	},
+	{
+		"ModelType": 1418,
+		"Name": "Monk Chimera"
+	},
+	{
+		"ModelType": 1419,
+		"Name": "Spiked Monk Chimera"
+	},
+	{
+		"ModelType": 1420,
+		"Name": "Forgotten Wisent"
+	},
+	{
+		"ModelType": 1421,
+		"Name": "Charybterix"
+	},
+	{
+		"ModelType": 1422,
+		"Name": "Trained Sanuwa"
+	},
+	{
+		"ModelType": 1423,
+		"Name": "Wind-Up Zundu Warrior",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1424,
+		"Name": "Okeanis F (Purple)"
+	},
+	{
+		"ModelType": 1425,
+		"Name": "Spinnning Wheel  with spikes in the middle"
+	},
+	{
+		"ModelType": 1426,
+		"Name": "Spriggan (w/ huge rock)"
+	},
+	{
+		"ModelType": 1427,
+		"Name": "Enraged Marid"
+	},
+	{
+		"ModelType": 1428,
+		"Name": "Groundskeeper C (Purple)"
+	},
+	{
+		"ModelType": 1429,
+		"Name": "Skatene B (White)"
+	},
+	{
+		"ModelType": 1430,
+		"Name": "Sephirot-Egi"
+	},
+	{
+		"ModelType": 1431,
+		"Name": "Mammet - PVP"
+	},
+	{
+		"ModelType": 1432,
+		"Name": "Wind Elemental"
+	},
+	{
+		"ModelType": 1433,
+		"Name": "Tornado with leaves"
+	},
+	{
+		"ModelType": 1434,
+		"Name": "Anima",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1435,
+		"Name": "Glowing Anima",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1436,
+		"Name": "Byakko (Beast Form)"
+	},
+	{
+		"ModelType": 1437,
+		"Name": "Byakko (Beast Form - Enraged)"
+	},
+	{
+		"ModelType": 1438,
+		"Name": "Sabertooth tiger"
+	},
+	{
+		"ModelType": 1439,
+		"Name": "Vanara"
+	},
+	{
+		"ModelType": 1443,
+		"Name": "Enormous Black Boulder/Ball"
+	},
+	{
+		"ModelType": 1444,
+		"Name": "Gloria-class Airship",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1445,
+		"Name": "Zuro Roggo (Antitower Boss 1)"
+	},
+	{
+		"ModelType": 1446,
+		"Name": "Zu (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1447,
+		"Name": "Bennu (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1448,
+		"Name": "Floating pink and red hearts"
+	},
+	{
+		"ModelType": 1449,
+		"Name": "Magic Pot from FFXI"
+	},
+	{
+		"ModelType": 1450,
+		"Name": "Weird floating meteorite"
+	},
+	{
+		"ModelType": 1451,
+		"Name": "Magic Doll from sky in FFXI"
+	},
+	{
+		"ModelType": 1452,
+		"Name": "Pink orb with floating pink diamonds"
+	},
+	{
+		"ModelType": 1453,
+		"Name": "Wind tornado"
+	},
+	{
+		"ModelType": 1454,
+		"Name": "Floating black void with purple glow"
+	},
+	{
+		"ModelType": 1455,
+		"Name": "Sasquatch (Hullbreaker Isle Boss 1)"
+	},
+	{
+		"ModelType": 1456,
+		"Name": "Tuco Tuco"
+	},
+	{
+		"ModelType": 1457,
+		"Name": "Zurvan Add"
+	},
+	{
+		"ModelType": 1458,
+		"Name": "Faust",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1459,
+		"Name": "Morpho",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1461,
+		"Name": "Calca",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1462,
+		"Name": "Brina",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1463,
+		"Name": "Dragonet",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1464,
+		"Name": "Lucky Bucket",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1465,
+		"Name": "Piggy",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1466,
+		"Name": "Poroggo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1467,
+		"Name": "Fenrir",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1468,
+		"Name": "Cheerleader",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1469,
+		"Name": "Calamari",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1470,
+		"Name": "Brachiosaur",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1471,
+		"Name": "Blaster Clone (Alexander)"
+	},
+	{
+		"ModelType": 1472,
+		"Name": "Black Pegasus",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1473,
+		"Name": "Minotaur"
+	},
+	{
+		"ModelType": 1474,
+		"Name": "Minotaur (Mottled - Red)"
+	},
+	{
+		"ModelType": 1475,
+		"Name": "Large Egg (White)"
+	},
+	{
+		"ModelType": 1476,
+		"Name": "Astrope",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1477,
+		"Name": "Sephirot (Pre-Fight Cutscene)"
+	},
+	{
+		"ModelType": 1478,
+		"Name": "Vanara of Biting Cold"
+	},
+	{
+		"ModelType": 1479,
+		"Name": "Vanara of Resonating Thunder"
+	},
+	{
+		"ModelType": 1480,
+		"Name": "Ozma Phase One"
+	},
+	{
+		"ModelType": 1481,
+		"Name": "Ozma Phase Two"
+	},
+	{
+		"ModelType": 1482,
+		"Name": "Crimson Morpho"
+	},
+	{
+		"ModelType": 1483,
+		"Name": "Moon Gana"
+	},
+	{
+		"ModelType": 1484,
+		"Name": "Edward FF4 Minion?"
+	},
+	{
+		"ModelType": 1486,
+		"Name": "Vath Warlord"
+	},
+	{
+		"ModelType": 1487,
+		"Name": "Raubahn Sword on the ground"
+	},
+	{
+		"ModelType": 1488,
+		"Name": "Calistoferi"
+	},
+	{
+		"ModelType": 1489,
+		"Name": "Green Caterpillar"
+	},
+	{
+		"ModelType": 1490,
+		"Name": "Hraesvelgr"
+	},
+	{
+		"ModelType": 1491,
+		"Name": "Arachne Eve"
+	},
+	{
+		"ModelType": 1492,
+		"Name": "Blaster (Alexander) "
+	},
+	{
+		"ModelType": 1493,
+		"Name": "Vortexer (Alexander)"
+	},
+	{
+		"ModelType": 1494,
+		"Name": "Swindler (Alexander)"
+	},
+	{
+		"ModelType": 1495,
+		"Name": "Brawler (Alexander)"
+	},
+	{
+		"ModelType": 1496,
+		"Name": "Siege Breaker (Doma Castle 1st Boss)"
+	},
+	{
+		"ModelType": 1498,
+		"Name": "Forgall"
+	},
+	{
+		"ModelType": 1499,
+		"Name": "Black Cat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1501,
+		"Name": "Small Glowing Orb with Music Note in it"
+	},
+	{
+		"ModelType": 1502,
+		"Name": "Striking Dummy"
+	},
+	{
+		"ModelType": 1503,
+		"Name": "Edda"
+	},
+	{
+		"ModelType": 1504,
+		"Name": "Revenant (Grey)"
+	},
+	{
+		"ModelType": 1505,
+		"Name": "Nimbus Cloud",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1506,
+		"Name": "Glowing Orb"
+	},
+	{
+		"ModelType": 1507,
+		"Name": "Whelk from FF6 - Purple"
+	},
+	{
+		"ModelType": 1508,
+		"Name": "Whelk from FF6 - Grey"
+	},
+	{
+		"ModelType": 1509,
+		"Name": "Sarchosurcus"
+	},
+	{
+		"ModelType": 1510,
+		"Name": "Dragon (Zombie)"
+	},
+	{
+		"ModelType": 1511,
+		"Name": "Lanner (Bismarck)"
+	},
+	{
+		"ModelType": 1512,
+		"Name": "Lanner (Ravana)"
+	},
+	{
+		"ModelType": 1513,
+		"Name": "Lanner (Thordan)"
+	},
+	{
+		"ModelType": 1514,
+		"Name": "Lanner (Sephirot)"
+	},
+	{
+		"ModelType": 1515,
+		"Name": "Cloud Mallow",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1516,
+		"Name": "Brute Justice"
+	},
+	{
+		"ModelType": 1517,
+		"Name": "Creepy Black Mage"
+	},
+	{
+		"ModelType": 1518,
+		"Name": "Creepy White Mage"
+	},
+	{
+		"ModelType": 1519,
+		"Name": "Groundskeeper A"
+	},
+	{
+		"ModelType": 1520,
+		"Name": "Original Fat Chocobo",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1521,
+		"Name": "Ahriman (Purple)"
+	},
+	{
+		"ModelType": 1522,
+		"Name": "Sea Monk (Spiked - Blue)"
+	},
+	{
+		"ModelType": 1523,
+		"Name": "Striking Dummy (Special)"
+	},
+	{
+		"ModelType": 1524,
+		"Name": "Dragonet (Silver Blue - Dragoon Questline NPC)"
+	},
+	{
+		"ModelType": 1525,
+		"Name": "Gryphon (Irisdescent Blue-Green)"
+	},
+	{
+		"ModelType": 1526,
+		"Name": "Blue treasure chest"
+	},
+	{
+		"ModelType": 1527,
+		"Name": "Red treasure chest"
+	},
+	{
+		"ModelType": 1528,
+		"Name": "Fan Construct"
+	},
+	{
+		"ModelType": 1529,
+		"Name": "Atomos (Silver)"
+	},
+	{
+		"ModelType": 1530,
+		"Name": "Bird of Paradise (Rainbow)"
+	},
+	{
+		"ModelType": 1531,
+		"Name": "Estinien (Nidhogg Fusion)"
+	},
+	{
+		"ModelType": 1532,
+		"Name": "Fat Moogle",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1533,
+		"Name": "Nidhogg Phase 3"
+	},
+	{
+		"ModelType": 1534,
+		"Name": "Whisper-go",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1535,
+		"Name": "The Epigraph (Weeping City Mid-Boss)"
+	},
+	{
+		"ModelType": 1536,
+		"Name": "Sophia"
+	},
+	{
+		"ModelType": 1537,
+		"Name": "Sophia's Head"
+	},
+	{
+		"ModelType": 1538,
+		"Name": "Sarcophagus of the Demon Queen: Scathach"
+	},
+	{
+		"ModelType": 1539,
+		"Name": "Zurvan"
+	},
+	{
+		"ModelType": 1541,
+		"Name": "Diremite (Green-Yellow)"
+	},
+	{
+		"ModelType": 1542,
+		"Name": "Spider Mite (Green-Yellow)"
+	},
+	{
+		"ModelType": 1543,
+		"Name": "Spider Mite (Yellow-Brown)"
+	},
+	{
+		"ModelType": 1544,
+		"Name": "Wind-Up Ramuh",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1545,
+		"Name": "Wind-Up Shiva",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1546,
+		"Name": "Callistoferi",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1547,
+		"Name": "Wind-Up Aymeric",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1548,
+		"Name": "Asian Moogle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1549,
+		"Name": "Lamia-Dalvag-Parthenope"
+	},
+	{
+		"ModelType": 1550,
+		"Name": "Lamia-Dalvag-Parthenope"
+	},
+	{
+		"ModelType": 1551,
+		"Name": "Lamia-Dalvag-Parthenope"
+	},
+	{
+		"ModelType": 1552,
+		"Name": "Ancient Wyvern (Iridescent Blue)"
+	},
+	{
+		"ModelType": 1553,
+		"Name": "Dragon (Shadow)"
+	},
+	{
+		"ModelType": 1554,
+		"Name": "Ancient Wyvern (Deep White)"
+	},
+	{
+		"ModelType": 1555,
+		"Name": "Nidhogg"
+	},
+	{
+		"ModelType": 1556,
+		"Name": "Nidhogg Phase 2 or 3?"
+	},
+	{
+		"ModelType": 1557,
+		"Name": "Hraesvelgr again"
+	},
+	{
+		"ModelType": 1558,
+		"Name": "Another Hraesvelgr"
+	},
+	{
+		"ModelType": 1559,
+		"Name": "Hraesvelgr with eyes closed"
+	},
+	{
+		"ModelType": 1560,
+		"Name": "Hraesvelgr with one eye open"
+	},
+	{
+		"ModelType": 1561,
+		"Name": "Tiger (Spirit - Blue)"
+	},
+	{
+		"ModelType": 1562,
+		"Name": "Dangerous Boquet"
+	},
+	{
+		"ModelType": 1563,
+		"Name": "A barrel"
+	},
+	{
+		"ModelType": 1564,
+		"Name": "Calofisteri Spine [SKL]"
+	},
+	{
+		"ModelType": 1565,
+		"Name": "Calofisteri's Hair Attack"
+	},
+	{
+		"ModelType": 1566,
+		"Name": "Giant Neon Tentacle"
+	},
+	{
+		"ModelType": 1567,
+		"Name": "Giant Neon Tentacle - 2nd form"
+	},
+	{
+		"ModelType": 1568,
+		"Name": "Giant Neon vore plant"
+	},
+	{
+		"ModelType": 1569,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1570,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1571,
+		"Name": "Floating ball of ice"
+	},
+	{
+		"ModelType": 1572,
+		"Name": "Thundercloud"
+	},
+	{
+		"ModelType": 1573,
+		"Name": "Floating orb of ice"
+	},
+	{
+		"ModelType": 1574,
+		"Name": "Flame Sergeant Dalvag"
+	},
+	{
+		"ModelType": 1575,
+		"Name": "Flame Sergeant Dalvag lookalike without the glowing eyes"
+	},
+	{
+		"ModelType": 1577,
+		"Name": "Parthenope"
+	},
+	{
+		"ModelType": 1578,
+		"Name": "Bijou (Calofisteri Add)"
+	},
+	{
+		"ModelType": 1579,
+		"Name": "Wyvern (White) [Locked]"
+	},
+	{
+		"ModelType": 1580,
+		"Name": "Lanner (Nidhogg)"
+	},
+	{
+		"ModelType": 1581,
+		"Name": "Gaol (Ozma)"
+	},
+	{
+		"ModelType": 1582,
+		"Name": "Tozol Huatotl (Xelphatol Final Boss)"
+	},
+	{
+		"ModelType": 1583,
+		"Name": "Alexander Prime"
+	},
+	{
+		"ModelType": 1584,
+		"Name": "Diloc Ciluoc (Xelphatol 1st Boss)"
+	},
+	{
+		"ModelType": 1585,
+		"Name": "Goten (T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1586,
+		"Name": "Ginga (T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1587,
+		"Name": "Raigo (T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1588,
+		"Name": "Nidhogg (Spirit)"
+	},
+	{
+		"ModelType": 1589,
+		"Name": "Dragonet (Blue/White)"
+	},
+	{
+		"ModelType": 1590,
+		"Name": "Callistoferi again"
+	},
+	{
+		"ModelType": 1591,
+		"Name": "Callistoferi yet again"
+	},
+	{
+		"ModelType": 1592,
+		"Name": "Strix (Gubal HM Final Boss)"
+	},
+	{
+		"ModelType": 1593,
+		"Name": "Mystic Panda",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1599,
+		"Name": "Revenant (Red)"
+	},
+	{
+		"ModelType": 1600,
+		"Name": "Fancy glowing blue spear/pole"
+	},
+	{
+		"ModelType": 1601,
+		"Name": "Fancy giant red sword buried in the ground"
+	},
+	{
+		"ModelType": 1602,
+		"Name": "Dragon's Head (Shinryu Add)"
+	},
+	{
+		"ModelType": 1603,
+		"Name": "Demon Tome (Gubal 1st Boss)"
+	},
+	{
+		"ModelType": 1604,
+		"Name": "Zu Pullet"
+	},
+	{
+		"ModelType": 1605,
+		"Name": "Cruise Chaser"
+	},
+	{
+		"ModelType": 1606,
+		"Name": "Cruise Chaser again"
+	},
+	{
+		"ModelType": 1607,
+		"Name": "A silhouette of Sophia"
+	},
+	{
+		"ModelType": 1608,
+		"Name": "Tsanahale (Green/Pink)"
+	},
+	{
+		"ModelType": 1609,
+		"Name": "Demon of the Tome (Unbound - Gubal HM 1st Boss)"
+	},
+	{
+		"ModelType": 1610,
+		"Name": "Eradicator (Alex 11 Trash)"
+	},
+	{
+		"ModelType": 1611,
+		"Name": "Wind-Up Yuna",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1612,
+		"Name": "Wind-Up Rikku",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1613,
+		"Name": "Wind-Up Lulu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1614,
+		"Name": "Namingway",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1615,
+		"Name": "Shaggy Shoat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1616,
+		"Name": "Wind-Up Thancred",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1617,
+		"Name": "Wind-Up Alisaie",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1618,
+		"Name": "Wind-Up Alexander",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1619,
+		"Name": "Kum Kum (Syrcus Tower Amon Adds)"
+	},
+	{
+		"ModelType": 1620,
+		"Name": "Pudding (Oil)"
+	},
+	{
+		"ModelType": 1621,
+		"Name": "Hraesvalgr (Spirit)"
+	},
+	{
+		"ModelType": 1622,
+		"Name": "Glowing Toxic Neon Green Orb"
+	},
+	{
+		"ModelType": 1623,
+		"Name": "Flaming Orb"
+	},
+	{
+		"ModelType": 1624,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1626,
+		"Name": "Wind-Up Edda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1627,
+		"Name": "3 Rocks"
+	},
+	{
+		"ModelType": 1628,
+		"Name": "Balloon Turret (Xelphatol Diloc Add)"
+	},
+	{
+		"ModelType": 1629,
+		"Name": "Managarm",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1630,
+		"Name": "Sahagin (EQ)"
+	},
+	{
+		"ModelType": 1631,
+		"Name": "Minotaur"
+	},
+	{
+		"ModelType": 1632,
+		"Name": "Naked Yumemi"
+	},
+	{
+		"ModelType": 1633,
+		"Name": "Cruise Seeker (Cruise Chaser Add)"
+	},
+	{
+		"ModelType": 1634,
+		"Name": "Skystone (Xelphatol Diloc Add)"
+	},
+	{
+		"ModelType": 1635,
+		"Name": "Disembodied Head",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1636,
+		"Name": "Glowing sky blue Allagan orb"
+	},
+	{
+		"ModelType": 1637,
+		"Name": "Refurbisher (Alexander)"
+	},
+	{
+		"ModelType": 1638,
+		"Name": "Gobbie (EQ)"
+	},
+	{
+		"ModelType": 1639,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 1640,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 1641,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 1642,
+		"Name": "Sahagin (EQ)"
+	},
+	{
+		"ModelType": 1643,
+		"Name": "Ugly Red Demon"
+	},
+	{
+		"ModelType": 1644,
+		"Name": "Succubus (EQ)"
+	},
+	{
+		"ModelType": 1646,
+		"Name": "Whisper A-go-go",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1647,
+		"Name": "Nidhogg (Fused with Estinien) 2"
+	},
+	{
+		"ModelType": 1648,
+		"Name": "Little Midgardsormr",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1649,
+		"Name": "Coincounter Primus (Aquapolis Final Boss)"
+	},
+	{
+		"ModelType": 1650,
+		"Name": "Unicolt",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1651,
+		"Name": "Wind-Up Moenbryda",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1652,
+		"Name": "T-pose Default Model"
+	},
+	{
+		"ModelType": 1653,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1654,
+		"Name": "Magitek Killer Mantis"
+	},
+	{
+		"ModelType": 1656,
+		"Name": "Gobbie (EQ)"
+	},
+	{
+		"ModelType": 1657,
+		"Name": "Orange Kappa"
+	},
+	{
+		"ModelType": 1658,
+		"Name": "Starlight Bear",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1659,
+		"Name": "Frog"
+	},
+	{
+		"ModelType": 1660,
+		"Name": "Green Kappa"
+	},
+	{
+		"ModelType": 1663,
+		"Name": "Ixal (EQ)"
+	},
+	{
+		"ModelType": 1664,
+		"Name": "Liquid Flame (Humanoid Form)"
+	},
+	{
+		"ModelType": 1665,
+		"Name": "Liquid Flame (Hand Form)"
+	},
+	{
+		"ModelType": 1666,
+		"Name": "Liquid Flame (PIllar Form)"
+	},
+	{
+		"ModelType": 1667,
+		"Name": "Allagan Drone (Ant)"
+	},
+	{
+		"ModelType": 1668,
+		"Name": "Nybeth Obdilord"
+	},
+	{
+		"ModelType": 1669,
+		"Name": "Magitek Predator (w/ Pilot)"
+	},
+	{
+		"ModelType": 1670,
+		"Name": "Gobroller Mk. VI (Alexander 7)"
+	},
+	{
+		"ModelType": 1671,
+		"Name": "A floating multicolored crystal"
+	},
+	{
+		"ModelType": 1672,
+		"Name": "Crystal-Powered Laser Cannon"
+	},
+	{
+		"ModelType": 1673,
+		"Name": "Exploding Fat Cannister (Alexander 11 Adds)"
+	},
+	{
+		"ModelType": 1674,
+		"Name": "Susanoo"
+	},
+	{
+		"ModelType": 1675,
+		"Name": "Lakshmi"
+	},
+	{
+		"ModelType": 1676,
+		"Name": "Syldra",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1677,
+		"Name": "Palace of the Dead - Kuribu (Pomander of Resolution)"
+	},
+	{
+		"ModelType": 1678,
+		"Name": "Gaol (Obsidian)"
+	},
+	{
+		"ModelType": 1679,
+		"Name": "Armored Weapon (Magitek Laser Thing)"
+	},
+	{
+		"ModelType": 1680,
+		"Name": "Amikiri (Shisui of the Violet Tides 1st Boss)"
+	},
+	{
+		"ModelType": 1681,
+		"Name": "Gowrow (Sohm Al HM 2nd Boss)"
+	},
+	{
+		"ModelType": 1682,
+		"Name": "Tatsunoko (Blue/Purple)"
+	},
+	{
+		"ModelType": 1683,
+		"Name": "Bombfish"
+	},
+	{
+		"ModelType": 1684,
+		"Name": "Yak Ram Thing"
+	},
+	{
+		"ModelType": 1685,
+		"Name": "A giant tornado"
+	},
+	{
+		"ModelType": 1686,
+		"Name": "Ozma (Shade Form - Adds Sub-boss)"
+	},
+	{
+		"ModelType": 1687,
+		"Name": "Floating Glowing White Staff"
+	},
+	{
+		"ModelType": 1688,
+		"Name": "Christmas Paissa"
+	},
+	{
+		"ModelType": 1689,
+		"Name": "Scathach"
+	},
+	{
+		"ModelType": 1690,
+		"Name": "Bulldog Pup",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1691,
+		"Name": "Cupid (Minion) From valentines day event"
+	},
+	{
+		"ModelType": 1692,
+		"Name": "Wind-Up Bartz",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1693,
+		"Name": "Wind-Up Kain",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1694,
+		"Name": "Hraesvelgr artbook",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1695,
+		"Name": "Gigi",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1696,
+		"Name": "Castaway Chick",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1697,
+		"Name": "Anima",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1698,
+		"Name": "Wind-Up Red Mage",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1699,
+		"Name": "Blue Kojin (EQ - Headless)"
+	},
+	{
+		"ModelType": 1700,
+		"Name": "Sophia (without head)"
+	},
+	{
+		"ModelType": 1701,
+		"Name": "Sophia (second form)"
+	},
+	{
+		"ModelType": 1702,
+		"Name": "Sophia's glowing scales"
+	},
+	{
+		"ModelType": 1703,
+		"Name": "Arrhidaeus' Lanner (Alexander Prime Add)"
+	},
+	{
+		"ModelType": 1704,
+		"Name": "Arrhidaeus' Lanner (Winged - Alexander Prime Add)"
+	},
+	{
+		"ModelType": 1705,
+		"Name": "Arrhidaeus' Lanner (Clock - Alexander Prime Add)"
+	},
+	{
+		"ModelType": 1706,
+		"Name": "Arrhidaeus' Lanner (Guns - Alexander Prime Add)"
+	},
+	{
+		"ModelType": 1708,
+		"Name": "Shinryu EX?"
+	},
+	{
+		"ModelType": 1709,
+		"Name": "Ugly Blue Scorpion Bug"
+	},
+	{
+		"ModelType": 1710,
+		"Name": "Purple Gryphon"
+	},
+	{
+		"ModelType": 1711,
+		"Name": "Governor (Sirensong Sea 1st Boss)"
+	},
+	{
+		"ModelType": 1712,
+		"Name": "Magna Roader (Purple)"
+	},
+	{
+		"ModelType": 1713,
+		"Name": "Alte Roite (Omega 1) [Frozen]"
+	},
+	{
+		"ModelType": 1714,
+		"Name": "Ghost Aurelia (Sirensong Sea)"
+	},
+	{
+		"ModelType": 1716,
+		"Name": "Lorelei (Sirensong Sea Final Boss)"
+	},
+	{
+		"ModelType": 1717,
+		"Name": "Antlion"
+	},
+	{
+		"ModelType": 1718,
+		"Name": "Matamata"
+	},
+	{
+		"ModelType": 1719,
+		"Name": "Unkiu"
+	},
+	{
+		"ModelType": 1720,
+		"Name": "Simurgh from FFXI / Phorusrhacos"
+	},
+	{
+		"ModelType": 1721,
+		"Name": "Gyuk"
+	},
+	{
+		"ModelType": 1722,
+		"Name": "Refurbisher (Alexander)"
+	},
+	{
+		"ModelType": 1723,
+		"Name": "Refurbisher (Alexander)"
+	},
+	{
+		"ModelType": 1724,
+		"Name": "Alexander Prime (Alexander)"
+	},
+	{
+		"ModelType": 1725,
+		"Name": "Battle Lion",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1726,
+		"Name": "Qiqirn (EQ)"
+	},
+	{
+		"ModelType": 1727,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1728,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1729,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 1730,
+		"Name": "Stone Gaol (Titan)"
+	},
+	{
+		"ModelType": 1731,
+		"Name": "Ferdiad Hollow"
+	},
+	{
+		"ModelType": 1732,
+		"Name": "Canis Pugnax"
+	},
+	{
+		"ModelType": 1733,
+		"Name": "Magma Snipper"
+	},
+	{
+		"ModelType": 1734,
+		"Name": "Cait Sith"
+	},
+	{
+		"ModelType": 1735,
+		"Name": "Cait Sith (Clean - Redbill Scarf)"
+	},
+	{
+		"ModelType": 1736,
+		"Name": "Magitek Driller"
+	},
+	{
+		"ModelType": 1737,
+		"Name": "Anala (Magma)"
+	},
+	{
+		"ModelType": 1738,
+		"Name": "Garula (Bardam's Mettle 1st Boss)"
+	},
+	{
+		"ModelType": 1739,
+		"Name": "Ying-Yang"
+	},
+	{
+		"ModelType": 1740,
+		"Name": "Ananta (EQ)"
+	},
+	{
+		"ModelType": 1741,
+		"Name": "Magitek Gobwalker Mk. IX"
+	},
+	{
+		"ModelType": 1742,
+		"Name": "Gobbie (EQ)"
+	},
+	{
+		"ModelType": 1743,
+		"Name": "Suzaku"
+	},
+	{
+		"ModelType": 1744,
+		"Name": "Voidsent Wyvern (Boss?)"
+	},
+	{
+		"ModelType": 1745,
+		"Name": "Revenant (Purple)"
+	},
+	{
+		"ModelType": 1746,
+		"Name": "Rock Rhino (Mossy)"
+	},
+	{
+		"ModelType": 1747,
+		"Name": "Goobbue (Frozen)"
+	},
+	{
+		"ModelType": 1748,
+		"Name": "Shadow Dragon (Purple/Green)"
+	},
+	{
+		"ModelType": 1749,
+		"Name": "Generic Blue Demon thing"
+	},
+	{
+		"ModelType": 1750,
+		"Name": "Sea Monk (Psychadelic)"
+	},
+	{
+		"ModelType": 1751,
+		"Name": "Doom Knight"
+	},
+	{
+		"ModelType": 1752,
+		"Name": "Behemoth"
+	},
+	{
+		"ModelType": 1753,
+		"Name": "Arbuda (Temple of the Fist 2nd Boss)"
+	},
+	{
+		"ModelType": 1754,
+		"Name": "Inferno (Castrum Abania Final Boss)"
+	},
+	{
+		"ModelType": 1755,
+		"Name": "Catastrophe"
+	},
+	{
+		"ModelType": 1756,
+		"Name": "Execrated Will(EQ - Zurvan Adds)"
+	},
+	{
+		"ModelType": 1757,
+		"Name": "Ivan Coeurlfist"
+	},
+	{
+		"ModelType": 1758,
+		"Name": "Ozma"
+	},
+	{
+		"ModelType": 1759,
+		"Name": "Tenaga (Yanxian Dryad)"
+	},
+	{
+		"ModelType": 1760,
+		"Name": "Sad Pumpkin"
+	},
+	{
+		"ModelType": 1761,
+		"Name": "Lugat (Sirensong Sea 1st Boss)"
+	},
+	{
+		"ModelType": 1762,
+		"Name": "Sophia without head (gold)"
+	},
+	{
+		"ModelType": 1763,
+		"Name": "Cruise Chaser"
+	},
+	{
+		"ModelType": 1764,
+		"Name": "Numbers (Eureka NM)"
+	},
+	{
+		"ModelType": 1765,
+		"Name": "Firebird",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1766,
+		"Name": "Yojimbo"
+	},
+	{
+		"ModelType": 1767,
+		"Name": "Muud Suud"
+	},
+	{
+		"ModelType": 1768,
+		"Name": "Lanner (Sophia)"
+	},
+	{
+		"ModelType": 1769,
+		"Name": "Halloween Ahriman",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1770,
+		"Name": "Weirdly colored lion"
+	},
+	{
+		"ModelType": 1771,
+		"Name": "Rock monster with two hands"
+	},
+	{
+		"ModelType": 1772,
+		"Name": "Rock Plant Fish Mouth???"
+	},
+	{
+		"ModelType": 1773,
+		"Name": "Falcon (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1774,
+		"Name": "Power Core (Deconstructor Add)"
+	},
+	{
+		"ModelType": 1775,
+		"Name": "Raigo (T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1776,
+		"Name": "Archon Throne",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1777,
+		"Name": "Golden Egg"
+	},
+	{
+		"ModelType": 1778,
+		"Name": "Zenos Yae Galvus (No Helm)"
+	},
+	{
+		"ModelType": 1779,
+		"Name": "Captain Madison (Satasha HM 1st Boss)"
+	},
+	{
+		"ModelType": 1780,
+		"Name": "Atomos (Yellow/Black)"
+	},
+	{
+		"ModelType": 1781,
+		"Name": "Diabolos (Injured)"
+	},
+	{
+		"ModelType": 1782,
+		"Name": "Scathach",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1783,
+		"Name": "Nidhogg",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1784,
+		"Name": "Fox",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1785,
+		"Name": "Kitten Thing",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1786,
+		"Name": "Odder Otter",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1787,
+		"Name": "Tiny Tatsunoko",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1788,
+		"Name": "Bom Boko",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1789,
+		"Name": "Sparrow",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1790,
+		"Name": "Bombfish",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1791,
+		"Name": "Faehound S (Red/Black)"
+	},
+	{
+		"ModelType": 1792,
+		"Name": "Karakuri Shinobi (Boss)"
+	},
+	{
+		"ModelType": 1793,
+		"Name": "Namazu (Big)"
+	},
+	{
+		"ModelType": 1794,
+		"Name": "Number XXIV (Castrum Abania 2nd Boss)"
+	},
+	{
+		"ModelType": 1795,
+		"Name": "Imp Jester"
+	},
+	{
+		"ModelType": 1796,
+		"Name": "Connla (Scathach Add)"
+	},
+	{
+		"ModelType": 1797,
+		"Name": "Karakuri Mask?"
+	},
+	{
+		"ModelType": 1798,
+		"Name": "Shisui Yohi (Shisui Final Boss)"
+	},
+	{
+		"ModelType": 1799,
+		"Name": "Halicarnassus (Omega 3)"
+	},
+	{
+		"ModelType": 1800,
+		"Name": "Hecatoncheir (Green)"
+	},
+	{
+		"ModelType": 1801,
+		"Name": "Zurvan"
+	},
+	{
+		"ModelType": 1802,
+		"Name": "Player (T)"
+	},
+	{
+		"ModelType": 1803,
+		"Name": "Scathach (Dead)"
+	},
+	{
+		"ModelType": 1804,
+		"Name": "Player (T)"
+	},
+	{
+		"ModelType": 1805,
+		"Name": "Ixion"
+	},
+	{
+		"ModelType": 1806,
+		"Name": "Khun Shavar (Staff Training Dummy)"
+	},
+	{
+		"ModelType": 1807,
+		"Name": "Grasshopper"
+	},
+	{
+		"ModelType": 1808,
+		"Name": "Armored Weapon (Magitek Laser Spider)"
+	},
+	{
+		"ModelType": 1811,
+		"Name": "Zurvan (Fettered)"
+	},
+	{
+		"ModelType": 1812,
+		"Name": "Wolf Dude (Headless?)"
+	},
+	{
+		"ModelType": 1813,
+		"Name": "Doman Armor Golem? (Steel)"
+	},
+	{
+		"ModelType": 1814,
+		"Name": "Coralshell"
+	},
+	{
+		"ModelType": 1815,
+		"Name": "Coeurl (Grey/Green)"
+	},
+	{
+		"ModelType": 1816,
+		"Name": "Coeurl (Red/Orange)"
+	},
+	{
+		"ModelType": 1817,
+		"Name": "Bardam's Hammer Golem"
+	},
+	{
+		"ModelType": 1818,
+		"Name": "Magitek Avenger"
+	},
+	{
+		"ModelType": 1819,
+		"Name": "Dhara? (Yellow/Brown)"
+	},
+	{
+		"ModelType": 1820,
+		"Name": "Scathach Tendril Hand"
+	},
+	{
+		"ModelType": 1821,
+		"Name": "Deidar"
+	},
+	{
+		"ModelType": 1822,
+		"Name": "Diabolos"
+	},
+	{
+		"ModelType": 1823,
+		"Name": "Player (T)"
+	},
+	{
+		"ModelType": 1824,
+		"Name": "Worst Girl",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1825,
+		"Name": "Yugiri",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1826,
+		"Name": "Gosetsu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1827,
+		"Name": "Yotsuyu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1828,
+		"Name": "Grynethwaht",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1829,
+		"Name": "Angel bell",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1830,
+		"Name": "Namazu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1831,
+		"Name": "Ivon Coeurlfist",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1832,
+		"Name": "Demon Doll?",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1833,
+		"Name": "Rat Thing?",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1834,
+		"Name": "Magitek Avenger",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1835,
+		"Name": "Wolf (White/Light Red)"
+	},
+	{
+		"ModelType": 1836,
+		"Name": "Wolf (Blue/Red)"
+	},
+	{
+		"ModelType": 1837,
+		"Name": "Faehound L (Blue/Black)"
+	},
+	{
+		"ModelType": 1838,
+		"Name": "The Griffin's Blade"
+	},
+	{
+		"ModelType": 1839,
+		"Name": "Scathach"
+	},
+	{
+		"ModelType": 1841,
+		"Name": "Blue Orb (Big)"
+	},
+	{
+		"ModelType": 1842,
+		"Name": "Orange Rotating Rings"
+	},
+	{
+		"ModelType": 1843,
+		"Name": "Bulbasaur? (Skalla Boss)"
+	},
+	{
+		"ModelType": 1844,
+		"Name": "Lion (White)"
+	},
+	{
+		"ModelType": 1845,
+		"Name": "Lion"
+	},
+	{
+		"ModelType": 1846,
+		"Name": "Lion (Magma)"
+	},
+	{
+		"ModelType": 1847,
+		"Name": "Fist Temple Golem?"
+	},
+	{
+		"ModelType": 1848,
+		"Name": "Dhruva? (Ice)"
+	},
+	{
+		"ModelType": 1849,
+		"Name": "Dhara? (Blue/Black) / Gnome"
+	},
+	{
+		"ModelType": 1850,
+		"Name": "Bear (Black)"
+	},
+	{
+		"ModelType": 1851,
+		"Name": "Dragonfly (Green/Yellow)"
+	},
+	{
+		"ModelType": 1852,
+		"Name": "Griffin (True)"
+	},
+	{
+		"ModelType": 1853,
+		"Name": "Treant?"
+	},
+	{
+		"ModelType": 1854,
+		"Name": "Electral Orb"
+	},
+	{
+		"ModelType": 1855,
+		"Name": "Wind-Up Moon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1856,
+		"Name": "Dragonet ( Blue)"
+	},
+	{
+		"ModelType": 1857,
+		"Name": "Lanner (Zurvan)"
+	},
+	{
+		"ModelType": 1858,
+		"Name": "Faehound L (Purple/Black)"
+	},
+	{
+		"ModelType": 1859,
+		"Name": "Faehound S (Blue/Black)"
+	},
+	{
+		"ModelType": 1860,
+		"Name": "T-Pose"
+	},
+	{
+		"ModelType": 1861,
+		"Name": "Atomos (Chrome Blue)"
+	},
+	{
+		"ModelType": 1862,
+		"Name": "Hex Shield Thing"
+	},
+	{
+		"ModelType": 1863,
+		"Name": "Neo Exdeath"
+	},
+	{
+		"ModelType": 1864,
+		"Name": "Garlean Scientist Asshole"
+	},
+	{
+		"ModelType": 1865,
+		"Name": "Cait Sith"
+	},
+	{
+		"ModelType": 1866,
+		"Name": "Diabolos Prime"
+	},
+	{
+		"ModelType": 1867,
+		"Name": "Apa/Undine"
+	},
+	{
+		"ModelType": 1868,
+		"Name": "Tengu"
+	},
+	{
+		"ModelType": 1869,
+		"Name": "Elephant (Grey/Blankets)"
+	},
+	{
+		"ModelType": 1870,
+		"Name": "Manta (No Saddle)"
+	},
+	{
+		"ModelType": 1871,
+		"Name": "Gobroller Mk. VII (Alex 10)"
+	},
+	{
+		"ModelType": 1872,
+		"Name": "Rock Beast (Purple Crystals)"
+	},
+	{
+		"ModelType": 1873,
+		"Name": "Zenos (Wind Katana)"
+	},
+	{
+		"ModelType": 1875,
+		"Name": "Alte Roite (Omega 1)"
+	},
+	{
+		"ModelType": 1876,
+		"Name": "Hellhound (Steel Grey)"
+	},
+	{
+		"ModelType": 1877,
+		"Name": "Nine-Tails (FATE Boss)"
+	},
+	{
+		"ModelType": 1878,
+		"Name": "Echidna (EQ)"
+	},
+	{
+		"ModelType": 1885,
+		"Name": "Zenos Yae Galvus (Helmet)"
+	},
+	{
+		"ModelType": 1886,
+		"Name": "Player (?)"
+	},
+	{
+		"ModelType": 1887,
+		"Name": "Player (?)"
+	},
+	{
+		"ModelType": 1888,
+		"Name": "Demon Face Totem (Omega 4)"
+	},
+	{
+		"ModelType": 1889,
+		"Name": "Ruby Tide Princess"
+	},
+	{
+		"ModelType": 1890,
+		"Name": "Magna Roader (Red)"
+	},
+	{
+		"ModelType": 1891,
+		"Name": "Maned Dragon?"
+	},
+	{
+		"ModelType": 1892,
+		"Name": "Level Checker"
+	},
+	{
+		"ModelType": 1893,
+		"Name": "Shinryu (Huge)"
+	},
+	{
+		"ModelType": 1894,
+		"Name": "Yol"
+	},
+	{
+		"ModelType": 1895,
+		"Name": "Genbu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1896,
+		"Name": "Exdeath",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1897,
+		"Name": "Khloe",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1898,
+		"Name": "Susanoo",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1899,
+		"Name": "Lakshmi",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1900,
+		"Name": "Temple of the Fist Ghost"
+	},
+	{
+		"ModelType": 1901,
+		"Name": "Mossling"
+	},
+	{
+		"ModelType": 1902,
+		"Name": "Pig",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1903,
+		"Name": "Magitek Colossus (Cobalt)"
+	},
+	{
+		"ModelType": 1904,
+		"Name": "Manzasiri"
+	},
+	{
+		"ModelType": 1905,
+		"Name": "Cobra (Blue)"
+	},
+	{
+		"ModelType": 1906,
+		"Name": "Shalloweye"
+	},
+	{
+		"ModelType": 1907,
+		"Name": "Archamoth"
+	},
+	{
+		"ModelType": 1908,
+		"Name": "Mossy Stone Block Demon"
+	},
+	{
+		"ModelType": 1909,
+		"Name": "Razor Disc (Doma Boss Add)"
+	},
+	{
+		"ModelType": 1910,
+		"Name": "Karakuri Shinobi"
+	},
+	{
+		"ModelType": 1911,
+		"Name": "Susanoo"
+	},
+	{
+		"ModelType": 1913,
+		"Name": "Zenos Sword (Wind)"
+	},
+	{
+		"ModelType": 1914,
+		"Name": "Zenos Sword (Lightning)"
+	},
+	{
+		"ModelType": 1915,
+		"Name": "Zenos Sword (Force?)"
+	},
+	{
+		"ModelType": 1917,
+		"Name": "Hypertuned Grynewaht",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1918,
+		"Name": "Tomegi",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1919,
+		"Name": "Ushitora",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 1920,
+		"Name": "Player (T)"
+	},
+	{
+		"ModelType": 1923,
+		"Name": "Wind Blob?"
+	},
+	{
+		"ModelType": 1924,
+		"Name": "Alpha (Omega)"
+	},
+	{
+		"ModelType": 1925,
+		"Name": "Catastrophe Tentacle"
+	},
+	{
+		"ModelType": 1926,
+		"Name": "Shinryu Tail"
+	},
+	{
+		"ModelType": 1927,
+		"Name": "Hrodric Poisontongue"
+	},
+	{
+		"ModelType": 1928,
+		"Name": "Dragon (Yellow)"
+	},
+	{
+		"ModelType": 1929,
+		"Name": "Coblyn (Pink)"
+	},
+	{
+		"ModelType": 1930,
+		"Name": "Bahamut (Large-Blue)"
+	},
+	{
+		"ModelType": 1931,
+		"Name": "Wolf (Red/Grey)"
+	},
+	{
+		"ModelType": 1932,
+		"Name": "Stone Gaol (Susanoo)"
+	},
+	{
+		"ModelType": 1933,
+		"Name": "Namazu (Blank Eyes)"
+	},
+	{
+		"ModelType": 1934,
+		"Name": "Glowing Dragon Skull (Yojimbo Add)"
+	},
+	{
+		"ModelType": 1935,
+		"Name": "Steppe Stone Block?"
+	},
+	{
+		"ModelType": 1936,
+		"Name": "Void Ark Plant Beast?"
+	},
+	{
+		"ModelType": 1937,
+		"Name": "Living Liquid (Alex)"
+	},
+	{
+		"ModelType": 1938,
+		"Name": "Gowrow (Sohl Al HM)"
+	},
+	{
+		"ModelType": 1939,
+		"Name": "Okina (S-Rank Hunt)"
+	},
+	{
+		"ModelType": 1940,
+		"Name": "Magitek... Crawley Thing (Red/Black)"
+	},
+	{
+		"ModelType": 1941,
+		"Name": "Yumemi (Non-Naked)"
+	},
+	{
+		"ModelType": 1942,
+		"Name": "Doman Armor Golem? (Red)"
+	},
+	{
+		"ModelType": 1943,
+		"Name": "Dhammel"
+	},
+	{
+		"ModelType": 1944,
+		"Name": "Lammergeyer? (Red)"
+	},
+	{
+		"ModelType": 1945,
+		"Name": "Scarab (Tan)"
+	},
+	{
+		"ModelType": 1947,
+		"Name": "Crab Scorpion (Grey)"
+	},
+	{
+		"ModelType": 1948,
+		"Name": "Doman Bear? (Orange) Wolverene"
+	},
+	{
+		"ModelType": 1949,
+		"Name": "Doman Treant?"
+	},
+	{
+		"ModelType": 1950,
+		"Name": "Phurble (Green)"
+	},
+	{
+		"ModelType": 1951,
+		"Name": "Angler Fish (Brown/Orange)"
+	},
+	{
+		"ModelType": 1952,
+		"Name": "Horse (Brown)"
+	},
+	{
+		"ModelType": 1953,
+		"Name": "Lanner (Brown)"
+	},
+	{
+		"ModelType": 1954,
+		"Name": "Zenos Yae Galvus (Again)"
+	},
+	{
+		"ModelType": 1955,
+		"Name": "Zenos Yae Galvus (Again)"
+	},
+	{
+		"ModelType": 1956,
+		"Name": "Zenos Yae Galvus (Helmet)"
+	},
+	{
+		"ModelType": 1957,
+		"Name": "Feather Orb"
+	},
+	{
+		"ModelType": 1958,
+		"Name": "Water Orb"
+	},
+	{
+		"ModelType": 1959,
+		"Name": "Water Globe (Purple)"
+	},
+	{
+		"ModelType": 1960,
+		"Name": "Shining Orb"
+	},
+	{
+		"ModelType": 1961,
+		"Name": "Fire Orb"
+	},
+	{
+		"ModelType": 1962,
+		"Name": "Sun Orb"
+	},
+	{
+		"ModelType": 1963,
+		"Name": "Electric Orb"
+	},
+	{
+		"ModelType": 1964,
+		"Name": "Targeting mark on ground"
+	},
+	{
+		"ModelType": 1965,
+		"Name": "Susanoo Blocking Shield Effect"
+	},
+	{
+		"ModelType": 1966,
+		"Name": "Black Hole"
+	},
+	{
+		"ModelType": 1967,
+		"Name": "Black Hole [Effect]"
+	},
+	{
+		"ModelType": 1968,
+		"Name": "Wind-Up Bismark",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1969,
+		"Name": "Zenos in black armor with no helmet"
+	},
+	{
+		"ModelType": 1970,
+		"Name": "Red Armor Zenos without helmet and with Wind Katana"
+	},
+	{
+		"ModelType": 1971,
+		"Name": "Zenos in black armor"
+	},
+	{
+		"ModelType": 1972,
+		"Name": "Red Armor Zenos with Wind Katana"
+	},
+	{
+		"ModelType": 1973,
+		"Name": "Lammergeyer? (Green)"
+	},
+	{
+		"ModelType": 1974,
+		"Name": "Magitek Bit"
+	},
+	{
+		"ModelType": 1975,
+		"Name": "Lakshmi"
+	},
+	{
+		"ModelType": 1978,
+		"Name": "Wind-Up Hien",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1979,
+		"Name": "Wind-Up Ravana",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1980,
+		"Name": "Wind-Up Kojin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1981,
+		"Name": "Mameshiba",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1982,
+		"Name": "Tengu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1983,
+		"Name": "Matanga",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 1984,
+		"Name": "Garlean Gatling Gun"
+	},
+	{
+		"ModelType": 1985,
+		"Name": "Ancient Wyvern (Spined - Black/Purple)"
+	},
+	{
+		"ModelType": 1986,
+		"Name": "Doom Knight Champion"
+	},
+	{
+		"ModelType": 1987,
+		"Name": "Ixion"
+	},
+	{
+		"ModelType": 1988,
+		"Name": "Salt and Light (S-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1989,
+		"Name": "Orcus (A-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1990,
+		"Name": "Erle (A-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1991,
+		"Name": "Sum (A-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1992,
+		"Name": "Grimekhala (A-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1993,
+		"Name": "Vochtstein (A-Rank SB Hunt)"
+	},
+	{
+		"ModelType": 1994,
+		"Name": "Salt Dhruva"
+	},
+	{
+		"ModelType": 1995,
+		"Name": "Manta Ray (Kojin Quest Mount)"
+	},
+	{
+		"ModelType": 1996,
+		"Name": "Magitek Predator",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 1997,
+		"Name": "Khun Chuluu (Sad Bardam Walls)"
+	},
+	{
+		"ModelType": 1998,
+		"Name": "Spirit Coeurl"
+	},
+	{
+		"ModelType": 1999,
+		"Name": "Terrified Namazu"
+	},
+	{
+		"ModelType": 2000,
+		"Name": "Adamantoise"
+	},
+	{
+		"ModelType": 2001,
+		"Name": "Harakiri Hanya (Kugane Castle)"
+	},
+	{
+		"ModelType": 2002,
+		"Name": "Magitek Rearguard (Doma Castle 1st Boss)"
+	},
+	{
+		"ModelType": 2003,
+		"Name": "Magitek Bit Bomb (Rearguard Add)"
+	},
+	{
+		"ModelType": 2004,
+		"Name": "Magitek Heavy Loader (Bomb)"
+	},
+	{
+		"ModelType": 2005,
+		"Name": "Cerberus (Red - Eureka)"
+	},
+	{
+		"ModelType": 2006,
+		"Name": "Ent"
+	},
+	{
+		"ModelType": 2007,
+		"Name": "Red Egg"
+	},
+	{
+		"ModelType": 2008,
+		"Name": "Blue Egg"
+	},
+	{
+		"ModelType": 2009,
+		"Name": "Floating Purple Dragon Head"
+	},
+	{
+		"ModelType": 2010,
+		"Name": "Ivan Coeurlfist"
+	},
+	{
+		"ModelType": 2011,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 2012,
+		"Name": "Susanoo Sword Part"
+	},
+	{
+		"ModelType": 2013,
+		"Name": "Lakshmi"
+	},
+	{
+		"ModelType": 2014,
+		"Name": "Hoarhound (Fenrir - Purple/Red)"
+	},
+	{
+		"ModelType": 2015,
+		"Name": "Demon Tome (Blank)"
+	},
+	{
+		"ModelType": 2016,
+		"Name": "Zenos Without Helmet"
+	},
+	{
+		"ModelType": 2017,
+		"Name": "Zenos With Helmet"
+	},
+	{
+		"ModelType": 2018,
+		"Name": "Tentacle (Exdeath Add)"
+	},
+	{
+		"ModelType": 2019,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 2020,
+		"Name": "Yol (Pink)"
+	},
+	{
+		"ModelType": 2021,
+		"Name": "Gold Namazu"
+	},
+	{
+		"ModelType": 2022,
+		"Name": "Susanoo Battle Mode"
+	},
+	{
+		"ModelType": 2023,
+		"Name": "Floating Blue Light"
+	},
+	{
+		"ModelType": 2024,
+		"Name": "Neo Exdeath"
+	},
+	{
+		"ModelType": 2025,
+		"Name": "Spirit Warrior (Temple of the Fist)"
+	},
+	{
+		"ModelType": 2026,
+		"Name": "Spirit Warrior 2 (Temple of the Fist)"
+	},
+	{
+		"ModelType": 2027,
+		"Name": "Matoya (EQ-Headless)"
+	},
+	{
+		"ModelType": 2028,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 2029,
+		"Name": "Horse (Namazu Quest Mount)"
+	},
+	{
+		"ModelType": 2030,
+		"Name": "Nezha Chariot",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2031,
+		"Name": "Generic Person - With Carrying Pole",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2032,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2033,
+		"Name": "Generic Person - Holding Lamp",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2034,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2035,
+		"Name": "Generic Person - Holding Bento",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2036,
+		"Name": "Spectre (Blue)"
+	},
+	{
+		"ModelType": 2037,
+		"Name": "Hashmal: Bringer of Order (Rabanastre 2nd Boss)"
+	},
+	{
+		"ModelType": 2038,
+		"Name": "Mateus: the Corrupt (Rabanastre 1st Boss)"
+	},
+	{
+		"ModelType": 2039,
+		"Name": "Treant (Christmas Event)"
+	},
+	{
+		"ModelType": 2040,
+		"Name": "Level Checker (Red)"
+	},
+	{
+		"ModelType": 2041,
+		"Name": "Level Checker (Green)"
+	},
+	{
+		"ModelType": 2042,
+		"Name": "Kelpie (Skalla 1st Boss)"
+	},
+	{
+		"ModelType": 2043,
+		"Name": "Sea Faerie? (Skall Add)"
+	},
+	{
+		"ModelType": 2044,
+		"Name": "The Ultima Beast (Fractal Cont. HM Final Boss)"
+	},
+	{
+		"ModelType": 2045,
+		"Name": "The Ultima Warrior (Fractal Cont. HM 1st Boss)"
+	},
+	{
+		"ModelType": 2046,
+		"Name": "Wind-Up Ramza"
+	},
+	{
+		"ModelType": 2047,
+		"Name": "Coeurl (Regular) [Frozen]"
+	},
+	{
+		"ModelType": 2048,
+		"Name": "Coeurl (Red) [Frozen]"
+	},
+	{
+		"ModelType": 2049,
+		"Name": "Coeurl (Dark Red) [Frozen]"
+	},
+	{
+		"ModelType": 2050,
+		"Name": "Zenos with Skull Helmet"
+	},
+	{
+		"ModelType": 2051,
+		"Name": "Halicarnassus (Omega 3)"
+	},
+	{
+		"ModelType": 2052,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 2053,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 2054,
+		"Name": "Chain Bind (Green) [Effect]"
+	},
+	{
+		"ModelType": 2055,
+		"Name": "Sadu's Door Model [Incorrect]"
+	},
+	{
+		"ModelType": 2056,
+		"Name": "Susanoo"
+	},
+	{
+		"ModelType": 2057,
+		"Name": "Treasure Chest (Copper)"
+	},
+	{
+		"ModelType": 2058,
+		"Name": "Scorpion Bug (Brown)"
+	},
+	{
+		"ModelType": 2059,
+		"Name": "Yol (Purple/Green)"
+	},
+	{
+		"ModelType": 2060,
+		"Name": "Training Dummy (Elite)"
+	},
+	{
+		"ModelType": 2061,
+		"Name": "Ixion"
+	},
+	{
+		"ModelType": 2062,
+		"Name": "X Slash [Effect]"
+	},
+	{
+		"ModelType": 2063,
+		"Name": "Wood Table"
+	},
+	{
+		"ModelType": 2064,
+		"Name": "Basket of Fish"
+	},
+	{
+		"ModelType": 2065,
+		"Name": "Inferno XL (Castrum Abania Final Boss)"
+	},
+	{
+		"ModelType": 2066,
+		"Name": "Koala",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2067,
+		"Name": "Salt and Pepper Seal",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2068,
+		"Name": "Mudkip",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2069,
+		"Name": "Wind-Up Ixion"
+	},
+	{
+		"ModelType": 2070,
+		"Name": "Ultros"
+	},
+	{
+		"ModelType": 2071,
+		"Name": "Korpukkur (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2072,
+		"Name": "Magitek Avenger",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2073,
+		"Name": "Aquamarine Carbuncle",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2074,
+		"Name": "Marid",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2075,
+		"Name": "The Old One (Skalla 2nd Boss)"
+	},
+	{
+		"ModelType": 2076,
+		"Name": "Primelephas (Eureka)"
+	},
+	{
+		"ModelType": 2077,
+		"Name": "Val Guardian"
+	},
+	{
+		"ModelType": 2078,
+		"Name": "Shinryu"
+	},
+	{
+		"ModelType": 2079,
+		"Name": "Principia (Allagan Summoner Tome)"
+	},
+	{
+		"ModelType": 2080,
+		"Name": "Midgardsormr pet size"
+	},
+	{
+		"ModelType": 2081,
+		"Name": "Fox kit",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2082,
+		"Name": "Ice-Skating Goddess (Mateus Add)"
+	},
+	{
+		"ModelType": 2083,
+		"Name": "Rofocale (Rabanastre 3rd Boss)"
+	},
+	{
+		"ModelType": 2084,
+		"Name": "Argath Thadalfus (Rabanastre Final Boss)"
+	},
+	{
+		"ModelType": 2085,
+		"Name": "Bombadeel (Eureka NM)"
+	},
+	{
+		"ModelType": 2086,
+		"Name": "Mirrorknight (Corrupted - Green/Purple)"
+	},
+	{
+		"ModelType": 2087,
+		"Name": "Zangbeto"
+	},
+	{
+		"ModelType": 2088,
+		"Name": "Squib (Eureka)"
+	},
+	{
+		"ModelType": 2089,
+		"Name": "Lamashtu (Eureka NM)"
+	},
+	{
+		"ModelType": 2090,
+		"Name": "Block of ice"
+	},
+	{
+		"ModelType": 2091,
+		"Name": "Rolling Boulder"
+	},
+	{
+		"ModelType": 2092,
+		"Name": "Floating Water Bubble"
+	},
+	{
+		"ModelType": 2093,
+		"Name": "Archaeodemon (Rabanastre Trash)"
+	},
+	{
+		"ModelType": 2094,
+		"Name": "Little Snowman With Candy Cane"
+	},
+	{
+		"ModelType": 2095,
+		"Name": "Giant Cannon (Blue)"
+	},
+	{
+		"ModelType": 2096,
+		"Name": "Giant Cannon (Red)"
+	},
+	{
+		"ModelType": 2097,
+		"Name": "Rival Wings Mech #1 - Blue"
+	},
+	{
+		"ModelType": 2098,
+		"Name": "Rival Wings Mech #2 - Blue"
+	},
+	{
+		"ModelType": 2099,
+		"Name": "Rival Wings Mech #3 - Blue"
+	},
+	{
+		"ModelType": 2100,
+		"Name": "Rival Wings Mech #1 - Red"
+	},
+	{
+		"ModelType": 2101,
+		"Name": "Rival Wings Mech #2 - Red"
+	},
+	{
+		"ModelType": 2102,
+		"Name": "Rival Wings Mech #3 - Red"
+	},
+	{
+		"ModelType": 2103,
+		"Name": "Floating Sword"
+	},
+	{
+		"ModelType": 2104,
+		"Name": "Bangaa (EQ)"
+	},
+	{
+		"ModelType": 2105,
+		"Name": "Bangaa (EQ)"
+	},
+	{
+		"ModelType": 2106,
+		"Name": "Bangaa (EQ)"
+	},
+	{
+		"ModelType": 2107,
+		"Name": "Bangaa Guy"
+	},
+	{
+		"ModelType": 2108,
+		"Name": "Bangaa Guy - red"
+	},
+	{
+		"ModelType": 2109,
+		"Name": "Bangaa Guy - grey"
+	},
+	{
+		"ModelType": 2110,
+		"Name": "Flying Dragon"
+	},
+	{
+		"ModelType": 2111,
+		"Name": "Flying Dragon - White"
+	},
+	{
+		"ModelType": 2112,
+		"Name": "Flying Dragon - Super Saiyan Gold"
+	},
+	{
+		"ModelType": 2113,
+		"Name": "Flying Dragon - Green-ish"
+	},
+	{
+		"ModelType": 2114,
+		"Name": "Hecatoncheir (EQ)"
+	},
+	{
+		"ModelType": 2115,
+		"Name": "Flying Chair",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2116,
+		"Name": "Legendary Kamuy",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2117,
+		"Name": "Striped Ray",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2118,
+		"Name": "Magitek Claw"
+	},
+	{
+		"ModelType": 2119,
+		"Name": "Red Hare",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2120,
+		"Name": "Raubahn",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2121,
+		"Name": "Byakko"
+	},
+	{
+		"ModelType": 2122,
+		"Name": "Weird Multicolored Sphere"
+	},
+	{
+		"ModelType": 2123,
+		"Name": "Bangaa (EQ)"
+	},
+	{
+		"ModelType": 2124,
+		"Name": "Wind-up Shinryu"
+	},
+	{
+		"ModelType": 2125,
+		"Name": "Citrine Carbuncle",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2126,
+		"Name": "Tyrannosaur",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2127,
+		"Name": "Genbu"
+	},
+	{
+		"ModelType": 2128,
+		"Name": "A Chicken"
+	},
+	{
+		"ModelType": 2130,
+		"Name": "Red Kojin (EQ)"
+	},
+	{
+		"ModelType": 2131,
+		"Name": "Argath Thadalfus? (Rabanastre Final Boss)"
+	},
+	{
+		"ModelType": 2132,
+		"Name": "??? (Saddle: Weapon on Floor)"
+	},
+	{
+		"ModelType": 2133,
+		"Name": "Wind-Up Kojin ( Purple - Minion)"
+	},
+	{
+		"ModelType": 2134,
+		"Name": "Motherbit (Fractal Cont. HM 1st Boss)"
+	},
+	{
+		"ModelType": 2135,
+		"Name": "Regalia but with smoke"
+	},
+	{
+		"ModelType": 2136,
+		"Name": "Phantom Train"
+	},
+	{
+		"ModelType": 2137,
+		"Name": "God Kefka"
+	},
+	{
+		"ModelType": 2138,
+		"Name": "Guardian (Omega 7)"
+	},
+	{
+		"ModelType": 2139,
+		"Name": "Ananta",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2140,
+		"Name": "Moai Head",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2141,
+		"Name": "Whittret",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2142,
+		"Name": "Black checkered egg"
+	},
+	{
+		"ModelType": 2143,
+		"Name": "Kefka",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2144,
+		"Name": "Magnai",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2145,
+		"Name": "Otake-Maru (Hell's Lid 1st Boss)"
+	},
+	{
+		"ModelType": 2146,
+		"Name": "Kamaitachi (Hell's Lid 2nd Boss)"
+	},
+	{
+		"ModelType": 2147,
+		"Name": "Alpha (Chocobo from Omega)"
+	},
+	{
+		"ModelType": 2148,
+		"Name": "Sea Faerie? (Skalla Trash)"
+	},
+	{
+		"ModelType": 2149,
+		"Name": "Shinryu"
+	},
+	{
+		"ModelType": 2150,
+		"Name": "Pulsating blue ground field"
+	},
+	{
+		"ModelType": 2151,
+		"Name": "Allagan Bit (Motherbit Add)"
+	},
+	{
+		"ModelType": 2152,
+		"Name": "Crab from Hells Lid"
+	},
+	{
+		"ModelType": 2153,
+		"Name": "Phantom Train Ghost"
+	},
+	{
+		"ModelType": 2154,
+		"Name": "Gilgamesh"
+	},
+	{
+		"ModelType": 2155,
+		"Name": "Aurelia Polyp",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2156,
+		"Name": "Byakko cub",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2157,
+		"Name": "Shinryu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2158,
+		"Name": "Allagan Prototype Chimera (Fractal HM)"
+	},
+	{
+		"ModelType": 2159,
+		"Name": "Allagan Prototype Minotaur (Fractal HM)"
+	},
+	{
+		"ModelType": 2160,
+		"Name": "Chadarnook (Omega 6 Boss)"
+	},
+	{
+		"ModelType": 2161,
+		"Name": "Pazuzu (Eureka Anemos NM)"
+	},
+	{
+		"ModelType": 2162,
+		"Name": "Dadaluma (Omega 7 Add)"
+	},
+	{
+		"ModelType": 2163,
+		"Name": "Cat form Byakko"
+	},
+	{
+		"ModelType": 2164,
+		"Name": "Goddess Chadarnook (Omega 6 Add)"
+	},
+	{
+		"ModelType": 2165,
+		"Name": "Regular Kefka"
+	},
+	{
+		"ModelType": 2166,
+		"Name": "Airforce (Omega 7 Add)"
+	},
+	{
+		"ModelType": 2167,
+		"Name": "Auspicious Kamuy",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2168,
+		"Name": "Wind-Up Mithra",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2169,
+		"Name": "Prince of Anemos",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2170,
+		"Name": "Komainu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2171,
+		"Name": "Turtle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2172,
+		"Name": "Pagos Bunny"
+	},
+	{
+		"ModelType": 2173,
+		"Name": "Giant Tiger"
+	},
+	{
+		"ModelType": 2174,
+		"Name": "Air Force",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2175,
+		"Name": "Typhon [Frozen]"
+	},
+	{
+		"ModelType": 2176,
+		"Name": "Indigo Whale"
+	},
+	{
+		"ModelType": 2177,
+		"Name": "Glowing: Pulsating Green Sphere of Epilepsy"
+	},
+	{
+		"ModelType": 2178,
+		"Name": "Ananta (EQ)"
+	},
+	{
+		"ModelType": 2179,
+		"Name": "Broken Heart (Left)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2180,
+		"Name": "Broken Heart (Right)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2181,
+		"Name": "Floating Glowing Missile"
+	},
+	{
+		"ModelType": 2183,
+		"Name": "Floating Gold Needle"
+	},
+	{
+		"ModelType": 2184,
+		"Name": "Kefka Forsaken"
+	},
+	{
+		"ModelType": 2185,
+		"Name": "Creepy Floating Head with Scythes for arms and another head on top"
+	},
+	{
+		"ModelType": 2186,
+		"Name": "Zenos (Recovering)"
+	},
+	{
+		"ModelType": 2187,
+		"Name": "Otengu (Swallow's Compass 1st Boss)"
+	},
+	{
+		"ModelType": 2188,
+		"Name": "Koryu"
+	},
+	{
+		"ModelType": 2189,
+		"Name": "Eyeball Slime (Radioactive)"
+	},
+	{
+		"ModelType": 2190,
+		"Name": "Orb (Byakko's Balls)"
+	},
+	{
+		"ModelType": 2191,
+		"Name": "True Griffin",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2192,
+		"Name": "White Whittret",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2193,
+		"Name": "Golem (Gougan)"
+	},
+	{
+		"ModelType": 2194,
+		"Name": "Dodo Bird"
+	},
+	{
+		"ModelType": 2195,
+		"Name": "Lunar Kamuy",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2196,
+		"Name": "Belias: the Constantly Fucking Going Invincible (Ridorana 2nd Boss)"
+	},
+	{
+		"ModelType": 2197,
+		"Name": "Famfrit: the Darkening Cloud (Ridorana 1st boss)"
+	},
+	{
+		"ModelType": 2199,
+		"Name": "A Tornado (literally)"
+	},
+	{
+		"ModelType": 2200,
+		"Name": "Phantom Train Markers"
+	},
+	{
+		"ModelType": 2202,
+		"Name": "Mikoshi",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2203,
+		"Name": "Rathalos (Monster Hunter)"
+	},
+	{
+		"ModelType": 2204,
+		"Name": "Palico from Monster Hunter"
+	},
+	{
+		"ModelType": 2205,
+		"Name": "Poogie? (Disappears Immediately)"
+	},
+	{
+		"ModelType": 2210,
+		"Name": "Tsukuyomi"
+	},
+	{
+		"ModelType": 2211,
+		"Name": "Wukong - Monkey King"
+	},
+	{
+		"ModelType": 2212,
+		"Name": "Math Construct boss from Ridorana"
+	},
+	{
+		"ModelType": 2213,
+		"Name": "Magitek Trooper FFXV"
+	},
+	{
+		"ModelType": 2214,
+		"Name": "MA-X FFXV"
+	},
+	{
+		"ModelType": 2215,
+		"Name": "Iseultalon FFXV"
+	},
+	{
+		"ModelType": 2216,
+		"Name": "Eureka Pagos NM Marlboro Stack"
+	},
+	{
+		"ModelType": 2217,
+		"Name": "Daidarabotchi (Swallow's Compass 1st Boss)"
+	},
+	{
+		"ModelType": 2218,
+		"Name": "Sai Taisui (Swallow's Compass)"
+	},
+	{
+		"ModelType": 2219,
+		"Name": "Flaming Wall monster from Hell's Lid"
+	},
+	{
+		"ModelType": 2221,
+		"Name": "Namazu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2222,
+		"Name": "Sabotender Emperatiz"
+	},
+	{
+		"ModelType": 2223,
+		"Name": "Decotitus"
+	},
+	{
+		"ModelType": 2224,
+		"Name": "Namazu"
+	},
+	{
+		"ModelType": 2225,
+		"Name": "Another type of Namazu"
+	},
+	{
+		"ModelType": 2226,
+		"Name": "Namazu with headband"
+	},
+	{
+		"ModelType": 2227,
+		"Name": "Another type of Namazu with headband"
+	},
+	{
+		"ModelType": 2228,
+		"Name": "Wise Namazu"
+	},
+	{
+		"ModelType": 2229,
+		"Name": "Wise Namazu with headband"
+	},
+	{
+		"ModelType": 2230,
+		"Name": "Flying Rathalos (Monster Hunter)"
+	},
+	{
+		"ModelType": 2231,
+		"Name": "Poroggo"
+	},
+	{
+		"ModelType": 2232,
+		"Name": "Ananta",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2233,
+		"Name": "Shalloweye"
+	},
+	{
+		"ModelType": 2234,
+		"Name": "Red Demon Spinning Mask (Heaven-on-High)"
+	},
+	{
+		"ModelType": 2235,
+		"Name": "Blue Demon Spinning Mask (Heaven-on-High)"
+	},
+	{
+		"ModelType": 2236,
+		"Name": "Hiruku (HoH Floor 30 Boss)"
+	},
+	{
+		"ModelType": 2237,
+		"Name": "King Igloo (Eureka Pagos NM)"
+	},
+	{
+		"ModelType": 2238,
+		"Name": "Monkey king",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2239,
+		"Name": "A wall lantern",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2240,
+		"Name": "A lizard type of",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2241,
+		"Name": "Wind up Cirina",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2242,
+		"Name": "Wind up Sadu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2243,
+		"Name": "Malboro with skirt",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2244,
+		"Name": "Wind up Tarutaru?",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2245,
+		"Name": "Wind up Tsukuyomi",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2246,
+		"Name": "Wind up Zhloe",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2247,
+		"Name": "Math Construct",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2248,
+		"Name": "A giant rock - grey"
+	},
+	{
+		"ModelType": 2249,
+		"Name": "A giant rock - white"
+	},
+	{
+		"ModelType": 2250,
+		"Name": "A giant rock - purplish/black"
+	},
+	{
+		"ModelType": 2251,
+		"Name": "Pure White Tsukuyomi"
+	},
+	{
+		"ModelType": 2252,
+		"Name": "Pure Black Tsukuyomi"
+	},
+	{
+		"ModelType": 2253,
+		"Name": "Battle Mode Tsukuyomi"
+	},
+	{
+		"ModelType": 2254,
+		"Name": "Battle Mode Pure White Tsukuyomi"
+	},
+	{
+		"ModelType": 2255,
+		"Name": "Battle Mode Pure Black Tsukuyomi"
+	},
+	{
+		"ModelType": 2256,
+		"Name": "Fallen Samurai (Mounted)"
+	},
+	{
+		"ModelType": 2257,
+		"Name": "Rathalos (Monster Hunter) [Frozen]"
+	},
+	{
+		"ModelType": 2258,
+		"Name": "Magitek Conveyor",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2259,
+		"Name": "Suzaku - Human"
+	},
+	{
+		"ModelType": 2260,
+		"Name": "Bangaa Boss Guy"
+	},
+	{
+		"ModelType": 2261,
+		"Name": "Suzaku - Human"
+	},
+	{
+		"ModelType": 2262,
+		"Name": "Rusted Math Construct"
+	},
+	{
+		"ModelType": 2264,
+		"Name": "Ultima Weapon Ultimate"
+	},
+	{
+		"ModelType": 2265,
+		"Name": "Yukinko (Eureka Pagos)"
+	},
+	{
+		"ModelType": 2266,
+		"Name": "Louhi (Eureka Pagos NM)"
+	},
+	{
+		"ModelType": 2267,
+		"Name": "Yiazmat (Ridorana Final Boss)"
+	},
+	{
+		"ModelType": 2268,
+		"Name": "Grani",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2269,
+		"Name": "Ridorana Exploding Fire Bell Trash"
+	},
+	{
+		"ModelType": 2270,
+		"Name": "Cute monkey"
+	},
+	{
+		"ModelType": 2271,
+		"Name": "Ultima Weapon of some sort"
+	},
+	{
+		"ModelType": 2272,
+		"Name": "Yiazmat (Enraged)"
+	},
+	{
+		"ModelType": 2273,
+		"Name": "Dark Ewer (Famfrit Add)"
+	},
+	{
+		"ModelType": 2274,
+		"Name": "Odder Otter with asian hat"
+	},
+	{
+		"ModelType": 2275,
+		"Name": "Ash Dragon (Pagos)"
+	},
+	{
+		"ModelType": 2276,
+		"Name": "Garuda"
+	},
+	{
+		"ModelType": 2277,
+		"Name": "Ifrit"
+	},
+	{
+		"ModelType": 2278,
+		"Name": "Titan"
+	},
+	{
+		"ModelType": 2279,
+		"Name": "Golden King Crab"
+	},
+	{
+		"ModelType": 2280,
+		"Name": "Val Corpse (Eureka Pagos)"
+	},
+	{
+		"ModelType": 2281,
+		"Name": "A ball of fire"
+	},
+	{
+		"ModelType": 2283,
+		"Name": "A huge ring of green mirrors"
+	},
+	{
+		"ModelType": 2284,
+		"Name": "Palico from Monster hunter (different one)"
+	},
+	{
+		"ModelType": 2285,
+		"Name": "Poogie from Monster hunter"
+	},
+	{
+		"ModelType": 2286,
+		"Name": "Floating gold fan"
+	},
+	{
+		"ModelType": 2287,
+		"Name": "Dreadnaught"
+	},
+	{
+		"ModelType": 2289,
+		"Name": "8 Namazu carrying a platform with nothing on it"
+	},
+	{
+		"ModelType": 2290,
+		"Name": "Magitek Sky Armor"
+	},
+	{
+		"ModelType": 2291,
+		"Name": "Floating blue cloud of depression"
+	},
+	{
+		"ModelType": 2292,
+		"Name": "T-Pose Default Model"
+	},
+	{
+		"ModelType": 2293,
+		"Name": "Tsukuyomi again"
+	},
+	{
+		"ModelType": 2294,
+		"Name": "Withered Belladonna"
+	},
+	{
+		"ModelType": 2295,
+		"Name": "Dorpokkur"
+	},
+	{
+		"ModelType": 2296,
+		"Name": "Matamata"
+	},
+	{
+		"ModelType": 2297,
+		"Name": "Nullchu"
+	},
+	{
+		"ModelType": 2298,
+		"Name": "Magitek Predator",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2299,
+		"Name": "Fat Cat"
+	},
+	{
+		"ModelType": 2300,
+		"Name": "Deformed Mameshiba?"
+	},
+	{
+		"ModelType": 2301,
+		"Name": "Weird lion",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2302,
+		"Name": "Defective Drone"
+	},
+	{
+		"ModelType": 2303,
+		"Name": "Fallen Samurai "
+	},
+	{
+		"ModelType": 2304,
+		"Name": "Juedi",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2306,
+		"Name": "Safeguard System",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2307,
+		"Name": "Prototype Conveyor",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2308,
+		"Name": "Spinning Gear"
+	},
+	{
+		"ModelType": 2309,
+		"Name": "Yojimbo"
+	},
+	{
+		"ModelType": 2310,
+		"Name": "Festive Namazu"
+	},
+	{
+		"ModelType": 2311,
+		"Name": "Omega - Midgardsormr"
+	},
+	{
+		"ModelType": 2312,
+		"Name": "Fatter Cat",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2313,
+		"Name": "Frost Dragon"
+	},
+	{
+		"ModelType": 2314,
+		"Name": "Frost Dragon"
+	},
+	{
+		"ModelType": 2315,
+		"Name": "Immaculate Apa"
+	},
+	{
+		"ModelType": 2317,
+		"Name": "Spinning White Orb"
+	},
+	{
+		"ModelType": 2318,
+		"Name": "Moogle (EQ)"
+	},
+	{
+		"ModelType": 2320,
+		"Name": "Omega M"
+	},
+	{
+		"ModelType": 2321,
+		"Name": "Omega F"
+	},
+	{
+		"ModelType": 2322,
+		"Name": "Neo Omega"
+	},
+	{
+		"ModelType": 2323,
+		"Name": "Omega M | F Puddle"
+	},
+	{
+		"ModelType": 2324,
+		"Name": "Alpha"
+	},
+	{
+		"ModelType": 2325,
+		"Name": "Ghost"
+	},
+	{
+		"ModelType": 2326,
+		"Name": "Ghost"
+	},
+	{
+		"ModelType": 2327,
+		"Name": "Suzaku -",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2328,
+		"Name": "OMG - Omega",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2329,
+		"Name": "G'raha Tia",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2330,
+		"Name": "Cloud",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2331,
+		"Name": "Aerith",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2332,
+		"Name": "Tifa",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2333,
+		"Name": "Kukulkan"
+	},
+	{
+		"ModelType": 2334,
+		"Name": "Brown Slime"
+	},
+	{
+		"ModelType": 2335,
+		"Name": "Omega - Midgardsormr"
+	},
+	{
+		"ModelType": 2336,
+		"Name": "Slime"
+	},
+	{
+		"ModelType": 2337,
+		"Name": "Magitek Predator (EQ)"
+	},
+	{
+		"ModelType": 2338,
+		"Name": "Ceruleum Engine"
+	},
+	{
+		"ModelType": 2339,
+		"Name": "Mister Bright-Eyes"
+	},
+	{
+		"ModelType": 2340,
+		"Name": "Magicked Carpet",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2341,
+		"Name": "Tokkapchi - Minon"
+	},
+	{
+		"ModelType": 2342,
+		"Name": "Capybara"
+	},
+	{
+		"ModelType": 2343,
+		"Name": "???",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2344,
+		"Name": "Moogle",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2345,
+		"Name": "Suzaku Indicator (Red)"
+	},
+	{
+		"ModelType": 2346,
+		"Name": "Suzaku Indicator (Yellow)"
+	},
+	{
+		"ModelType": 2347,
+		"Name": "Suzaku Indicator (Blue)"
+	},
+	{
+		"ModelType": 2348,
+		"Name": "Suzaku Indicator (Purple)"
+	},
+	{
+		"ModelType": 2349,
+		"Name": "Suzaku Indicator (North)"
+	},
+	{
+		"ModelType": 2350,
+		"Name": "Suzaku Indicator (East)"
+	},
+	{
+		"ModelType": 2351,
+		"Name": "Suzaku Indicator (South)"
+	},
+	{
+		"ModelType": 2352,
+		"Name": "Suzaku Indicator (West)"
+	},
+	{
+		"ModelType": 2353,
+		"Name": "Blue Orb"
+	},
+	{
+		"ModelType": 2354,
+		"Name": "Red Orb"
+	},
+	{
+		"ModelType": 2355,
+		"Name": "Suzaku Orb"
+	},
+	{
+		"ModelType": 2356,
+		"Name": "Mist"
+	},
+	{
+		"ModelType": 2357,
+		"Name": "Tokkapchi"
+	},
+	{
+		"ModelType": 2358,
+		"Name": "Penthesilea"
+	},
+	{
+		"ModelType": 2359,
+		"Name": "Euphonius Kamuy"
+	},
+	{
+		"ModelType": 2360,
+		"Name": "Omega"
+	},
+	{
+		"ModelType": 2361,
+		"Name": "Magna Roader"
+	},
+	{
+		"ModelType": 2362,
+		"Name": "Magitek Sky Armor"
+	},
+	{
+		"ModelType": 2363,
+		"Name": "Gilgamesh"
+	},
+	{
+		"ModelType": 2364,
+		"Name": "Pillar"
+	},
+	{
+		"ModelType": 2365,
+		"Name": "Suzaku"
+	},
+	{
+		"ModelType": 2366,
+		"Name": "Suzaku - Dressed"
+	},
+	{
+		"ModelType": 2367,
+		"Name": "Hedetet - Pillar"
+	},
+	{
+		"ModelType": 2368,
+		"Name": "Suzaku - Feather"
+	},
+	{
+		"ModelType": 2369,
+		"Name": "Chakram - The Burn"
+	},
+	{
+		"ModelType": 2370,
+		"Name": "Noctis",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2371,
+		"Name": "Hedetet"
+	},
+	{
+		"ModelType": 2372,
+		"Name": "Eldthurs",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2373,
+		"Name": "Khalamari"
+	},
+	{
+		"ModelType": 2374,
+		"Name": "Omega Rocket Punch 1"
+	},
+	{
+		"ModelType": 2375,
+		"Name": "Omega Rocket Punch 2"
+	},
+	{
+		"ModelType": 2376,
+		"Name": "Desert Desman"
+	},
+	{
+		"ModelType": 2377,
+		"Name": "Omega - Chaos"
+	},
+	{
+		"ModelType": 2378,
+		"Name": "Omega- Floating Right Arm"
+	},
+	{
+		"ModelType": 2379,
+		"Name": "Omega- Floating Left Arm"
+	},
+	{
+		"ModelType": 2380,
+		"Name": "Omega 12 Structure?"
+	},
+	{
+		"ModelType": 2381,
+		"Name": "Gilgamesh"
+	},
+	{
+		"ModelType": 2382,
+		"Name": "Fran (Demihuman)"
+	},
+	{
+		"ModelType": 2384,
+		"Name": "Solus Zos Galvus",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2385,
+		"Name": "Fat Black Chocobo",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2387,
+		"Name": "Omega - M"
+	},
+	{
+		"ModelType": 2388,
+		"Name": "Omega - F (With Weapon)"
+	},
+	{
+		"ModelType": 2389,
+		"Name": "Omega - F (No Weapon)"
+	},
+	{
+		"ModelType": 2390,
+		"Name": "Floating Staff"
+	},
+	{
+		"ModelType": 2391,
+		"Name": "Floating Axe"
+	},
+	{
+		"ModelType": 2392,
+		"Name": "Generic Person - Holding Wood",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2393,
+		"Name": "Suzaku Effect"
+	},
+	{
+		"ModelType": 2394,
+		"Name": "Lakhamu"
+	},
+	{
+		"ModelType": 2395,
+		"Name": "Jar?"
+	},
+	{
+		"ModelType": 2396,
+		"Name": "Desert Armadillo"
+	},
+	{
+		"ModelType": 2397,
+		"Name": "Bunch of Sticks"
+	},
+	{
+		"ModelType": 2398,
+		"Name": "Ultima"
+	},
+	{
+		"ModelType": 2399,
+		"Name": "Absolute Virtue"
+	},
+	{
+		"ModelType": 2400,
+		"Name": "Hidden Gorge Machine"
+	},
+	{
+		"ModelType": 2401,
+		"Name": "Korpokkur"
+	},
+	{
+		"ModelType": 2402,
+		"Name": "Blood Angel (Ultima add)"
+	},
+	{
+		"ModelType": 2403,
+		"Name": "Seiryu"
+	},
+	{
+		"ModelType": 2404,
+		"Name": "Yojimbo"
+	},
+	{
+		"ModelType": 2405,
+		"Name": "Alpha"
+	},
+	{
+		"ModelType": 2406,
+		"Name": "Sabotender Emperador",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2407,
+		"Name": "Annia Quo Soranus and Julia Quo Soranus (Ghimlyt) (T-Pose)"
+	},
+	{
+		"ModelType": 2408,
+		"Name": "Wall of Snakes (Seiryu)"
+	},
+	{
+		"ModelType": 2409,
+		"Name": "Ozma"
+	},
+	{
+		"ModelType": 2410,
+		"Name": "The Thunder God (Orbonne-Not Fucked Up)"
+	},
+	{
+		"ModelType": 2411,
+		"Name": "Swearing Imp Thing"
+	},
+	{
+		"ModelType": 2412,
+		"Name": "Fran",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2413,
+		"Name": "Wind-Up Tataru"
+	},
+	{
+		"ModelType": 2414,
+		"Name": "Seiryu",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2415,
+		"Name": "Magitek Asshole",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2416,
+		"Name": "Armored Weapon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2417,
+		"Name": "Furball Minion x3"
+	},
+	{
+		"ModelType": 2418,
+		"Name": "Mini Absolute Virtue"
+	},
+	{
+		"ModelType": 2419,
+		"Name": "Fate boss in Greatwoods"
+	},
+	{
+		"ModelType": 2420,
+		"Name": "Armor Boi (Ghimlyt)"
+	},
+	{
+		"ModelType": 2421,
+		"Name": "Agrias (Orbonne)"
+	},
+	{
+		"ModelType": 2422,
+		"Name": "Mustadio (Orbonne)"
+	},
+	{
+		"ModelType": 2423,
+		"Name": "Azulmagia"
+	},
+	{
+		"ModelType": 2424,
+		"Name": "Provenance Watcher"
+	},
+	{
+		"ModelType": 2425,
+		"Name": "Absolute Virtue Dragon Add"
+	},
+	{
+		"ModelType": 2426,
+		"Name": "Phoenix - Possibly Suzaku"
+	},
+	{
+		"ModelType": 2427,
+		"Name": "Midgardsormr Head (Omega)"
+	},
+	{
+		"ModelType": 2428,
+		"Name": "Chiliad Cama"
+	},
+	{
+		"ModelType": 2429,
+		"Name": "Ugly ass Red Chicken"
+	},
+	{
+		"ModelType": 2430,
+		"Name": "Amalj'aa???"
+	},
+	{
+		"ModelType": 2431,
+		"Name": "Wetland Warg"
+	},
+	{
+		"ModelType": 2432,
+		"Name": "Tempest mob?? Unknown"
+	},
+	{
+		"ModelType": 2433,
+		"Name": "Grey Draco"
+	},
+	{
+		"ModelType": 2434,
+		"Name": "Phillia (Holmister final boss)"
+	},
+	{
+		"ModelType": 2435,
+		"Name": "Eros (Ravel Final Boss)"
+	},
+	{
+		"ModelType": 2436,
+		"Name": "Omega Level Checker"
+	},
+	{
+		"ModelType": 2437,
+		"Name": " Eldthurs",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2438,
+		"Name": "Eggplant",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2439,
+		"Name": "Matmata"
+	},
+	{
+		"ModelType": 2440,
+		"Name": "Giant Autoturret (Orbonne Add)"
+	},
+	{
+		"ModelType": 2441,
+		"Name": "minion nu mou"
+	},
+	{
+		"ModelType": 2442,
+		"Name": "Hedgehog",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2443,
+		"Name": "Pillow"
+	},
+	{
+		"ModelType": 2444,
+		"Name": "Fisherman Otter",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2445,
+		"Name": "Gigantender"
+	},
+	{
+		"ModelType": 2446,
+		"Name": "Phenoix Add"
+	},
+	{
+		"ModelType": 2447,
+		"Name": "Korpokkur"
+	},
+	{
+		"ModelType": 2448,
+		"Name": "Harpy (Orbonne)"
+	},
+	{
+		"ModelType": 2451,
+		"Name": "Ultimate Kamuy/Wolf"
+	},
+	{
+		"ModelType": 2452,
+		"Name": "Hallowed Kamuy",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2453,
+		"Name": "Ovni"
+	},
+	{
+		"ModelType": 2454,
+		"Name": "Sticks are alive!?"
+	},
+	{
+		"ModelType": 2455,
+		"Name": "Ran'jit"
+	},
+	{
+		"ModelType": 2456,
+		"Name": "Ran'jit with scythe"
+	},
+	{
+		"ModelType": 2457,
+		"Name": "Ran'jit pet"
+	},
+	{
+		"ModelType": 2458,
+		"Name": "Eden Mount!?"
+	},
+	{
+		"ModelType": 2459,
+		"Name": "Omega M | F Puddle"
+	},
+	{
+		"ModelType": 2460,
+		"Name": "Omega 11s Hands"
+	},
+	{
+		"ModelType": 2461,
+		"Name": "Soft Pillow"
+	},
+	{
+		"ModelType": 2462,
+		"Name": "Sin Eater Mob??"
+	},
+	{
+		"ModelType": 2463,
+		"Name": "Raiden"
+	},
+	{
+		"ModelType": 2464,
+		"Name": "Seiryu (Snake Form)"
+	},
+	{
+		"ModelType": 2465,
+		"Name": "War Tiger",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2466,
+		"Name": "Magitek Avenger A-1"
+	},
+	{
+		"ModelType": 2467,
+		"Name": "Maxima Roader",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2468,
+		"Name": "Eurekan Petrel",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2469,
+		"Name": "Garuda XV Event"
+	},
+	{
+		"ModelType": 2470,
+		"Name": "Trisiltia"
+	},
+	{
+		"ModelType": 2471,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2472,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2473,
+		"Name": "Ultima: The High Seraph (Orbonne)"
+	},
+	{
+		"ModelType": 2474,
+		"Name": "Titania"
+	},
+	{
+		"ModelType": 2475,
+		"Name": "Aenc Thon: Lord of the Lingering Gaze"
+	},
+	{
+		"ModelType": 2476,
+		"Name": "Griaule"
+	},
+	{
+		"ModelType": 2477,
+		"Name": "Lakelord Aenc Thon of the Long Gait"
+	},
+	{
+		"ModelType": 2478,
+		"Name": "Hades: first form "
+	},
+	{
+		"ModelType": 2479,
+		"Name": "Slime (Gold)"
+	},
+	{
+		"ModelType": 2481,
+		"Name": "Christmas Slime"
+	},
+	{
+		"ModelType": 2482,
+		"Name": "Fae Gwiber",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2483,
+		"Name": "Black Hayate",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2484,
+		"Name": "chameleon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2485,
+		"Name": "Y'shtola",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2486,
+		"Name": "Ryne",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2487,
+		"Name": "Ran'jit  - Frozen "
+	},
+	{
+		"ModelType": 2488,
+		"Name": "Masterless Talos"
+	},
+	{
+		"ModelType": 2489,
+		"Name": "Amphibious Talos"
+	},
+	{
+		"ModelType": 2491,
+		"Name": "Micro Gigantender",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2492,
+		"Name": "Armadillo Bowler",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2493,
+		"Name": "The Great Serpent of Ronka",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2494,
+		"Name": "Clionid Larva minion "
+	},
+	{
+		"ModelType": 2495,
+		"Name": "Bitty Duckbill",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2496,
+		"Name": "Gilgamesh"
+	},
+	{
+		"ModelType": 2497,
+		"Name": "T.G. Sword"
+	},
+	{
+		"ModelType": 2498,
+		"Name": "Ozma"
+	},
+	{
+		"ModelType": 2499,
+		"Name": "Owain's Hand"
+	},
+	{
+		"ModelType": 2500,
+		"Name": "Art's Spear"
+	},
+	{
+		"ModelType": 2501,
+		"Name": "Owain's Spear"
+	},
+	{
+		"ModelType": 2502,
+		"Name": "Ceto"
+	},
+	{
+		"ModelType": 2503,
+		"Name": "Art"
+	},
+	{
+		"ModelType": 2504,
+		"Name": "Owain"
+	},
+	{
+		"ModelType": 2506,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2507,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2508,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2509,
+		"Name": "Alt Model (???)"
+	},
+	{
+		"ModelType": 2510,
+		"Name": "The Thunder God (Orbonne)"
+	},
+	{
+		"ModelType": 2511,
+		"Name": "Regalia"
+	},
+	{
+		"ModelType": 2512,
+		"Name": "Ozma"
+	},
+	{
+		"ModelType": 2513,
+		"Name": "???Unsure sapling mob"
+	},
+	{
+		"ModelType": 2514,
+		"Name": "Vauthry"
+	},
+	{
+		"ModelType": 2515,
+		"Name": "Innocence"
+	},
+	{
+		"ModelType": 2516,
+		"Name": "Goblin/Lamebrix"
+	},
+	{
+		"ModelType": 2517,
+		"Name": "Goblin/Lamebrix"
+	},
+	{
+		"ModelType": 2520,
+		"Name": " Feo UI (Demimonster(Equipment change needed)"
+	},
+	{
+		"ModelType": 2521,
+		"Name": "Tusk"
+	},
+	{
+		"ModelType": 2522,
+		"Name": "Batsquatch"
+	},
+	{
+		"ModelType": 2523,
+		"Name": "Gukumatz "
+	},
+	{
+		"ModelType": 2524,
+		"Name": "Forgiven Jealousy (Sin Eater)"
+	},
+	{
+		"ModelType": 2525,
+		"Name": "Daen (??)"
+	},
+	{
+		"ModelType": 2526,
+		"Name": "Kamuy of the Nine Tails",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2527,
+		"Name": "Eden's Leviathan"
+	},
+	{
+		"ModelType": 2528,
+		"Name": "Eden's Titan"
+	},
+	{
+		"ModelType": 2529,
+		"Name": "Eden's Titan 2nd Form"
+	},
+	{
+		"ModelType": 2530,
+		"Name": "Eden "
+	},
+	{
+		"ModelType": 2531,
+		"Name": "Terminus Bellweather"
+	},
+	{
+		"ModelType": 2532,
+		"Name": "Lozatl"
+	},
+	{
+		"ModelType": 2533,
+		"Name": "Hades: second form"
+	},
+	{
+		"ModelType": 2534,
+		"Name": "Lake Anemone"
+	},
+	{
+		"ModelType": 2535,
+		"Name": "Greater Armadillo"
+	},
+	{
+		"ModelType": 2536,
+		"Name": "Triceratops - Mount"
+	},
+	{
+		"ModelType": 2537,
+		"Name": "Giant Iguana"
+	},
+	{
+		"ModelType": 2538,
+		"Name": "Ultima Grandcross Crystal"
+	},
+	{
+		"ModelType": 2539,
+		"Name": "Amaro (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2540,
+		"Name": "The Fae Bismarck"
+	},
+	{
+		"ModelType": 2541,
+		"Name": "Rusted Golem (Orbonne Add)"
+	},
+	{
+		"ModelType": 2542,
+		"Name": "Prototype Magitek Armor (Ghimlyt Boss)"
+	},
+	{
+		"ModelType": 2543,
+		"Name": "Turtle Doll (Red)"
+	},
+	{
+		"ModelType": 2544,
+		"Name": "Overweight Miqo'te Woman (Demihuman - Equipment must be changed)"
+	},
+	{
+		"ModelType": 2545,
+		"Name": "Ephemeral Warrior (Thunder God Add)"
+	},
+	{
+		"ModelType": 2546,
+		"Name": "Zenos"
+	},
+	{
+		"ModelType": 2547,
+		"Name": "Hashmal Junior"
+	},
+	{
+		"ModelType": 2548,
+		"Name": "Batraal Junior"
+	},
+	{
+		"ModelType": 2549,
+		"Name": "Famfrit Junior"
+	},
+	{
+		"ModelType": 2551,
+		"Name": "Daidarabochi Shikigami (Seiryu Add)"
+	},
+	{
+		"ModelType": 2553,
+		"Name": "Shining Pegasus?"
+	},
+	{
+		"ModelType": 2554,
+		"Name": "Zenos"
+	},
+	{
+		"ModelType": 2555,
+		"Name": "Zenos"
+	},
+	{
+		"ModelType": 2556,
+		"Name": "Zenos"
+	},
+	{
+		"ModelType": 2557,
+		"Name": "Construct 8 (Refurbished)"
+	},
+	{
+		"ModelType": 2558,
+		"Name": "Flower Basket"
+	},
+	{
+		"ModelType": 2559,
+		"Name": "Forgiven Conformity (Sin Eater)"
+	},
+	{
+		"ModelType": 2560,
+		"Name": "Sin Eater Bird (??) "
+	},
+	{
+		"ModelType": 2561,
+		"Name": "Sin Eater Dzo (??)"
+	},
+	{
+		"ModelType": 2562,
+		"Name": "Sin Eater Bear (??) "
+	},
+	{
+		"ModelType": 2563,
+		"Name": "The Tycoon"
+	},
+	{
+		"ModelType": 2564,
+		"Name": "Giant Beaver"
+	},
+	{
+		"ModelType": 2565,
+		"Name": "Suzaku",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2566,
+		"Name": "Eden's",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2567,
+		"Name": "Omega-M",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2568,
+		"Name": "Omega-F minion "
+	},
+	{
+		"ModelType": 2569,
+		"Name": "Cube",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2570,
+		"Name": "Forgiven Obsentity (Mt.Gulag Final Boss)"
+	},
+	{
+		"ModelType": 2571,
+		"Name": "Cladoselcahe"
+	},
+	{
+		"ModelType": 2572,
+		"Name": "Doliodus  "
+	},
+	{
+		"ModelType": 2573,
+		"Name": "Puck: Titania Add"
+	},
+	{
+		"ModelType": 2574,
+		"Name": "Moss Fungus"
+	},
+	{
+		"ModelType": 2575,
+		"Name": "The First's Construction"
+	},
+	{
+		"ModelType": 2576,
+		"Name": "Hades"
+	},
+	{
+		"ModelType": 2577,
+		"Name": "Looks like it came straight from Doom"
+	},
+	{
+		"ModelType": 2578,
+		"Name": "Horse can't see????"
+	},
+	{
+		"ModelType": 2579,
+		"Name": "Fire Bomber"
+	},
+	{
+		"ModelType": 2580,
+		"Name": "Ice Bomber"
+	},
+	{
+		"ModelType": 2582,
+		"Name": "Formidable"
+	},
+	{
+		"ModelType": 2583,
+		"Name": "Ironfrog Mover"
+	},
+	{
+		"ModelType": 2584,
+		"Name": "Innocent Gwiber"
+	},
+	{
+		"ModelType": 2585,
+		"Name": "Archaeotania "
+	},
+	{
+		"ModelType": 2586,
+		"Name": "Marquis Morbol "
+	},
+	{
+		"ModelType": 2587,
+		"Name": "Echevore"
+	},
+	{
+		"ModelType": 2588,
+		"Name": "Dagon"
+	},
+	{
+		"ModelType": 2589,
+		"Name": "Geodude"
+	},
+	{
+		"ModelType": 2590,
+		"Name": "Unsure: Tail-less Pieste (??)"
+	},
+	{
+		"ModelType": 2591,
+		"Name": "Unsure: Stone beast with large bulb  (??)"
+	},
+	{
+		"ModelType": 2592,
+		"Name": "The First Beast"
+	},
+	{
+		"ModelType": 2593,
+		"Name": "Aglaope"
+	},
+	{
+		"ModelType": 2594,
+		"Name": "Gunitt"
+	},
+	{
+		"ModelType": 2595,
+		"Name": "Garden Porxie"
+	},
+	{
+		"ModelType": 2596,
+		"Name": "Ronkan Dreamer"
+	},
+	{
+		"ModelType": 2597,
+		"Name": "Deacon"
+	},
+	{
+		"ModelType": 2598,
+		"Name": "Huracan"
+	},
+	{
+		"ModelType": 2599,
+		"Name": "A Rank O Poorest Pauldia"
+	},
+	{
+		"ModelType": 2600,
+		"Name": "Kuribu Sin Eater"
+	},
+	{
+		"ModelType": 2601,
+		"Name": "Evil Weapon"
+	},
+	{
+		"ModelType": 2602,
+		"Name": "Tiny Echevore",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2604,
+		"Name": "Shoebill",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2605,
+		"Name": "Butterfly Effect",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2606,
+		"Name": "Ironfrog Ambler",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2607,
+		"Name": "Forgiven Hate minion "
+	},
+	{
+		"ModelType": 2608,
+		"Name": "Tinker's bell",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2609,
+		"Name": "Emet-Selch",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2610,
+		"Name": "Crystal Exarch",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2611,
+		"Name": "Forgiven Dissonance"
+	},
+	{
+		"ModelType": 2612,
+		"Name": "Mithridates "
+	},
+	{
+		"ModelType": 2613,
+		"Name": "Forgiven Cruelty "
+	},
+	{
+		"ModelType": 2614,
+		"Name": "Forgiven Rebellion"
+	},
+	{
+		"ModelType": 2615,
+		"Name": "sin eater cocoon"
+	},
+	{
+		"ModelType": 2616,
+		"Name": "Mustardseed: Titania add"
+	},
+	{
+		"ModelType": 2617,
+		"Name": "Peaceblossom: Titnia add"
+	},
+	{
+		"ModelType": 2618,
+		"Name": "Automation Queen (MCH ROBOT)"
+	},
+	{
+		"ModelType": 2619,
+		"Name": "Seraph"
+	},
+	{
+		"ModelType": 2620,
+		"Name": "Pyheonix"
+	},
+	{
+		"ModelType": 2622,
+		"Name": "Sin Eater Diremite (??) "
+	},
+	{
+		"ModelType": 2623,
+		"Name": "Sin Eater Diremite B (??)"
+	},
+	{
+		"ModelType": 2624,
+		"Name": "Tentacle"
+	},
+	{
+		"ModelType": 2625,
+		"Name": "Engendered Soma "
+	},
+	{
+		"ModelType": 2627,
+		"Name": "Eden's Voidwalker"
+	},
+	{
+		"ModelType": 2628,
+		"Name": "Eden's Voidwalker's hand add stuff"
+	},
+	{
+		"ModelType": 2629,
+		"Name": "Forgiven Extortion (Sin Eater fenrir)"
+	},
+	{
+		"ModelType": 2630,
+		"Name": "Forgiven Apathy"
+	},
+	{
+		"ModelType": 2631,
+		"Name": "Spikey"
+	},
+	{
+		"ModelType": 2632,
+		"Name": "Tesleen Sin Eater"
+	},
+	{
+		"ModelType": 2633,
+		"Name": "Forgiven Ambition"
+	},
+	{
+		"ModelType": 2634,
+		"Name": "Forgiven Violence"
+	},
+	{
+		"ModelType": 2635,
+		"Name": "Feather"
+	},
+	{
+		"ModelType": 2636,
+		"Name": "Tentacle Woman"
+	},
+	{
+		"ModelType": 2637,
+		"Name": "Darker Tentacle Woman"
+	},
+	{
+		"ModelType": 2638,
+		"Name": "Gate Final Mt.Gulag"
+	},
+	{
+		"ModelType": 2639,
+		"Name": "Gate Final Mt.Gulag"
+	},
+	{
+		"ModelType": 2640,
+		"Name": "CATASTROPHE"
+	},
+	{
+		"ModelType": 2641,
+		"Name": "Flying Head"
+	},
+	{
+		"ModelType": 2642,
+		"Name": "Sticks Sticks but ice"
+	},
+	{
+		"ModelType": 2643,
+		"Name": "Golemn"
+	},
+	{
+		"ModelType": 2644,
+		"Name": "Sword"
+	},
+	{
+		"ModelType": 2645,
+		"Name": "Circus Ahriman (T-pose)"
+	},
+	{
+		"ModelType": 2646,
+		"Name": "Magicked Bed",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2647,
+		"Name": "Sin Eater Demon wall"
+	},
+	{
+		"ModelType": 2648,
+		"Name": "Titania's Add"
+	},
+	{
+		"ModelType": 2649,
+		"Name": "Dodo"
+	},
+	{
+		"ModelType": 2650,
+		"Name": "Goobu"
+	},
+	{
+		"ModelType": 2651,
+		"Name": "Sea Anemone"
+	},
+	{
+		"ModelType": 2652,
+		"Name": "Etainmoth"
+	},
+	{
+		"ModelType": 2653,
+		"Name": "Phooka"
+	},
+	{
+		"ModelType": 2654,
+		"Name": "Sword"
+	},
+	{
+		"ModelType": 2655,
+		"Name": "Mark CXLIV Thermocoil Boilbuster"
+	},
+	{
+		"ModelType": 2656,
+		"Name": "Boulder in MSQ"
+	},
+	{
+		"ModelType": 2657,
+		"Name": "Trappy thing in 73 dgn"
+	},
+	{
+		"ModelType": 2658,
+		"Name": "Violet Triffid"
+	},
+	{
+		"ModelType": 2659,
+		"Name": "Ngozi"
+	},
+	{
+		"ModelType": 2660,
+		"Name": "Green Glider"
+	},
+	{
+		"ModelType": 2661,
+		"Name": "A rank in greatwoods?"
+	},
+	{
+		"ModelType": 2662,
+		"Name": "ShB S-rank goobue"
+	},
+	{
+		"ModelType": 2663,
+		"Name": "Serpent"
+	},
+	{
+		"ModelType": 2664,
+		"Name": "A rock"
+	},
+	{
+		"ModelType": 2665,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2666,
+		"Name": "Looks Delicious: from Tempest"
+	},
+	{
+		"ModelType": 2667,
+		"Name": "Shinryu head?"
+	},
+	{
+		"ModelType": 2668,
+		"Name": "S-rank SHB"
+	},
+	{
+		"ModelType": 2669,
+		"Name": "The Forlorn"
+	},
+	{
+		"ModelType": 2670,
+		"Name": "Golden Construct"
+	},
+	{
+		"ModelType": 2671,
+		"Name": "Forgiven Whimsy"
+	},
+	{
+		"ModelType": 2672,
+		"Name": "Gnole"
+	},
+	{
+		"ModelType": 2673,
+		"Name": "Engedered Pteraketos"
+	},
+	{
+		"ModelType": 2674,
+		"Name": "Ancient Lizard"
+	},
+	{
+		"ModelType": 2675,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2676,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2677,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2678,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2679,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2680,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2681,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2682,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2683,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2684,
+		"Name": "Cubus"
+	},
+	{
+		"ModelType": 2685,
+		"Name": "Flanborg"
+	},
+	{
+		"ModelType": 2686,
+		"Name": "Succubus"
+	},
+	{
+		"ModelType": 2687,
+		"Name": "Friendly Tempest Demihumans"
+	},
+	{
+		"ModelType": 2688,
+		"Name": "Hobgoblin"
+	},
+	{
+		"ModelType": 2689,
+		"Name": "Hobgoblin"
+	},
+	{
+		"ModelType": 2690,
+		"Name": "Hobgoblin"
+	},
+	{
+		"ModelType": 2691,
+		"Name": "Demihuman?"
+	},
+	{
+		"ModelType": 2692,
+		"Name": "Kobold (Without Helmet)"
+	},
+	{
+		"ModelType": 2693,
+		"Name": "Nu Mou"
+	},
+	{
+		"ModelType": 2694,
+		"Name": "Friendly Tempest Demihumans"
+	},
+	{
+		"ModelType": 2695,
+		"Name": "Friendly Tempest Demihumans"
+	},
+	{
+		"ModelType": 2698,
+		"Name": "Dark orb"
+	},
+	{
+		"ModelType": 2699,
+		"Name": "Eden's Orb"
+	},
+	{
+		"ModelType": 2701,
+		"Name": "Eden"
+	},
+	{
+		"ModelType": 2702,
+		"Name": "Fist in Titana"
+	},
+	{
+		"ModelType": 2703,
+		"Name": "Golden Nimbus"
+	},
+	{
+		"ModelType": 2705,
+		"Name": "Glowy Orb"
+	},
+	{
+		"ModelType": 2707,
+		"Name": "Greatwoods Golem"
+	},
+	{
+		"ModelType": 2708,
+		"Name": "Eden's Titan Rocks"
+	},
+	{
+		"ModelType": 2709,
+		"Name": "Eden's Voidwalker's Adds"
+	},
+	{
+		"ModelType": 2710,
+		"Name": "Storge - Malikah's Well 3rd boss"
+	},
+	{
+		"ModelType": 2711,
+		"Name": "Feo Ul King Titania"
+	},
+	{
+		"ModelType": 2712,
+		"Name": "???"
+	},
+	{
+		"ModelType": 2713,
+		"Name": "Amaurotine",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2716,
+		"Name": "Red ugly bird"
+	},
+	{
+		"ModelType": 2717,
+		"Name": "Spriggan Stonecarrier",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2718,
+		"Name": "Philia - Holminster Switch"
+	},
+	{
+		"ModelType": 2719,
+		"Name": "Dummy"
+	},
+	{
+		"ModelType": 2720,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2721,
+		"Name": "Chain/Stun/Whatever"
+	},
+	{
+		"ModelType": 2722,
+		"Name": "Golden Fuath (??)"
+	},
+	{
+		"ModelType": 2723,
+		"Name": "Golem boss that does water stuff"
+	},
+	{
+		"ModelType": 2724,
+		"Name": "Tyger (S-Rank Hunt)"
+	},
+	{
+		"ModelType": 2726,
+		"Name": "Giraffe?"
+	},
+	{
+		"ModelType": 2728,
+		"Name": "Forgiven Reticence",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2729,
+		"Name": "Talos"
+	},
+	{
+		"ModelType": 2731,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2732,
+		"Name": "Amber Iguana"
+	},
+	{
+		"ModelType": 2733,
+		"Name": "Battle Tiger",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2734,
+		"Name": "Froggo"
+	},
+	{
+		"ModelType": 2735,
+		"Name": "Therion"
+	},
+	{
+		"ModelType": 2736,
+		"Name": "Therion - Flying"
+	},
+	{
+		"ModelType": 2737,
+		"Name": "Sin Eater"
+	},
+	{
+		"ModelType": 2738,
+		"Name": "Cracked Ronkan Vessel"
+	},
+	{
+		"ModelType": 2739,
+		"Name": "Sin Eater cacoon"
+	},
+	{
+		"ModelType": 2740,
+		"Name": "Dark Orb"
+	},
+	{
+		"ModelType": 2741,
+		"Name": "Piglet"
+	},
+	{
+		"ModelType": 2742,
+		"Name": "Pixie Minion ??"
+	},
+	{
+		"ModelType": 2743,
+		"Name": "Engels"
+	},
+	{
+		"ModelType": 2744,
+		"Name": "Quetzalcoatl - Akadaemia"
+	},
+	{
+		"ModelType": 2745,
+		"Name": "Pegasus"
+	},
+	{
+		"ModelType": 2746,
+		"Name": "Dark Pegasus"
+	},
+	{
+		"ModelType": 2747,
+		"Name": "Fenrir"
+	},
+	{
+		"ModelType": 2748,
+		"Name": "Ugly ass bird"
+	},
+	{
+		"ModelType": 2749,
+		"Name": "Cute",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2750,
+		"Name": "Dark Wizard!? Forgot what name this guy is?"
+	},
+	{
+		"ModelType": 2752,
+		"Name": "Morbol (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2753,
+		"Name": "Eden's Titan"
+	},
+	{
+		"ModelType": 2754,
+		"Name": "Eden Prime"
+	},
+	{
+		"ModelType": 2755,
+		"Name": "Meerkat"
+	},
+	{
+		"ModelType": 2756,
+		"Name": "Minion with a Knife"
+	},
+	{
+		"ModelType": 2757,
+		"Name": "Sin eater lion"
+	},
+	{
+		"ModelType": 2758,
+		"Name": "Skyslipper (E4S Mount)"
+	},
+	{
+		"ModelType": 2759,
+		"Name": "Circus Ahriman",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2760,
+		"Name": "Portly Porxie",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2761,
+		"Name": "Epimetheus",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2762,
+		"Name": "Menoetius",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2763,
+		"Name": "Add in Twinning?"
+	},
+	{
+		"ModelType": 2764,
+		"Name": "Formidable"
+	},
+	{
+		"ModelType": 2766,
+		"Name": "Pixies - Demihumans"
+	},
+	{
+		"ModelType": 2767,
+		"Name": "Box"
+	},
+	{
+		"ModelType": 2768,
+		"Name": "Smaller Box"
+	},
+	{
+		"ModelType": 2769,
+		"Name": "Glider (Green)"
+	},
+	{
+		"ModelType": 2770,
+		"Name": "Glider (Blue)"
+	},
+	{
+		"ModelType": 2771,
+		"Name": "Construct VII",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2772,
+		"Name": "Shadow Gwiber",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2773,
+		"Name": "White Horse",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2774,
+		"Name": "Brute Justice",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2775,
+		"Name": "Little Fish"
+	},
+	{
+		"ModelType": 2776,
+		"Name": "Maliktender (A Rank)"
+	},
+	{
+		"ModelType": 2777,
+		"Name": "Debitage"
+	},
+	{
+		"ModelType": 2778,
+		"Name": "Cliffmole"
+	},
+	{
+		"ModelType": 2779,
+		"Name": "Consort of Sin: Forgiven Obscenity"
+	},
+	{
+		"ModelType": 2780,
+		"Name": "Dagon"
+	},
+	{
+		"ModelType": 2781,
+		"Name": "Last boss in Mt.Gulag"
+	},
+	{
+		"ModelType": 2782,
+		"Name": "Alexander Prime (TEA version)"
+	},
+	{
+		"ModelType": 2783,
+		"Name": "Perfect Alexander (Golden)"
+	},
+	{
+		"ModelType": 2784,
+		"Name": "Perfect Alexander (Coloured)"
+	},
+	{
+		"ModelType": 2785,
+		"Name": "Seeker of Solitutde (Cosmos 1st Boss)"
+	},
+	{
+		"ModelType": 2786,
+		"Name": "Hobbes (Copied Factory 2nd Boss)"
+	},
+	{
+		"ModelType": 2787,
+		"Name": "Hobbes Armature"
+	},
+	{
+		"ModelType": 2788,
+		"Name": "Hobbes Armature 2"
+	},
+	{
+		"ModelType": 2789,
+		"Name": "Ludus (Cosmos Final Boss)"
+	},
+	{
+		"ModelType": 2790,
+		"Name": "Leannan Sith Seed"
+	},
+	{
+		"ModelType": 2791,
+		"Name": "Serial-jointed Command Model (Copied Factory 1st Boss)"
+	},
+	{
+		"ModelType": 2792,
+		"Name": "9S-operated Walking Fortress (Copied Factory Final Boss)"
+	},
+	{
+		"ModelType": 2793,
+		"Name": "Lord Tolthewil (Cosmos Mini-Boss)"
+	},
+	{
+		"ModelType": 2794,
+		"Name": "Hades Extreme (???)"
+	},
+	{
+		"ModelType": 2795,
+		"Name": "9S in Flier"
+	},
+	{
+		"ModelType": 2796,
+		"Name": "2P in Flier"
+	},
+	{
+		"ModelType": 2797,
+		"Name": "Garuda, Heritor of the Vortex"
+	},
+	{
+		"ModelType": 2799,
+		"Name": "Kingly Peacock(T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2800,
+		"Name": "Little Leannan",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2801,
+		"Name": "Dress-Up Estinien",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2802,
+		"Name": "Wind-Up Hobgoblin",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2804,
+		"Name": "Destrudo (Pixie Quest Boss)"
+	},
+	{
+		"ModelType": 2805,
+		"Name": "PROBABLY Engels (absolutely massive)"
+	},
+	{
+		"ModelType": 2806,
+		"Name": "Arch Ultima"
+	},
+	{
+		"ModelType": 2807,
+		"Name": "Spartoi"
+	},
+	{
+		"ModelType": 2808,
+		"Name": "Golden Heart"
+	},
+	{
+		"ModelType": 2809,
+		"Name": "Nier Orbs"
+	},
+	{
+		"ModelType": 2810,
+		"Name": "2P",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2811,
+		"Name": "Red orb (???)"
+	},
+	{
+		"ModelType": 2812,
+		"Name": "Blue square (???)"
+	},
+	{
+		"ModelType": 2813,
+		"Name": "Magicked Broom sweeping"
+	},
+	{
+		"ModelType": 2814,
+		"Name": "Ruby Weapon"
+	},
+	{
+		"ModelType": 2816,
+		"Name": "Sppoky demon Bird"
+	},
+	{
+		"ModelType": 2817,
+		"Name": "Leannan Sith (Cosmos 2nd Boss)"
+	},
+	{
+		"ModelType": 2818,
+		"Name": "Pod 054",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2819,
+		"Name": "Pod 316"
+	},
+	{
+		"ModelType": 2820,
+		"Name": "9S",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2821,
+		"Name": "Goliath Tank ?? (Nier Raid)"
+	},
+	{
+		"ModelType": 2822,
+		"Name": "Nier Add"
+	},
+	{
+		"ModelType": 2823,
+		"Name": "Nier Add 2"
+	},
+	{
+		"ModelType": 2824,
+		"Name": "Nier Add 3"
+	},
+	{
+		"ModelType": 2825,
+		"Name": "Nier Add 4"
+	},
+	{
+		"ModelType": 2826,
+		"Name": "Nier Add 5"
+	},
+	{
+		"ModelType": 2827,
+		"Name": "Nier Add 6"
+	},
+	{
+		"ModelType": 2828,
+		"Name": "Nier Goliath Tank"
+	},
+	{
+		"ModelType": 2829,
+		"Name": "Nier Reverse-Jointed Goliath"
+	},
+	{
+		"ModelType": 2830,
+		"Name": "Zombie Behemoth"
+	},
+	{
+		"ModelType": 2831,
+		"Name": "Sand Mandagora ??"
+	},
+	{
+		"ModelType": 2832,
+		"Name": "Thordan - New Model Variant"
+	},
+	{
+		"ModelType": 2838,
+		"Name": "Ufiti",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2839,
+		"Name": "Pod (Nier Raid)"
+	},
+	{
+		"ModelType": 2840,
+		"Name": "Crystal Scorpion?"
+	},
+	{
+		"ModelType": 2841,
+		"Name": "Arch Ultima no pilot"
+	},
+	{
+		"ModelType": 2842,
+		"Name": "Nier Flier no pilot"
+	},
+	{
+		"ModelType": 2843,
+		"Name": "Nier Walking Fortress no pilot"
+	},
+	{
+		"ModelType": 2845,
+		"Name": "Nier Missiles"
+	},
+	{
+		"ModelType": 2846,
+		"Name": "Marx Support"
+	},
+	{
+		"ModelType": 2848,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2849,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2850,
+		"Name": "Bacon Bits",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2851,
+		"Name": "Ezel II"
+	},
+	{
+		"ModelType": 2852,
+		"Name": "Serial-jointed Command Model (Copied Factory 1st Boss)"
+	},
+	{
+		"ModelType": 2853,
+		"Name": "Gaia"
+	},
+	{
+		"ModelType": 2854,
+		"Name": "Eden 7 Birds"
+	},
+	{
+		"ModelType": 2855,
+		"Name": "Sungold Talos",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2856,
+		"Name": "T-Rex",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2857,
+		"Name": "Little Leafman",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2858,
+		"Name": "Silver Dasher",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2860,
+		"Name": "Peacock (T-pose)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2861,
+		"Name": "Great Vessel of Ronka",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2862,
+		"Name": "Pterodactyl",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2863,
+		"Name": "Ruby Gwiber",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2864,
+		"Name": "Kyklops (Anamensis 2nd Boss)"
+	},
+	{
+		"ModelType": 2865,
+		"Name": "Kukshs Dheem (Anamensis Final Boss)"
+	},
+	{
+		"ModelType": 2866,
+		"Name": "Ramuh, Heritor of Levin"
+	},
+	{
+		"ModelType": 2867,
+		"Name": "Mochi Minotaur"
+	},
+	{
+		"ModelType": 2868,
+		"Name": "Generic Person",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2869,
+		"Name": "Insatiable Flame: Lugus"
+	},
+	{
+		"ModelType": 2870,
+		"Name": "Small Stubby (Nier)"
+	},
+	{
+		"ModelType": 2872,
+		"Name": "Ruby Weapon Add (???)"
+	},
+	{
+		"ModelType": 2873,
+		"Name": "Unknown (Anamensis 1st Boss)"
+	},
+	{
+		"ModelType": 2874,
+		"Name": "Eden Ramuh Horse Add"
+	},
+	{
+		"ModelType": 2875,
+		"Name": "Eden Ramuh Black"
+	},
+	{
+		"ModelType": 2876,
+		"Name": "Bozja Walking Cannon"
+	},
+	{
+		"ModelType": 2877,
+		"Name": "Flying Hairy Eyeball"
+	},
+	{
+		"ModelType": 2878,
+		"Name": "Kukshs Dheem Add"
+	},
+	{
+		"ModelType": 2879,
+		"Name": "Ruby Weapon - Nael van Darnus phase"
+	},
+	{
+		"ModelType": 2880,
+		"Name": "Eden Idol of Darkness"
+	},
+	{
+		"ModelType": 2881,
+		"Name": "Sapphire Weapon Gundam"
+	},
+	{
+		"ModelType": 2883,
+		"Name": "Eden Ifrit"
+	},
+	{
+		"ModelType": 2884,
+		"Name": "Trench Amemone"
+	},
+	{
+		"ModelType": 2885,
+		"Name": "Lo ousia"
+	},
+	{
+		"ModelType": 2886,
+		"Name": "Glowing Evil Bird"
+	},
+	{
+		"ModelType": 2887,
+		"Name": "Nael Heads(Red)"
+	},
+	{
+		"ModelType": 2888,
+		"Name": "Nael Heads(Blue)"
+	},
+	{
+		"ModelType": 2889,
+		"Name": "Eden Raktapaksa"
+	},
+	{
+		"ModelType": 2890,
+		"Name": "Eden Raktapaksa"
+	},
+	{
+		"ModelType": 2891,
+		"Name": "Behatted Serpent of Ronka",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2892,
+		"Name": "Paissa Patissier",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2893,
+		"Name": "Paissa Threadpuller",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2894,
+		"Name": "Ancient One",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2895,
+		"Name": "The Major-General",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2896,
+		"Name": "Wind-Up Dulia-Chai",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2897,
+		"Name": "Amaro",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2898,
+		"Name": "Laladile",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2899,
+		"Name": "Unlucky Rabbit",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2900,
+		"Name": "Hybodus",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2901,
+		"Name": "Ramuh (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2902,
+		"Name": "Eden Verse Shiva"
+	},
+	{
+		"ModelType": 2903,
+		"Name": "Eden Verse Shiva (Hydaelyn Form)"
+	},
+	{
+		"ModelType": 2904,
+		"Name": "Elidibus (Warrior of Light)"
+	},
+	{
+		"ModelType": 2905,
+		"Name": "Eden Verse Idol of Darkness"
+	},
+	{
+		"ModelType": 2906,
+		"Name": "Eden Bird Adds"
+	},
+	{
+		"ModelType": 2908,
+		"Name": "Eden Verse Idol of Darkness"
+	},
+	{
+		"ModelType": 2909,
+		"Name": "Zenos"
+	},
+	{
+		"ModelType": 2910,
+		"Name": "Eden Verse Shiva (Hraesvelgr Form)"
+	},
+	{
+		"ModelType": 2911,
+		"Name": "Ruby Weapon Orbs"
+	},
+	{
+		"ModelType": 2912,
+		"Name": "Eden Verse Idol of Darkness Birds"
+	},
+	{
+		"ModelType": 2913,
+		"Name": "Rubellite Carbuncle",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2915,
+		"Name": "Huaca"
+	},
+	{
+		"ModelType": 2917,
+		"Name": "BLU Blue X"
+	},
+	{
+		"ModelType": 2918,
+		"Name": "BLU Red X"
+	},
+	{
+		"ModelType": 2919,
+		"Name": "BLU Green X"
+	},
+	{
+		"ModelType": 2920,
+		"Name": "Garuda's Feathers"
+	},
+	{
+		"ModelType": 2921,
+		"Name": "Aqua Orb"
+	},
+	{
+		"ModelType": 2922,
+		"Name": "Lightning Spark"
+	},
+	{
+		"ModelType": 2924,
+		"Name": "Earthen Golem"
+	},
+	{
+		"ModelType": 2925,
+		"Name": "Brionac (Castrum Lacus Litore) (LARGE)"
+	},
+	{
+		"ModelType": 2926,
+		"Name": "Gabriel"
+	},
+	{
+		"ModelType": 2927,
+		"Name": "Vigilia"
+	},
+	{
+		"ModelType": 2928,
+		"Name": "Dáinsleif"
+	},
+	{
+		"ModelType": 2929,
+		"Name": "Bozja flying tank thing"
+	},
+	{
+		"ModelType": 2930,
+		"Name": "Alebrije monster thing"
+	},
+	{
+		"ModelType": 2931,
+		"Name": "Stack of blue cubes"
+	},
+	{
+		"ModelType": 2932,
+		"Name": "Void Octopus thing"
+	},
+	{
+		"ModelType": 2933,
+		"Name": "Pod (Nier raid)"
+	},
+	{
+		"ModelType": 2934,
+		"Name": "Eden Shiva (Naked: Transformation)"
+	},
+	{
+		"ModelType": 2935,
+		"Name": "Ruby Weapon (Nael van Darnus only)"
+	},
+	{
+		"ModelType": 2936,
+		"Name": "Ruby Weapon (Shell)"
+	},
+	{
+		"ModelType": 2937,
+		"Name": "Ramuh's Beard"
+	},
+	{
+		"ModelType": 2938,
+		"Name": "Animated Artisan",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2939,
+		"Name": "Black Parasol"
+	},
+	{
+		"ModelType": 2940,
+		"Name": "Blue Parasol"
+	},
+	{
+		"ModelType": 2941,
+		"Name": "Venat",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2942,
+		"Name": "Ifirit Orb"
+	},
+	{
+		"ModelType": 2943,
+		"Name": "Orb"
+	},
+	{
+		"ModelType": 2944,
+		"Name": "Eden Shiva (Hydaelyn Form)"
+	},
+	{
+		"ModelType": 2945,
+		"Name": "Griffon Lion?",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2947,
+		"Name": "Eden Idol of Darkness Birds"
+	},
+	{
+		"ModelType": 2948,
+		"Name": "Generic Person - Holding Baby",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 2953,
+		"Name": "Gaia"
+	},
+	{
+		"ModelType": 2954,
+		"Name": "Eden Idol of Darkness Birds"
+	},
+	{
+		"ModelType": 2955,
+		"Name": "Eden Idol of Darkness Birds"
+	},
+	{
+		"ModelType": 2956,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2957,
+		"Name": "813P-operated Aegis Unit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2958,
+		"Name": "724P-operated Superior Flight Unit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2959,
+		"Name": "905P-operated Heavy Artillery Unit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2960,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2961,
+		"Name": "Cladoselache",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2962,
+		"Name": "Light Artillery Unit (The Puppet's Bunker)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2963,
+		"Name": "The Queen (Gods Save the Queen)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2964,
+		"Name": "Compound 2P",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2965,
+		"Name": "white pod (minion/npc/flying model?)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2966,
+		"Name": "Emerald Weapon",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2967,
+		"Name": "Eden's Promise (Full Size)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2968,
+		"Name": "Spectral Berserker",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2969,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2970,
+		"Name": "4C6F6E67696E67: The Compound",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2971,
+		"Name": "Elddragon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2972,
+		"Name": "Broken Pod",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2973,
+		"Name": "Zul ",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2974,
+		"Name": "Jibanyan Couch (Static)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2975,
+		"Name": "Ehll Tou (Static)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2976,
+		"Name": "Gwiber of Light (Static)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 2977,
+		"Name": "Lalinator 5.H0",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2978,
+		"Name": "Wind-Up Mystel",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2979,
+		"Name": "Wind-Up Ardbert",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2980,
+		"Name": "Magitek Helldiver F1",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2981,
+		"Name": "Weatherproof Gaelicat",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2982,
+		"Name": "Ephemeral Necromancer",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2983,
+		"Name": "Allagan Melon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2984,
+		"Name": "Sand Fox",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2985,
+		"Name": "Petit Pteranodon",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2986,
+		"Name": "Dáinsleif F1",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2987,
+		"Name": "Lord Enma",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2988,
+		"Name": "Lord Ananta",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2989,
+		"Name": "Zazel",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2990,
+		"Name": "Demona",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2991,
+		"Name": "2B Automaton",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2992,
+		"Name": "2P Automaton",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 2993,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2994,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2995,
+		"Name": "Investigate",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 2996,
+		"Name": "Spectral Necromancer",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 2997,
+		"Name": "Water Orb",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 2998,
+		"Name": "Fire Orb",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 2999,
+		"Name": "Ball of feathers",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3000,
+		"Name": "Ehll Tou (Crafter Gear)",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 3001,
+		"Name": "Flight Unit Empty",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3003,
+		"Name": "Floor Mine",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3004,
+		"Name": "Red Orb of ouch",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3005,
+		"Name": "Magitek Hyperconveyor",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3006,
+		"Name": "Incitatus",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3007,
+		"Name": "Red Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3008,
+		"Name": "Purple Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3009,
+		"Name": "Yellow Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3010,
+		"Name": "Blue Checkered Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3011,
+		"Name": "Red Checkered Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3012,
+		"Name": "Black and White Checkered Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3014,
+		"Name": "Pile of Androids",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3015,
+		"Name": "Android",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 3017,
+		"Name": "Patriot",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3018,
+		"Name": "Flight Unit with Android",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3019,
+		"Name": "Construct X (used various places)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3020,
+		"Name": "Compound 2P (Black)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3021,
+		"Name": "Fatebreaker",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3022,
+		"Name": "Cloud of Darkness (Eden)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3023,
+		"Name": "Shadowkeeper",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3024,
+		"Name": "Gukumatz (Fatebreaker)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3025,
+		"Name": "Cerberus (Delibrum Reginae)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3026,
+		"Name": "White Orange Unicorn",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3027,
+		"Name": "Trinity Avowed",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3028,
+		"Name": "Ironfrog Mover",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3029,
+		"Name": "Sapphire Weapon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3030,
+		"Name": "Shiny Orb",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3031,
+		"Name": "Sultana Portrait",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3032,
+		"Name": "Much-coveted Mora",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3033,
+		"Name": "Syldrion-class Insubmersible",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3034,
+		"Name": "Wind-up Gaia",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3035,
+		"Name": "Wind-up Palom",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3037,
+		"Name": "Wind-up Edge",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3038,
+		"Name": "Wind-up Rydia",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3039,
+		"Name": "Wind-up Rosa",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3040,
+		"Name": "Save the Princess",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3041,
+		"Name": "Leshy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3042,
+		"Name": "Angel Wings",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3043,
+		"Name": "Snowman (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3044,
+		"Name": "Lunar Whale",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3045,
+		"Name": "Eden (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3046,
+		"Name": "Cerberus (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3047,
+		"Name": "Big Shell",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3048,
+		"Name": "Shadowkeeper (Standing)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3049,
+		"Name": "Emerald Weapon (Right Manipulator)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3050,
+		"Name": "Emerald Weapon (Left Manipulator)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3051,
+		"Name": "Trinity Seeker",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3052,
+		"Name": "Trinity Seeker (Swords)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3053,
+		"Name": "Trinity Seeker (Katanas)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3054,
+		"Name": "Mother Porxie",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3055,
+		"Name": "Queen's Warrior",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3056,
+		"Name": "Diamond Weapon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3057,
+		"Name": "Oracle of Darkness",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3058,
+		"Name": "Gogo, Master of Mimicry",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3059,
+		"Name": "Beastly Sculpture",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3060,
+		"Name": "Chiseled Sculpture",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3061,
+		"Name": "Emerald Weapon (with Manipulators, gold)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3062,
+		"Name": "Magitek Mine (Emerald Weapon)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3063,
+		"Name": "Lunar Bahamut",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3064,
+		"Name": "(Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3065,
+		"Name": "(Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3066,
+		"Name": "Exoray (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3067,
+		"Name": "Sonny of Ziggy",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3068,
+		"Name": "Cave Gelatin (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3069,
+		"Name": "Molten Phoebad (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3070,
+		"Name": "Emerald Weapon add (gold)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3071,
+		"Name": "Green Golem",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3072,
+		"Name": "Gold Minotaur",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3073,
+		"Name": "Grey Minotaur",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3074,
+		"Name": "Mud Ball (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3075,
+		"Name": "Mudman (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3076,
+		"Name": "Hot & Cold Fire 1 Arrow",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3077,
+		"Name": "Hot & Cold Fire 2 Arrow",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3078,
+		"Name": "Hot & Cold Blizzard 1 Arrow",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3079,
+		"Name": "Hot & Cold Blizzard 2 Arrow",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3080,
+		"Name": "Diamond Weapon (Armourless)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3081,
+		"Name": "Amhuluk",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3082,
+		"Name": "Lunar Bahamut Nail",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3084,
+		"Name": "Drone?",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3085,
+		"Name": "Queen's Soldier",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3086,
+		"Name": "Moogle",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3087,
+		"Name": "Cloud of Darknes (Eden, Clone)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3088,
+		"Name": "Queen's Knight",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3089,
+		"Name": "Hot & Cold Fire 2",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3090,
+		"Name": "Hot & Cold Blizzard 2",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3091,
+		"Name": "(Delibrum Reginae)",
+		"Type": "Unknown"
+	},
+	{
+		"ModelType": 3092,
+		"Name": "(Delibrum Reginae)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3093,
+		"Name": "(Delibrum Reginae)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3094,
+		"Name": "Shadowkeeper Shadow",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3095,
+		"Name": "Thunder Ring (Turn of the Heavens)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3096,
+		"Name": "Thunder Ring (Turn of the Heavens)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3097,
+		"Name": "Fire Mirror (Sundered Sky)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3098,
+		"Name": "Thunder Mirror (Sundered Sky)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3100,
+		"Name": "Emerald Gwiber",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3101,
+		"Name": "Prototype Roader",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3102,
+		"Name": "Chocorpokur",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3103,
+		"Name": "Gabriel Mark III",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3104,
+		"Name": "Antelope Doe",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3105,
+		"Name": "Antelope Stag",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3106,
+		"Name": "Drippy",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3107,
+		"Name": "Trike",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3108,
+		"Name": "Gull",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3109,
+		"Name": "Anteater",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3110,
+		"Name": "Dolphin Calf",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3111,
+		"Name": "Magitek Predator F1",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3112,
+		"Name": "Emerald Weapon (with Manipulators, green, open)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3113,
+		"Name": "Emerald Weapon (Right Manipulator, gold, sword)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3114,
+		"Name": "Emerald Weapon (Right Manipulator, gold, sword)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3115,
+		"Name": "Landerwaffe",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3116,
+		"Name": "Emerald Weapon Right Claw",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3117,
+		"Name": "Emerald Weapon Left Claw",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3118,
+		"Name": "Shadowkeeper (shadow clone)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3119,
+		"Name": "Shadowkeeper (standing shadow clone)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3121,
+		"Name": "Her Inflorescence",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3125,
+		"Name": "Lunar Ifrit",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3126,
+		"Name": "Umbral Orb (Trio)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3127,
+		"Name": "False Idol",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3130,
+		"Name": "Gretel",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3131,
+		"Name": "Hansel",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3148,
+		"Name": "Merlwyb",
+		"Type": "Character"
+	},
+	{
+		"ModelType": 3149,
+		"Name": "Umbral Orb (Solo)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3150,
+		"Name": "Eden's Promise",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3151,
+		"Name": "Eden's Promise",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3152,
+		"Name": "Senorita Sabotender",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3153,
+		"Name": "Benben Stone",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3154,
+		"Name": "Wanderer's Campfire",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3155,
+		"Name": "Smaller Stubby",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3156,
+		"Name": "Golden Beaver",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3157,
+		"Name": "Ascian Prime (Mitron/Loghrif)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3158,
+		"Name": "Sephirot-Egi (no leaves)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3159,
+		"Name": "Emerald Weapon (green, closed)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3166,
+		"Name": "Pleasant Dot Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3167,
+		"Name": "Prim Dot Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3168,
+		"Name": "Pastoral Dot Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3169,
+		"Name": "Gold Parasaucer",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3170,
+		"Name": "Conflagration Strike",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3172,
+		"Name": "Cruise Chaser (Mount)",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3174,
+		"Name": "Eden's Promise",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3175,
+		"Name": "Construct VI-S Core",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3176,
+		"Name": "Red Frog (Matoya's Relict)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3177,
+		"Name": "Rook Autoturret (Delibrum Reginae)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3178,
+		"Name": "Bishop Autoturret (Delibrum Reginae)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3179,
+		"Name": "Red Girl",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3179,
+		"Name": "Red Girl (Jumpscare)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3180,
+		"Name": "Red Girl (Giant)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3181,
+		"Name": "Xun-Zi / Meng-Zi",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3186,
+		"Name": "White Pylon (The Tower at Paradigm's Breach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3187,
+		"Name": "Black Pylon (The Tower at Paradigm's Breach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3188,
+		"Name": "Red Sphere (The Tower at Paradigm's Breach)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3189,
+		"Name": "White Hacking Droid (The Tower at Paradigm's Breach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3190,
+		"Name": "Black Hacking Droid (The Tower at Paradigm's Breach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3192,
+		"Name": "Magitek Core (Paglth'an)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3203,
+		"Name": "Tiamat Carrying Estinien",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3204,
+		"Name": "Spheroid (The Tower at Paradigm's Breach)",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3214,
+		"Name": "Wind-up Lyna",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3215,
+		"Name": "Wind-up Runar",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3217,
+		"Name": "9S Automaton",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3235,
+		"Name": "Diamond Gwiber",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3236,
+		"Name": "Polar Bear",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3237,
+		"Name": "Gilded Mikoshi",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3238,
+		"Name": "Resplendent Vessel Of Ronka",
+		"Type": "Mount"
+	},
+	{
+		"ModelType": 3242,
+		"Name": "Directional Orb (The Tower at Paradigm's Breach)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3243,
+		"Name": "White Lance (Red Girl)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3244,
+		"Name": "Black Lance (Red Girl)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3245,
+		"Name": "Latitudinal Marker (The Tower at Paradigm's Breach)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3246,
+		"Name": "Longitudinal Marker (The Tower at Paradigm's Breach)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3248,
+		"Name": "Energy Orb (The Tower at Paradigm's Breach)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3256,
+		"Name": "Floating Right Hand (Diamond Weapon)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3257,
+		"Name": "Floating Left Hand (Diamond Weapon)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3262,
+		"Name": "Diamond Weapon",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3286,
+		"Name": "Fat Cat Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3287,
+		"Name": "Great Paraserpent",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3288,
+		"Name": "Meteor Parasol",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3292,
+		"Name": "Electric orb (Paglth'an, Amhuluk fight)",
+		"Type": "Effect"
+	},
+	{
+		"ModelType": 3295,
+		"Name": "Hatchingtide 2021 Chicken",
+		"Type": "Monster"
+	},
+	{
+		"ModelType": 3316,
+		"Name": "Dolphin Calf",
+		"Type": "Minion"
+	},
+	{
+		"ModelType": 3326,
+		"Name": "Gull",
+		"Type": "Minion"
+	}
+]


### PR DESCRIPTION
This change includes name verification for the bulk of mounts and proper categorisations for them. It also addresses some sensitivity things such as swears to polish up the tool's image now that it's public. I'd like to work on refining this data further if there's interest from the dev team.

Apologies about the diff; it seems like the Windows line endings have messed this up somewhat. I can revert this file to having them if it's important.