### PR TITLE
EquipmentSelector: rearrange and add more options

### DIFF
--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -41,6 +41,9 @@
                 <CheckBox Padding="3" IsChecked="{Binding HideLocked}">
                     <XivToolsWpf:TextBlock Key="EquipmentSelector_HideLocked"/>
                 </CheckBox>
+                <CheckBox Padding="3" IsChecked="{Binding Ambidextrous}" Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
+                    <XivToolsWpf:TextBlock Key="EquipmentSelector_Ambidextrous"/>
+                </CheckBox>
                 <CheckBox Padding="3" IsChecked="{Binding AutoOffhand}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
                     <CheckBox.ToolTip>
                         <XivToolsWpf:TextBlock Key="EquipmentSelector_AutoOffhandTip"/>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -8,159 +8,142 @@
 			 xmlns:fa="http://schemas.awesome.incremented/wpf/xaml/fontawesome.sharp"
 			 xmlns:XivToolsWpf="clr-namespace:XivToolsWpf.Controls;assembly=XivToolsWpf"
 			 mc:Ignorable="d" 
-			 d:DesignHeight="450" Width="256">
+			 d:DesignHeight="450">
 
-	<Grid x:Name="ContentArea">
+    <StackPanel x:Name="ContentArea" Orientation="Horizontal">
+        <StackPanel Width="256">
+            <Expander Style="{StaticResource MaterialDesignExpander}">
+                <Expander.Header>
+                    <StackPanel>
+                        <XivToolsWpf:TextBlock Key="EquipmentSelector_Classes" Foreground="{DynamicResource MaterialDesignBody}"/>
+                        <TextBlock x:Name="JobFilterText" Text="All" Foreground="{DynamicResource MaterialDesignBodyLight}" FontSize="10"/>
+                    </StackPanel>
+                </Expander.Header>
+                <Border Background="{StaticResource MaterialDesignPaper}" CornerRadius="3">
+                    <controls:ClassFilter HorizontalAlignment="Center" Value="{Binding ClassFilter}"/>
+                </Border>
+            </Expander>
 
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto"/>
-			<RowDefinition Height="Auto"/>
-			<RowDefinition Height="Auto"/>
-			<RowDefinition/>
-		</Grid.RowDefinitions>
+            <Line X1="0" X2="1" StrokeThickness="1" Margin="2" Stroke="{DynamicResource MaterialDesignCardBackground}" Stretch="Fill"/>
 
-		<Expander Style="{StaticResource MaterialDesignExpander}">
-			<Expander.Header>
-				<StackPanel>
-					<XivToolsWpf:TextBlock Key="EquipmentSelector_Classes" Foreground="{DynamicResource MaterialDesignBody}"/>
-					<TextBlock x:Name="JobFilterText" Text="All" Foreground="{DynamicResource MaterialDesignBodyLight}" FontSize="10"/>
-				</StackPanel>
-			</Expander.Header>
-			<Border Background="{StaticResource MaterialDesignPaper}" CornerRadius="3">
-				<controls:ClassFilter HorizontalAlignment="Center" Value="{Binding ClassFilter}"/>
-			</Border>
-		</Expander>
+            <Expander Style="{StaticResource MaterialDesignExpander}">
+                <Expander.Header>
+                    <XivToolsWpf:TextBlock Key="EquipmentSelector_Categories" Foreground="{DynamicResource MaterialDesignBody}"/>
+                </Expander.Header>
+                <Border Background="{StaticResource MaterialDesignPaper}" CornerRadius="3">
+                    <controls:ItemCategoryFilter Value="{Binding CategoryFilter}"/>
+                </Border>
+            </Expander>
 
-        <Expander Style="{StaticResource MaterialDesignExpander}" Grid.Row="1">
-            <Expander.Header>
-                <XivToolsWpf:TextBlock Key="EquipmentSelector_Categories" Foreground="{DynamicResource MaterialDesignBody}"/>
-            </Expander.Header>
-            <Border Background="{StaticResource MaterialDesignPaper}" CornerRadius="3">
-                <controls:ItemCategoryFilter Value="{Binding CategoryFilter}"/>
-            </Border>
-        </Expander>
-		
-		<!--<StackPanel Grid.Row="1" Orientation="Horizontal" Margin="6, 0, 0, 0">
-			<RadioButton Margin="3" IsChecked="{Binding AllMode}">
-				<controls:TextBlock Key="EquipmentSelector_All" Margin="0, -3, 6, 0"/>
-			</RadioButton>
+            <Line X1="0" X2="1" StrokeThickness="1" Margin="2" Stroke="{DynamicResource MaterialDesignCardBackground}" Stretch="Fill"/>
 
