### PR TITLE
Convert the item category dropdown to individually selectable checkboxes

### DIFF
--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -31,28 +31,16 @@
 			</Border>
 		</Expander>
 
-		<ComboBox Grid.Row="1" Margin="6" SelectedIndex="{Binding ModeInt}">
-			<ComboBoxItem>
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_All"/>
-			</ComboBoxItem>
-			<ComboBoxItem >
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_Items"/>
-			</ComboBoxItem>
-			<ComboBoxItem >
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_Props"/>
-			</ComboBoxItem>
-			<ComboBoxItem >
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_Performance"/>
-			</ComboBoxItem>
-			<ComboBoxItem >
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_Modded"/>
-			</ComboBoxItem>
-			<ComboBoxItem >
-				<XivToolsWpf:TextBlock Key="EquipmentSelector_Favorites"/>
-			</ComboBoxItem>
-		</ComboBox>
-
-			<!--<StackPanel Grid.Row="1" Orientation="Horizontal" Margin="6, 0, 0, 0">
+        <Expander Style="{StaticResource MaterialDesignExpander}" Grid.Row="1">
+            <Expander.Header>
+                <XivToolsWpf:TextBlock Key="EquipmentSelector_Categories" Foreground="{DynamicResource MaterialDesignBody}"/>
+            </Expander.Header>
+            <Border Background="{StaticResource MaterialDesignPaper}" CornerRadius="3">
+                <controls:ItemCategoryFilter Value="{Binding CategoryFilter}"/>
+            </Border>
+        </Expander>
+		
+		<!--<StackPanel Grid.Row="1" Orientation="Horizontal" Margin="6, 0, 0, 0">
 			<RadioButton Margin="3" IsChecked="{Binding AllMode}">
 				<controls:TextBlock Key="EquipmentSelector_All" Margin="0, -3, 6, 0"/>
 			</RadioButton>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -143,8 +143,8 @@ namespace Anamnesis.Character.Views
 					return false;
 
 				bool categoryFiltered = false;
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Items) && obj is not Prop && item.Key != 0;
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Props) && obj is Prop && obj is not PerformViewModel;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Items) && obj is not Prop && obj is not PerformViewModel && item.Key != 0;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Props) && obj is Prop;
 				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Performance) && obj is PerformViewModel;
 				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
 				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -4,13 +4,13 @@
 namespace Anamnesis.Character.Views
 {
 	using System;
-	using System.Windows;
 	using System.Windows.Controls;
 	using Anamnesis;
 	using Anamnesis.Character.Utilities;
 	using Anamnesis.GameData;
 	using Anamnesis.GameData.ViewModels;
 	using Anamnesis.Services;
+	using Anamnesis.Styles.Controls;
 	using Anamnesis.Styles.Drawers;
 	using PropertyChanged;
 
@@ -20,8 +20,8 @@ namespace Anamnesis.Character.Views
 	[AddINotifyPropertyChangedInterface]
 	public partial class EquipmentSelector : UserControl, SelectorDrawer.ISelectorView
 	{
-		private static Modes mode = Modes.All;
 		private static Classes classFilter = Classes.All;
+		private static ItemCategories categoryFilter = ItemCategories.All;
 		private static bool pairEquip = false;
 
 		private readonly ItemSlots slot;
@@ -55,30 +55,10 @@ namespace Anamnesis.Character.Views
 		public event DrawerEvent? Close;
 		public event DrawerEvent? SelectionChanged;
 
-		public enum Modes
-		{
-			All,
-			Items,
-			Props,
-			Performance,
-			Modded,
-			Favorites,
-		}
-
 		public IItem? Value
 		{
 			get => (IItem?)this.Selector.Value;
 			set => this.Selector.Value = value;
-		}
-
-		public int ModeInt
-		{
-			get => (int)mode;
-			set
-			{
-				mode = (Modes)value;
-				this.Selector.FilterItems();
-			}
 		}
 
 		public bool PairEquip
@@ -107,6 +87,16 @@ namespace Anamnesis.Character.Views
 			{
 				classFilter = value;
 				this.JobFilterText.Text = value.Describe();
+				this.Selector.FilterItems();
+			}
+		}
+
+		public ItemCategories CategoryFilter
+		{
+			get => categoryFilter;
+			set
+			{
+				categoryFilter = value;
 				this.Selector.FilterItems();
 			}
 		}
@@ -152,19 +142,13 @@ namespace Anamnesis.Character.Views
 				if (string.IsNullOrEmpty(item.Name))
 					return false;
 
-				if (mode == Modes.Items && (obj is Prop || item.Key == 0))
-					return false;
-
-				if (mode == Modes.Props && !(obj is Prop))
-					return false;
-
-				if (mode == Modes.Performance && !(obj is PerformViewModel))
-					return false;
-
-				if (mode == Modes.Modded && item.Mod == null)
-					return false;
-
-				if (mode == Modes.Favorites && !item.IsFavorite)
+				bool categoryFiltered = false;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Items) && obj is not Prop && item.Key != 0;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Props) && obj is Prop && obj is not PerformViewModel;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Performance) && obj is PerformViewModel;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
+				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;
+				if (!categoryFiltered)
 					return false;
 
 				if (this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand)

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -35,10 +35,10 @@
 	"Target_ConvertCarbuncleToPlayerMessage": "The Actor: \"{0}\" appears to be a Companion or Pet. Do you want to change them to an editable actor to allow for posing and appearance changes?",
 
 	"EquipmentSelector_Classes": "Classes / Jobs",
