### PR TITLE
Setting to customize accent color

### DIFF
--- a/Anamnesis/App.xaml.cs
+++ b/Anamnesis/App.xaml.cs
@@ -12,6 +12,7 @@ namespace Anamnesis
 	using System.Runtime.Loader;
 	using System.Threading.Tasks;
 	using System.Windows;
+	using System.Windows.Media;
 	using System.Windows.Threading;
 	using Anamnesis.GUI;
 	using Anamnesis.GUI.Windows;
@@ -88,12 +89,12 @@ namespace Anamnesis
 
 				LogService.CreateLog();
 
-				Themes.ApplySystemTheme();
-
 				this.CheckWorkingDirectory();
 				this.CheckForProcesses();
 
 				await Services.InitializeServices();
+
+				Themes.ApplySystemTheme(SettingsService.Current.UseCustomColor, (Color)ColorConverter.ConvertFromString(SettingsService.Current.CustomColor));
 
 				await Dispatch.MainThread();
 

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -434,6 +434,7 @@
 	"Settings_Theme_Zodiark": "Zodiark",
 	"Settings_Dyslexic": "Use dyslexic friendly font.",
 	"Settings_ShowGallery": "Show Gallery",
+	"Settings_Custom_Color": "Custom color",
 
 	"About_Version_Header": "Version",
 	"About_OpenSource_Header": "Proudly Open Source",

--- a/Anamnesis/Services/Settings.cs
+++ b/Anamnesis/Services/Settings.cs
@@ -28,6 +28,8 @@ namespace Anamnesis.Services
 		public bool IsDyslexic { get; set; } = false;
 		public bool ShowGallery { get; set; } = true;
 		public bool EnableTranslucency { get; set; } = true;
+		public bool UseCustomColor { get; set; } = false;
+		public string CustomColor { get; set; } = "#00FF00";
 
 		public DateTimeOffset LastUpdateCheck { get; set; } = DateTimeOffset.MinValue;
 	}

--- a/Anamnesis/Views/SettingsView.xaml
+++ b/Anamnesis/Views/SettingsView.xaml
@@ -29,8 +29,9 @@
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
-			<RowDefinition/>
-			<RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition />
+            <RowDefinition Height="Auto"/>
 		</Grid.RowDefinitions>
 
 
@@ -62,7 +63,10 @@
 		<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="7" Key="Settings_ShowGallery" Style="{StaticResource Label}"/>
 		<CheckBox IsChecked="{Binding SettingsService.Settings.ShowGallery}" Grid.Column="1" Grid.Row="7" Margin="6"/>
 
-		<GroupBox Grid.Row="8" Grid.ColumnSpan="2">
+        <XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="8" Key="" Text="Use custom color" Style="{StaticResource Label}"/>
+        <CheckBox IsChecked="{Binding SettingsService.Settings.UseCustomColor}" Unchecked="UpdateColor" Checked="UpdateColor" Grid.Column="1" Grid.Row="8" Margin="6"/>
+
+        <GroupBox Grid.Row="9" Grid.ColumnSpan="2">
 			<GroupBox.Header>
 				<XivToolsWPF:TextBlock Key="Settings_Directories"/>
 			</GroupBox.Header>
@@ -78,6 +82,7 @@
 					<RowDefinition/>
 					<RowDefinition/>
 					<RowDefinition/>
+                    <RowDefinition/>
 				</Grid.RowDefinitions>
 
 				<XivToolsWPF:TextBlock Grid.Row="0" Grid.Column="0" Key="Settings_Dir_Characters" Style="{StaticResource Label}"/>
@@ -88,7 +93,12 @@
 				<TextBox Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0" Style="{StaticResource MaterialDesignTextBox}" Text="{Binding SettingsService.Settings.DefaultPoseDirectory}" IsEnabled="False"/>
 				<Button Grid.Row="1" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowsePose"/>
 
-				<!--<ana:TextBlock Grid.Row="2" Grid.Column="0" Key="Settings_Dir_Scenes" Style="{StaticResource Label}"/>
+                <XivToolsWPF:TextBlock Grid.Row="2" Grid.Column="0" Key="Settings_Custom_Color" Style="{StaticResource Label}"/>
+                <wpf:ColorPicker Color="{Binding SettingsService.Settings.CustomColor}" Grid.Row="2" Grid.Column="1" Width="200" Height="180" Name="clrPicker" IsEnabled="{Binding SettingsService.Current.UseCustomColor}"/>
+
+                <Button Grid.Row="3" Grid.Column="1" Height="30" Style="{StaticResource TransparentButton}" Content="Save" Click="OnColorChange" IsEnabled="{Binding SettingsService.Current.UseCustomColor}"/>
+
+                <!--<ana:TextBlock Grid.Row="2" Grid.Column="0" Key="Settings_Dir_Scenes" Style="{StaticResource Label}"/>
 				<TextBox Grid.Row="2" Grid.Column="1" Margin="3, 0, 0, 0" Style="{StaticResource MaterialDesignTextBox}" Text="{Binding SettingsService.Settings.DefaultSceneDirectory}" IsEnabled="False"/>
 				<Button Grid.Row="2" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowseScene"/>-->
 

--- a/Anamnesis/Views/SettingsView.xaml.cs
+++ b/Anamnesis/Views/SettingsView.xaml.cs
@@ -7,9 +7,11 @@ namespace Anamnesis.GUI.Views
 	using System.Linq;
 	using System.Windows;
 	using System.Windows.Forms;
+	using System.Windows.Media;
 	using Anamnesis.Files;
 	using Anamnesis.Services;
 	using PropertyChanged;
+	using XivToolsWpf;
 
 	/// <summary>
 	/// Interaction logic for ThemeSettingsView.xaml.
@@ -105,6 +107,19 @@ namespace Anamnesis.GUI.Views
 				return;
 
 			SettingsService.Current.DefaultSceneDirectory = FileService.ParseFromFilePath(dlg.SelectedPath);
+		}
+
+		private void OnColorChange(object sender, RoutedEventArgs e)
+		{
+			SettingsService.Current.CustomColor = this.clrPicker.Color.ToString();
+			Themes.ApplySystemTheme(SettingsService.Current.UseCustomColor, (Color)ColorConverter.ConvertFromString(this.clrPicker.Color.ToString()));
+		}
+
+		private void UpdateColor(object sender, RoutedEventArgs e)
+		{
+			bool useCustomColor = SettingsService.Current.UseCustomColor;
+			string customColor = SettingsService.Current.CustomColor;
+			Themes.ApplySystemTheme(useCustomColor, useCustomColor ? (Color)ColorConverter.ConvertFromString(customColor) : null);
 		}
 
 		public class LanguageOption


### PR DESCRIPTION
Since some system color accents really don't match well with Anamnesis UI I created a setting to customize the accent with a color picker. There is also a check to keep using the system's accent.

I'm not very good with UI work so I just implemented the default color picker, anyone is welcome to change it to better match the app's style.

![image](https://user-images.githubusercontent.com/85121274/126233266-b16b8511-8b9b-4f03-a7e5-3ab8b32b37a4.png)