-			<RadioButton Margin="3" IsChecked="{Binding PropsMode}">
-				<controls:TextBlock Key="EquipmentSelector_Props" Margin="0, -3, 6, 0"/>
-			</RadioButton>
+            <StackPanel Margin="10,2">
+                <CheckBox Padding="3" IsChecked="{Binding PairEquip}" Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
+                    <XivToolsWpf:TextBlock Key="Character_Equipment_PairEquip"/>
+                </CheckBox>
+            </StackPanel>
+        </StackPanel>
 
-			<RadioButton Margin="3"  IsChecked="{Binding ItemsMode}">
-				<controls:TextBlock Key="EquipmentSelector_Items" Margin="0, -3, 6, 0"/>
-			</RadioButton>
+        <Line Y1="0" Y2="1" StrokeThickness="1" Margin="2" Stroke="{DynamicResource MaterialDesignCardBackground}" Stretch="Fill"/>
 
-			<RadioButton Margin="3"  IsChecked="{Binding ModdedMode}">
-				<controls:TextBlock Key="EquipmentSelector_Modded" Margin="0, -3, 6, 0"/>
-			</RadioButton>
-		</StackPanel>-->
-
-		<CheckBox Grid.Row="2" Margin="10, 3, 10, 3" IsChecked="{Binding PairEquip}" Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
-			<XivToolsWpf:TextBlock Key="Character_Equipment_PairEquip"/>
-		</CheckBox>
-
-		<cm3Drawers:SelectorDrawer
-			Grid.Row="3"
+        <cm3Drawers:SelectorDrawer Width="256"
 			x:Name="Selector"
 			Close="OnClose" 
 			Filter="OnFilter"
 			Sort="OnSort"
 			SelectionChanged="OnSelectionChanged">
 
-			<cm3Drawers:SelectorDrawer.ItemTemplate>
-				<DataTemplate>
-					<Grid>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
+            <cm3Drawers:SelectorDrawer.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-						<Grid.RowDefinitions>
-							<RowDefinition/>
-							<RowDefinition/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-						<Border Width="32" Height="32" Background="#444444" Grid.RowSpan="3" CornerRadius="3" Visibility="{Binding Icon, Converter={StaticResource NotNullToVisibilityConverter}}">
-							<Grid>
-								<Image Source="{Binding Icon}" Margin="1"/>
-								<Image Source="/Assets/IconBorderSmall.png" Margin="-2, 0, -2, -4"/>
-							</Grid>
-						</Border>
+                        <Border Width="32" Height="32" Background="#444444" Grid.RowSpan="3" CornerRadius="3" Visibility="{Binding Icon, Converter={StaticResource NotNullToVisibilityConverter}}">
+                            <Grid>
+                                <Image Source="{Binding Icon}" Margin="1"/>
+                                <Image Source="/Assets/IconBorderSmall.png" Margin="-2, 0, -2, -4"/>
+                            </Grid>
+                        </Border>
 
-						<TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Margin="6, 0, 0, 0" FontWeight="DemiBold" Foreground="{DynamicResource MaterialDesignBody}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Margin="6, 0, 0, 0" FontWeight="DemiBold" Foreground="{DynamicResource MaterialDesignBody}"/>
 
-						<StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0">
-							<TextBlock Text="{Binding Key}" Style="{StaticResource Label}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
-							<fa:IconBlock Icon="pen" FontSize="8" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-							<TextBlock Text="{Binding Description}" Style="{StaticResource Label}"/>
+                        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0">
+                            <TextBlock Text="{Binding Key}" Style="{StaticResource Label}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                            <fa:IconBlock Icon="pen" FontSize="8" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding Description}" Style="{StaticResource Label}"/>
 
-						</StackPanel>
+                        </StackPanel>
 
-				
 
-						<Rectangle Grid.ColumnSpan="3" 
+
+                        <Rectangle Grid.ColumnSpan="3" 
 									   Grid.RowSpan="2" 
 									   Fill="Transparent" >