-	"EquipmentSelector_All": "All",
+	"EquipmentSelector_Categories": "Categories",
+	"EquipmentSelector_Items": "Items",
 	"EquipmentSelector_Props": "Props",
 	"EquipmentSelector_Performance": "Performance",
-	"EquipmentSelector_Items": "Items",
 	"EquipmentSelector_Modded": "Modded",
 	"EquipmentSelector_Favorites": "Favorites",
 

--- a/Anamnesis/Styles/Controls/ItemCategories.cs
+++ b/Anamnesis/Styles/Controls/ItemCategories.cs
@@ -1,0 +1,37 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+#pragma warning disable SA1649
+namespace Anamnesis.Styles.Controls
+{
+	using System;
+
+	[Flags]
+	public enum ItemCategories
+	{
+		None = 0,
+
+		Items = 1 << 0,
+		Props = 1 << 1,
+		Performance = 1 << 2,
+		Modded = 1 << 3,
+		Favorites = 1 << 4,
+
+		All = Items | Props | Performance | Modded | Favorites,
+	}
+
+	public static class ItemCategoriesExtensions
+	{
+		public static ItemCategories SetFlag(this ItemCategories a, ItemCategories b, bool enabled)
+		{
+			if (enabled)
+			{
+				return a | b;
+			}
+			else
+			{
+				return a & ~b;
+			}
+		}
+	}
+}

--- a/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl x:Class="Anamnesis.Styles.Controls.ItemCategoryFilter"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+			 xmlns:local="clr-namespace:Anamnesis.Styles.Controls"
+			 xmlns:XivToolsWpf="clr-namespace:XivToolsWpf.Controls;assembly=XivToolsWpf"
+			 mc:Ignorable="d" 
+			 d:DesignHeight="450" d:DesignWidth="800">
+
+    <Grid x:Name="ContentArea">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Vertical" Margin="3, 3, 3, 6">
+            <local:ItemCategoryFilterItem Category="Items" Text="EquipmentSelector_Items" Value="{Binding Value}"/>
+            <local:ItemCategoryFilterItem Category="Props" Text="EquipmentSelector_Props" Value="{Binding Value}"/>
+            <local:ItemCategoryFilterItem Category="Performance" Text="EquipmentSelector_Performance" Value="{Binding Value}"/>
+            <local:ItemCategoryFilterItem Category="Modded" Text="EquipmentSelector_Modded" Value="{Binding Value}"/>
+            <local:ItemCategoryFilterItem Category="Favorites" Text="EquipmentSelector_Favorites" Value="{Binding Value}"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Center" Grid.ColumnSpan="3" Margin="3, 3, 3, 6">
+            <Button Style="{StaticResource TransparentButton}" Padding="3" MinWidth="64" Click="OnNoneClicked">
+                <XivToolsWpf:TextBlock Key="Common_None"/>
+            </Button>
+            <Button Style="{StaticResource TransparentButton}" Padding="3" MinWidth="64" Click="OnAllClicked">
+                <XivToolsWpf:TextBlock Key="Common_All"/>
+            </Button>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml.cs
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml.cs
@@ -1,0 +1,40 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Styles.Controls
+{
+	using System.Windows;
+	using System.Windows.Controls;
+	using XivToolsWpf.DependencyProperties;
+
+	/// <summary>
+	/// Interaction logic for ItemCategoryFilter.xaml.
+	/// </summary>
+	public partial class ItemCategoryFilter : UserControl
+	{
+		public static DependencyProperty<ItemCategories> ValueDp
+			= Binder.Register<ItemCategories, ItemCategoryFilter>(nameof(ItemCategoryFilter.Value));
+
+		public ItemCategoryFilter()
+		{
+			this.InitializeComponent();
+			this.ContentArea.DataContext = this;
+		}
+
+		public ItemCategories Value
+		{
+			get => ValueDp.Get(this);
+			set => ValueDp.Set(this, value);
+		}
+
+		private void OnNoneClicked(object sender, RoutedEventArgs e)
+		{
+			this.Value = ItemCategories.None;
+		}
+
+		private void OnAllClicked(object sender, RoutedEventArgs e)
+		{
+			this.Value = ItemCategories.All;
+		}
+	}
+}