-							<ToolTipService.ToolTip>
-								<StackPanel Orientation="Vertical">
-									<TextBlock Text="{Binding Name}" FontWeight="DemiBold"/>
-									<TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                            <ToolTipService.ToolTip>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="{Binding Name}" FontWeight="DemiBold"/>
+                                    <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
-									<Grid Grid.Column="1" Grid.Row="2" Margin="3, 3, 0, 0">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="Auto"/>
-											<ColumnDefinition/>
-										</Grid.ColumnDefinitions>
+                                    <Grid Grid.Column="1" Grid.Row="2" Margin="3, 3, 0, 0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
 
-										<Grid.RowDefinitions>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-										</Grid.RowDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
 
-										<TextBlock Grid.Column="0" Grid.Row="0" Text="Item Id: " HorizontalAlignment="Left" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
-										<TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding Key}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="0" Text="Item Id: " HorizontalAlignment="Left" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                                        <TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding Key}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="1" Text="Set: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ModelSet}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="1" Text="Set: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ModelSet}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="2" Text="Base: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding ModelBase}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="2" Text="Base: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding ModelBase}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="3" Text="Variant: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding ModelVariant}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="3" Text="Variant: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding ModelVariant}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="4" Text="Modded: " HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-										<TextBlock Grid.Column="1" Grid.Row="4" Text="{Binding Mod.ModPack.Name}" HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-									</Grid>
-								</StackPanel>
-							</ToolTipService.ToolTip>
-						</Rectangle>
+                                        <TextBlock Grid.Column="0" Grid.Row="4" Text="Modded: " HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                                        <TextBlock Grid.Column="1" Grid.Row="4" Text="{Binding Mod.ModPack.Name}" HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                                    </Grid>
+                                </StackPanel>
+                            </ToolTipService.ToolTip>
+                        </Rectangle>
 
-						<Grid Grid.Column="2" Grid.RowSpan="2">
+                        <Grid Grid.Column="2" Grid.RowSpan="2">
 
-							<ToggleButton Style="{StaticResource InvisibleToggleButton}" IsChecked="{Binding IsFavorite}" Margin="6,0,0,0" Padding="0">
-								<Grid>
-									<fa:IconBlock Icon="Star" FontSize="13" Opacity="0.25"
+                            <ToggleButton Style="{StaticResource InvisibleToggleButton}" IsChecked="{Binding IsFavorite}" Margin="6,0,0,0" Padding="0">
+                                <Grid>
+                                    <fa:IconBlock Icon="Star" FontSize="13" Opacity="0.25"
 												  Foreground="Black"
 												   Visibility="{Binding IsFavorite, Converter={StaticResource !B2V}}"/>
-									<fa:IconBlock Icon="Star" FontSize="13"
+                                    <fa:IconBlock Icon="Star" FontSize="13"
 										  Visibility="{Binding IsFavorite, Converter={StaticResource B2V}}"/>
-								</Grid>
-							</ToggleButton>
+                                </Grid>
+                            </ToggleButton>
 
-						</Grid>
+                        </Grid>
 
-					</Grid>
-				</DataTemplate>
-			</cm3Drawers:SelectorDrawer.ItemTemplate>
-		</cm3Drawers:SelectorDrawer>
-	</Grid>
+                    </Grid>
+                </DataTemplate>
+            </cm3Drawers:SelectorDrawer.ItemTemplate>
+        </cm3Drawers:SelectorDrawer>
+    </StackPanel>
 </UserControl>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -38,6 +38,9 @@
             <Line X1="0" X2="1" StrokeThickness="1" Margin="2" Stroke="{DynamicResource MaterialDesignCardBackground}" Stretch="Fill"/>
 
             <StackPanel Margin="10,2">
+                <CheckBox Padding="3" IsChecked="{Binding HideLocked}">
+                    <XivToolsWpf:TextBlock Key="EquipmentSelector_HideLocked"/>
+                </CheckBox>
                 <CheckBox Padding="3" IsChecked="{Binding PairEquip}" Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
                     <XivToolsWpf:TextBlock Key="Character_Equipment_PairEquip"/>
                 </CheckBox>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -41,8 +41,11 @@
                 <CheckBox Padding="3" IsChecked="{Binding HideLocked}">
                     <XivToolsWpf:TextBlock Key="EquipmentSelector_HideLocked"/>
                 </CheckBox>
-                <CheckBox Padding="3" IsChecked="{Binding PairEquip}" Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
-                    <XivToolsWpf:TextBlock Key="Character_Equipment_PairEquip"/>
+                <CheckBox Padding="3" IsChecked="{Binding AutoOffhand}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
+                    <CheckBox.ToolTip>
+                        <XivToolsWpf:TextBlock Key="EquipmentSelector_AutoOffhandTip"/>
+                    </CheckBox.ToolTip>
+                    <XivToolsWpf:TextBlock Key="EquipmentSelector_AutoOffhand"/>
                 </CheckBox>
             </StackPanel>
         </StackPanel>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -14,7 +14,9 @@ namespace Anamnesis.Character.Views
 	using Anamnesis.Services;
 	using Anamnesis.Styles.Controls;
 	using Anamnesis.Styles.Drawers;
+	using Lumina.Excel.GeneratedSheets;
 	using PropertyChanged;
+	using static Anamnesis.Memory.Customize;
 
 	/// <summary>
 	/// Interaction logic for EquipmentSelector.xaml.
@@ -25,18 +27,21 @@ namespace Anamnesis.Character.Views
 		private static readonly Dictionary<uint, ItemCategories> ManualItemCategories;
 		private static Classes classFilter = Classes.All;
 		private static ItemCategories categoryFilter = ItemCategories.All;
+		private static bool hideLocked = true;
 		private static bool pairEquip = false;
 
 		private readonly ItemSlots slot;
+		private readonly Memory.ActorViewModel? actor;
 
 		static EquipmentSelector()
 		{
 			ManualItemCategories = SerializerService.DeserializeFile<Dictionary<uint, ItemCategories>>("Data/ItemCategories.json");
 		}
 
-		public EquipmentSelector(ItemSlots slot)
+		public EquipmentSelector(ItemSlots slot, Memory.ActorViewModel? actor)
 		{
 			this.slot = slot;
+			this.actor = actor;
 
 			this.InitializeComponent();
 			this.ContentArea.DataContext = this;
@@ -90,6 +95,16 @@ namespace Anamnesis.Character.Views
 			set
 			{
 				categoryFilter = value;
+				this.Selector.FilterItems();
+			}
+		}
+
+		public bool HideLocked
+		{
+			get => hideLocked;
+			set
+			{
+				hideLocked = value;
 				this.Selector.FilterItems();
 			}
 		}
@@ -159,6 +174,9 @@ namespace Anamnesis.Character.Views
 			if (!this.ValidCategory(item))
 				return false;
 
+			if (this.HideLocked && item is ItemViewModel ivm && !this.CanEquip(ivm))
+				return false;
+
 			return this.MatchesSearch(item, search);
 		}
 
@@ -199,6 +217,29 @@ namespace Anamnesis.Character.Views
 			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
 			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;
 			return categoryFiltered;
+		}
+
+		private bool CanEquip(ItemViewModel item)
+		{
+			EquipRaceCategory? equipRaceCategory = GameDataService.EquipRaceCategories.GetRow(item.Value.EquipRestriction);
+			if (equipRaceCategory == null || this.actor == null || this.actor.Customize == null)
+				return true;
+
+			Genders gender = this.actor.Customize.Gender;
+			bool validGender = (gender == Genders.Masculine && equipRaceCategory.Male)
+				|| (gender == Genders.Feminine && equipRaceCategory.Female);
+
+			Races race = this.actor.Customize.Race;
+			bool validRace = (race == Races.Hyur && equipRaceCategory.Hyur)
+				|| (race == Races.Elezen && equipRaceCategory.Elezen)
+				|| (race == Races.Lalafel && equipRaceCategory.Lalafell)
+				|| (race == Races.Miqote && equipRaceCategory.Miqote)
+				|| (race == Races.Roegadyn && equipRaceCategory.Roegadyn)
+				|| (race == Races.AuRa && equipRaceCategory.AuRa)
+				|| (race == Races.Hrothgar && equipRaceCategory.Unknown6)
+				|| (race == Races.Viera && equipRaceCategory.Unknown7);
+
+			return validGender && validRace;
 		}
 
 		private bool MatchesSearch(IItem item, string[]? search = null)

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -29,6 +29,7 @@ namespace Anamnesis.Character.Views
 		private static Classes classFilter = Classes.All;
 		private static ItemCategories categoryFilter = ItemCategories.All;
 		private static bool hideLocked = true;
+		private static bool ambidextrous = false;
 		private static bool autoOffhand = true;
 
 		private readonly ItemSlots slot;