--- a/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="Anamnesis.Styles.Controls.ItemCategoryFilterItem"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+			 xmlns:local="clr-namespace:Anamnesis.Styles.Controls"
+             xmlns:XivToolsWpf="clr-namespace:XivToolsWpf.Controls;assembly=XivToolsWpf"
+             mc:Ignorable="d" 
+			 d:DesignHeight="450" d:DesignWidth="800">
+
+    <Grid x:Name="ContentArea">
+        <CheckBox Padding="3" IsChecked="{Binding IsSelected}">
+            <XivToolsWpf:TextBlock Key="{Binding Text}"/>
+        </CheckBox>
+    </Grid>
+</UserControl>

--- a/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml.cs
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml.cs
@@ -1,0 +1,55 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Styles.Controls
+{
+	using System.ComponentModel;
+	using System.Windows.Controls;
+	using PropertyChanged;
+	using XivToolsWpf.DependencyProperties;
+
+	/// <summary>
+	/// Interaction logic for ItemCategoryFilterItem.xaml.
+	/// </summary>
+	[AddINotifyPropertyChangedInterface]
+	public partial class ItemCategoryFilterItem : UserControl, INotifyPropertyChanged
+	{
+		public static DependencyProperty<ItemCategories> ValueDp
+			= Binder.Register<ItemCategories, ItemCategoryFilterItem>(nameof(ItemCategoryFilterItem.Value), OnValueChanged);
+		public static DependencyProperty<ItemCategories> CategoryDp
+			= Binder.Register<ItemCategories, ItemCategoryFilterItem>(nameof(ItemCategoryFilterItem.Category));
+
+		public ItemCategoryFilterItem()
+		{
+			this.InitializeComponent();
+			this.ContentArea.DataContext = this;
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		public string? Text { get; set; }
+
+		public ItemCategories Value
+		{
+			get => ValueDp.Get(this);
+			set => ValueDp.Set(this, value);
+		}
+
+		public ItemCategories Category
+		{
+			get => CategoryDp.Get(this);
+			set => CategoryDp.Set(this, value);
+		}
+
+		public bool IsSelected
+		{
+			get => this.Value.HasFlag(this.Category);
+			set => this.Value = this.Value.SetFlag(this.Category, value);
+		}
+
+		private static void OnValueChanged(ItemCategoryFilterItem sender, ItemCategories value)
+		{
+			sender.PropertyChanged?.Invoke(sender, new PropertyChangedEventArgs(nameof(ItemCategoryFilterItem.IsSelected)));
+		}
+	}
+}


### PR DESCRIPTION
This adds a little more flexibility on its own, but my intention is to expand this with additional categories for aetherial items, mogstation items, and no-longer-obtainable items, for more convenient glam testing.
The styling is very basic and the one extra string (so far) is not localized.

![Anamnesis_Gwpc3JNqXE](https://user-images.githubusercontent.com/28029167/124510448-d18bb800-dda1-11eb-9df8-7be76f2a261d.png)