@@ -111,6 +112,16 @@ namespace Anamnesis.Character.Views
 			}
 		}
 
+		public bool Ambidextrous
+		{
+			get => ambidextrous;
+			set
+			{
+				ambidextrous = value;
+				this.Selector.FilterItems();
+			}
+		}
+
 		public bool AutoOffhand
 		{
 			get => autoOffhand;
@@ -159,7 +170,7 @@ namespace Anamnesis.Character.Views
 			if (string.IsNullOrEmpty(item.Name))
 				return false;
 
-			if (this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand)
+			if (this.Ambidextrous && (this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand))
 			{
 				if (!item.IsWeapon)
 					return false;

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -69,28 +69,13 @@ namespace Anamnesis.Character.Views
 			set => this.Selector.Value = value;
 		}
 
-		public bool PairEquip
-		{
-			get => pairEquip;
-			set => pairEquip = value;
-		}
-
 		public bool IsWeaponSlot => this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand;
 
-		SelectorDrawer SelectorDrawer.ISelectorView.Selector
-		{
-			get
-			{
-				return this.Selector;
-			}
-		}
+		SelectorDrawer SelectorDrawer.ISelectorView.Selector => this.Selector;
 
 		public Classes ClassFilter
 		{
-			get
-			{
-				return classFilter;
-			}
+			get => classFilter;
 			set
 			{
 				classFilter = value;
@@ -107,6 +92,12 @@ namespace Anamnesis.Character.Views
 				categoryFilter = value;
 				this.Selector.FilterItems();
 			}
+		}
+
+		public bool PairEquip
+		{
+			get => pairEquip;
+			set => pairEquip = value;
 		}
 
 		public void OnClosed()
@@ -144,76 +135,31 @@ namespace Anamnesis.Character.Views
 
 		private bool OnFilter(object obj, string[]? search = null)
 		{
-			if (obj is IItem item)
+			if (obj is not IItem item)
+				return false;
+
+			// skip items without names
+			if (string.IsNullOrEmpty(item.Name))
+				return false;
+
+			if (this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand)
 			{
-				// skip items without names
-				if (string.IsNullOrEmpty(item.Name))
+				if (!item.IsWeapon)
 					return false;
-
-				ItemCategories itemCategory = ItemCategories.None;
-				if (obj is ItemViewModel)
-					itemCategory = ManualItemCategories.GetValueOrDefault(item.Key, ItemCategories.Standard);
-				else if (obj is Prop)
-					itemCategory = ItemCategories.Props;
-				else if (obj is PerformViewModel)
-					itemCategory = ItemCategories.Performance;
-
-				bool categoryFiltered = false;
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Standard) && itemCategory.HasFlag(ItemCategories.Standard);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Premium) && itemCategory.HasFlag(ItemCategories.Premium);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Limited) && itemCategory.HasFlag(ItemCategories.Limited);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Deprecated) && itemCategory.HasFlag(ItemCategories.Deprecated);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Props) && itemCategory.HasFlag(ItemCategories.Props);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Performance) && itemCategory.HasFlag(ItemCategories.Performance);
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
-				categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;
-				if (!categoryFiltered && itemCategory != ItemCategories.None)
+			}
+			else
+			{
+				if (!item.FitsInSlot(this.slot))
 					return false;
-
-				if (this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand)
-				{
-					if (!item.IsWeapon)
-					{
-						return false;
-					}
-				}
-				else
-				{
-					if (!item.FitsInSlot(this.slot))
-					{
-						return false;
-					}
-				}
-
-				if (!this.HasClass(this.ClassFilter, item.EquipableClasses))
-					return false;
-
-				bool matches = false;
-
-				matches |= SearchUtility.Matches(item.Name, search);
-				matches |= SearchUtility.Matches(item.Description, search);
-				matches |= SearchUtility.Matches(item.ModelSet.ToString(), search);
-				matches |= SearchUtility.Matches(item.ModelBase.ToString(), search);
-				matches |= SearchUtility.Matches(item.ModelVariant.ToString(), search);
-
-				if (item.HasSubModel)
-				{
-					matches |= SearchUtility.Matches(item.SubModelSet.ToString(), search);
-					matches |= SearchUtility.Matches(item.SubModelBase.ToString(), search);
-					matches |= SearchUtility.Matches(item.SubModelVariant.ToString(), search);
-				}
-
-				matches |= SearchUtility.Matches(item.Key.ToString(), search);
-
-				if (item.Mod != null && item.Mod.ModPack != null)
-				{
-					matches |= SearchUtility.Matches(item.Mod.ModPack.Name, search);
-				}
-
-				return matches;
 			}
 
-			return false;
+			if (!this.HasClass(this.ClassFilter, item.EquipableClasses))
+				return false;
+
+			if (!this.ValidCategory(item))
+				return false;
+
+			return this.MatchesSearch(item, search);
 		}
 
 		private bool HasClass(Classes a, Classes b)
@@ -230,6 +176,56 @@ namespace Anamnesis.Character.Views
 			}
 
 			return false;
+		}
+
+		private bool ValidCategory(IItem item)
+		{
+			ItemCategories itemCategory = ItemCategories.None;
+			if (item is ItemViewModel)
+				itemCategory = ManualItemCategories.GetValueOrDefault(item.Key, ItemCategories.Standard);
+			else if (item is Prop)
+				itemCategory = ItemCategories.Props;
+			else if (item is PerformViewModel)
+				itemCategory = ItemCategories.Performance;
+
+			// Always let uncategorized items through, otherwise there would be no way to get to them
+			bool categoryFiltered = itemCategory == ItemCategories.None;
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Standard) && itemCategory.HasFlag(ItemCategories.Standard);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Premium) && itemCategory.HasFlag(ItemCategories.Premium);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Limited) && itemCategory.HasFlag(ItemCategories.Limited);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Deprecated) && itemCategory.HasFlag(ItemCategories.Deprecated);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Props) && itemCategory.HasFlag(ItemCategories.Props);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Performance) && itemCategory.HasFlag(ItemCategories.Performance);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;
+			return categoryFiltered;
+		}
+
+		private bool MatchesSearch(IItem item, string[]? search = null)
+		{
+			bool matches = false;
+
+			matches |= SearchUtility.Matches(item.Name, search);
+			matches |= SearchUtility.Matches(item.Description, search);
+			matches |= SearchUtility.Matches(item.ModelSet.ToString(), search);
+			matches |= SearchUtility.Matches(item.ModelBase.ToString(), search);
+			matches |= SearchUtility.Matches(item.ModelVariant.ToString(), search);
+
+			if (item.HasSubModel)
+			{
+				matches |= SearchUtility.Matches(item.SubModelSet.ToString(), search);
+				matches |= SearchUtility.Matches(item.SubModelBase.ToString(), search);
+				matches |= SearchUtility.Matches(item.SubModelVariant.ToString(), search);
+			}
+
+			matches |= SearchUtility.Matches(item.Key.ToString(), search);
+
+			if (item.Mod != null && item.Mod.ModPack != null)
+			{
+				matches |= SearchUtility.Matches(item.Mod.ModPack.Name, search);
+			}
+
+			return matches;
 		}
 	}
 }

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -25,10 +25,11 @@ namespace Anamnesis.Character.Views
 	public partial class EquipmentSelector : UserControl, SelectorDrawer.ISelectorView
 	{
 		private static readonly Dictionary<uint, ItemCategories> ManualItemCategories;
+
 		private static Classes classFilter = Classes.All;
 		private static ItemCategories categoryFilter = ItemCategories.All;
 		private static bool hideLocked = true;
-		private static bool pairEquip = false;
+		private static bool autoOffhand = true;
 
 		private readonly ItemSlots slot;
 		private readonly Memory.ActorViewModel? actor;
@@ -74,6 +75,7 @@ namespace Anamnesis.Character.Views
 			set => this.Selector.Value = value;
 		}
 
+		public bool IsMainHandSlot => this.slot == ItemSlots.MainHand;
 		public bool IsWeaponSlot => this.slot == ItemSlots.MainHand || this.slot == ItemSlots.OffHand;
 
 		SelectorDrawer SelectorDrawer.ISelectorView.Selector => this.Selector;
@@ -109,10 +111,10 @@ namespace Anamnesis.Character.Views
 			}
 		}
 
-		public bool PairEquip
+		public bool AutoOffhand
 		{
-			get => pairEquip;
-			set => pairEquip = value;
+			get => autoOffhand;
+			set => autoOffhand = value;
 		}
 
 		public void OnClosed()

--- a/Anamnesis/Character/Views/ItemView.xaml.cs
+++ b/Anamnesis/Character/Views/ItemView.xaml.cs
@@ -126,7 +126,7 @@ namespace Anamnesis.Character.Views
 
 		private void OnClick(object sender, RoutedEventArgs e)
 		{
-			EquipmentSelector selector = new EquipmentSelector(this.Slot);
+			EquipmentSelector selector = new EquipmentSelector(this.Slot, this.Actor);
 			SelectorDrawer.Show(selector, this.Item, (i) => this.SetItem(i, selector.PairEquip));
 		}
 

--- a/Anamnesis/Extensions/LuminaExtensions.cs
+++ b/Anamnesis/Extensions/LuminaExtensions.cs
@@ -139,20 +139,20 @@ namespace Lumina
 		{
 			switch (slot)
 			{
-				case ItemSlots.MainHand: return self.MainHand != 0;
-				case ItemSlots.Head: return self.Head != 0;
-				case ItemSlots.Body: return self.Body != 0;
-				case ItemSlots.Hands: return self.Gloves != 0;
-				case ItemSlots.Waist: return self.Waist != 0;
-				case ItemSlots.Legs: return self.Legs != 0;
-				case ItemSlots.Feet: return self.Feet != 0;
-				case ItemSlots.OffHand: return self.OffHand != 0;
-				case ItemSlots.Ears: return self.Ears != 0;
-				case ItemSlots.Neck: return self.Neck != 0;
-				case ItemSlots.Wrists: return self.Wrists != 0;
-				case ItemSlots.RightRing: return self.FingerR != 0;
-				case ItemSlots.LeftRing: return self.FingerL != 0;
-				case ItemSlots.SoulCrystal: return self.SoulCrystal != 0;
+				case ItemSlots.MainHand: return self.MainHand == 1;
+				case ItemSlots.Head: return self.Head == 1;
+				case ItemSlots.Body: return self.Body == 1;
+				case ItemSlots.Hands: return self.Gloves == 1;
+				case ItemSlots.Waist: return self.Waist == 1;
+				case ItemSlots.Legs: return self.Legs == 1;
+				case ItemSlots.Feet: return self.Feet == 1;
+				case ItemSlots.OffHand: return self.OffHand == 1;
+				case ItemSlots.Ears: return self.Ears == 1;
+				case ItemSlots.Neck: return self.Neck == 1;
+				case ItemSlots.Wrists: return self.Wrists == 1;
+				case ItemSlots.RightRing: return self.FingerR == 1;
+				case ItemSlots.LeftRing: return self.FingerL == 1;
+				case ItemSlots.SoulCrystal: return self.SoulCrystal == 1;
 			}
 
 			return false;

--- a/Anamnesis/GameData/GameDataService.cs
+++ b/Anamnesis/GameData/GameDataService.cs
@@ -3,24 +3,20 @@
 
 namespace Anamnesis.Services
 {
-	using System;
-	using System.Collections.Generic;
-	using System.IO;
-	using System.Threading.Tasks;
-	using Anamnesis.Character;
-	using Anamnesis.GameData;
-	using Anamnesis.GameData.Sheets;
-	using Anamnesis.GameData.ViewModels;
-	using Anamnesis.Memory;
-	using Anamnesis.Serialization;
-	using Anamnesis.Serialization.Converters;
-	using Anamnesis.Updater;
-	using Lumina.Excel;
-	using Lumina.Excel.GeneratedSheets;
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Anamnesis.Character;
+    using Anamnesis.GameData;
+    using Anamnesis.GameData.Sheets;
+    using Anamnesis.GameData.ViewModels;
+    using Anamnesis.Memory;
+    using Anamnesis.Updater;
+    using Lumina.Excel;
+    using Lumina.Excel.GeneratedSheets;
+    using LuminaData = global::Lumina.GameData;
 
-	using LuminaData = global::Lumina.GameData;
-
-	public class GameDataService : ServiceBase<GameDataService>
+    public class GameDataService : ServiceBase<GameDataService>
 	{
 		private LuminaData? lumina;
 
@@ -37,6 +33,7 @@ namespace Anamnesis.Services
 		public static ISheet<ICharaMakeType> CharacterMakeTypes { get; protected set; }
 		public static ISheet<INpcResident> ResidentNPCs { get; protected set; }
 		public static ExcelSheet<WeatherRate> WeatherRates { get; protected set; }
+		public static ExcelSheet<EquipRaceCategory> EquipRaceCategories { get; protected set; }
 		public static ISheet<Monster> Monsters { get; private set; }
 		public static ISheet<Prop> Props { get; private set; }
 		#pragma warning restore CS8618
@@ -75,12 +72,17 @@ namespace Anamnesis.Services
 			this.lumina.GetExcelSheet<Perform>();
 
 			// no view models for these
-			ExcelSheet<WeatherRate>? sheet = this.lumina.GetExcelSheet<WeatherRate>();
+			static ExcelSheet<T> GetNotNullExcelSheet<T>(LuminaData lumina)
+			    where T : ExcelRow
+			{
+				ExcelSheet<T>? sheet = lumina.GetExcelSheet<T>();
+				if (sheet == null)
+					throw new Exception($"Missing sheet {typeof(T).Name}");
+				return sheet;
+			}
 
-			if (sheet == null)
-				throw new Exception("No weather sheet");
-
-			WeatherRates = sheet;
+			WeatherRates = GetNotNullExcelSheet<WeatherRate>(this.lumina);
+			EquipRaceCategories = GetNotNullExcelSheet<EquipRaceCategory>(this.lumina);
 
 			// these are json files that we write by hand
 			Monsters = new JsonListSheet<Monster>("Data/Monsters.json");

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -36,6 +36,8 @@
 
 	"EquipmentSelector_Classes": "Classes / Jobs",
 	"EquipmentSelector_HideLocked": "Hide race/gender-locked items",
+	"EquipmentSelector_AutoOffhand": "Auto-equip offhand",
+	"EquipmentSelector_AutoOffhandTip": "Automatically equip paired weapons in the offhand, and unequip the offhand when equipping two-handed weapons",
 
 	"EquipmentSelector_Categories": "Categories",
 	"EquipmentSelector_Standard": "Standard Items",
@@ -129,7 +131,6 @@
 	"Character_Equipment_Wrists": "Wrists",
 	"Character_Equipment_RightRing": "Right Ring",
 	"Character_Equipment_LeftRing": "Left Ring",
-	"Character_Equipment_PairEquip": "Equip both hands",
 	"Character_Equipment_Tint": "Tint Color",
 	"Character_Equipment_Dye": "Dye",
 	"Character_Equipment_Hide": "Hide the weapon (by setting its scale to 0)",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -36,6 +36,7 @@
 
 	"EquipmentSelector_Classes": "Classes / Jobs",
 	"EquipmentSelector_HideLocked": "Hide race/gender-locked items",
+	"EquipmentSelector_Ambidextrous": "Allow all weapons in either hand",
 	"EquipmentSelector_AutoOffhand": "Auto-equip offhand",
 	"EquipmentSelector_AutoOffhandTip": "Automatically equip paired weapons in the offhand, and unequip the offhand when equipping two-handed weapons",
 

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -35,6 +35,8 @@
 	"Target_ConvertCarbuncleToPlayerMessage": "The Actor: \"{0}\" appears to be a Companion or Pet. Do you want to change them to an editable actor to allow for posing and appearance changes?",
 
 	"EquipmentSelector_Classes": "Classes / Jobs",
+	"EquipmentSelector_HideLocked": "Hide race/gender-locked items",
+
 	"EquipmentSelector_Categories": "Categories",
 	"EquipmentSelector_Standard": "Standard Items",
 	"EquipmentSelector_StandardTip": "Items obtainable through normal gameplay",

--- a/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilter.xaml
@@ -14,7 +14,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" Margin="3, 3, 3, 6">
+        <StackPanel Orientation="Vertical" Margin="10,0">
             <local:ItemCategoryFilterItem Category="Standard" Value="{Binding Value}"
                                           Text="EquipmentSelector_Standard" ToolText="EquipmentSelector_StandardTip"/>
             <local:ItemCategoryFilterItem Category="Premium" Value="{Binding Value}"


### PR DESCRIPTION
Options have been moved to a separate panel in order to avoid crowding out the item list.
New: Option to hide race/gender-locked items
New: Option to allow mainhand weapons in the offhand and vice versa (previously the standard behavior, now off by default)
Changed: The pair equip option is renamed and now also unequips the offhand when equipping two-handed weapons

![Anamnesis_AWhAO5LCpe](https://user-images.githubusercontent.com/28029167/126243237-93ab9498-79b2-4964-8da9-12acc06f575b.png)
