### PR TITLE
Tentative changes for Tips and Gallery update

### DIFF
--- a/Anamnesis/Serialization/SerializerService.cs
+++ b/Anamnesis/Serialization/SerializerService.cs
@@ -8,8 +8,8 @@ namespace Anamnesis.Serialization
     using System.Net.Http;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
     using Anamnesis.Serialization.Converters;
-    using Anamnesis.Services;
 
     public class SerializerService : ServiceBase<SerializerService>
 	{
@@ -78,21 +78,21 @@ namespace Anamnesis.Serialization
 			return result;
 		}
 
-		public static T? DeserializeUrl<T>(string url)
-			where T : new()
+		public static async Task<T?> DeserializeUrlAsync<T>(string url)
+			where T : class
 		{
 			try
 			{
-				var httpClient = new HttpClient();
-				var response = httpClient.GetAsync(url).Result;
-				string json = response.Content.ReadAsStringAsync().Result;
+				HttpClient? httpClient = new HttpClient();
+				HttpResponseMessage? response = await httpClient.GetAsync(url).ConfigureAwait(false);
+				string json = await response.Content.ReadAsStringAsync();
 				T? result = JsonSerializer.Deserialize<T>(json, Options);
-				return result;
+				return null;
 			}
 			catch (Exception)
 			{
 				Log.Information("Failed to deserialize json from url");
-				return default(T);
+				return null;
 			}
 		}
 	}

--- a/Anamnesis/Serialization/SerializerService.cs
+++ b/Anamnesis/Serialization/SerializerService.cs
@@ -87,7 +87,7 @@ namespace Anamnesis.Serialization
 				HttpResponseMessage? response = await httpClient.GetAsync(url).ConfigureAwait(false);
 				string json = await response.Content.ReadAsStringAsync();
 				T? result = JsonSerializer.Deserialize<T>(json, Options);
-				return null;
+				return result;
 			}
 			catch (Exception)
 			{

--- a/Anamnesis/Serialization/SerializerService.cs
+++ b/Anamnesis/Serialization/SerializerService.cs
@@ -3,13 +3,15 @@
 
 namespace Anamnesis.Serialization
 {
-	using System;
-	using System.IO;
-	using System.Text.Json;
-	using System.Text.Json.Serialization;
-	using Anamnesis.Serialization.Converters;
+    using System;
+    using System.IO;
+    using System.Net.Http;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using Anamnesis.Serialization.Converters;
+    using Anamnesis.Services;
 
-	public class SerializerService : ServiceBase<SerializerService>
+    public class SerializerService : ServiceBase<SerializerService>
 	{
 		public static JsonSerializerOptions Options = new JsonSerializerOptions();
 
@@ -74,6 +76,24 @@ namespace Anamnesis.Serialization
 				throw new Exception("Failed to deserialize object");
 
 			return result;
+		}
+
+		public static T? DeserializeUrl<T>(string url)
+			where T : new()
+		{
+			try
+			{
+				var httpClient = new HttpClient();
+				var response = httpClient.GetAsync(url).Result;
+				string json = response.Content.ReadAsStringAsync().Result;
+				T? result = JsonSerializer.Deserialize<T>(json, Options);
+				return result;
+			}
+			catch (Exception)
+			{
+				Log.Information("Failed to deserialize json from url");
+				return default(T);
+			}
 		}
 	}
 }

--- a/Anamnesis/Services/TipService.cs
+++ b/Anamnesis/Services/TipService.cs
@@ -25,7 +25,7 @@ namespace Anamnesis.Services
 			try
 			{
 				const string tipsUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Tips.json";
-				var updatedTips = SerializerService.DeserializeUrl<List<TipEntry>>(tipsUrl);
+				List<TipEntry>? updatedTips = SerializerService.DeserializeUrlAsync<List<TipEntry>>(tipsUrl).Result;
 				if (updatedTips != null)
 					SerializerService.SerializeFile("Data/Tips.json", updatedTips);
 				this.tips = SerializerService.DeserializeFile<List<TipEntry>>("Data/Tips.json");

--- a/Anamnesis/Services/TipService.cs
+++ b/Anamnesis/Services/TipService.cs
@@ -24,7 +24,7 @@ namespace Anamnesis.Services
 		{
 			try
 			{
-				const string tipsUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Tips2.json";
+				const string tipsUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Tips.json";
 				var updatedTips = SerializerService.DeserializeUrl<List<TipEntry>>(tipsUrl);
 				if (updatedTips != null)
 					SerializerService.SerializeFile("Data/Tips.json", updatedTips);

--- a/Anamnesis/Services/TipService.cs
+++ b/Anamnesis/Services/TipService.cs
@@ -24,6 +24,10 @@ namespace Anamnesis.Services
 		{
 			try
 			{
+				const string tipsUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Tips2.json";
+				var updatedTips = SerializerService.DeserializeUrl<List<TipEntry>>(tipsUrl);
+				if (updatedTips != null)
+					SerializerService.SerializeFile("Data/Tips.json", updatedTips);
 				this.tips = SerializerService.DeserializeFile<List<TipEntry>>("Data/Tips.json");
 			}
 			catch (Exception ex)

--- a/Anamnesis/Views/Gallery.xaml.cs
+++ b/Anamnesis/Views/Gallery.xaml.cs
@@ -74,7 +74,7 @@ namespace Anamnesis.Views
 			while (this.IsVisible)
 			{
 				const string galleryUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Images.json";
-				var updatedGallery = SerializerService.DeserializeUrl<List<Entry>>(galleryUrl);
+				List<Entry>? updatedGallery = await SerializerService.DeserializeUrlAsync<List<Entry>>(galleryUrl);
 				if (updatedGallery != null)
 					SerializerService.SerializeFile("Data/Images.json", updatedGallery);
 				List<Entry> entries = SerializerService.DeserializeFile<List<Entry>>("Data/Images.json");

--- a/Anamnesis/Views/Gallery.xaml.cs
+++ b/Anamnesis/Views/Gallery.xaml.cs
@@ -73,6 +73,10 @@ namespace Anamnesis.Views
 
 			while (this.IsVisible)
 			{
+				const string galleryUrl = "https://raw.githubusercontent.com/imchillin/Anamnesis/master/Anamnesis/Data/Images.json";
+				var updatedGallery = SerializerService.DeserializeUrl<List<Entry>>(galleryUrl);
+				if (updatedGallery != null)
+					SerializerService.SerializeFile("Data/Images.json", updatedGallery);
 				List<Entry> entries = SerializerService.DeserializeFile<List<Entry>>("Data/Images.json");
 
 				while (this.IsVisible && entries.Count > 0)


### PR DESCRIPTION
This is a very basic idea for #271. I think an API or something external is an overkill for something like this.
This implementation should work for most basic edge cases, like GitHub beeing down or the JSON beeing invalid.
Righ now  `Gallery` is updating the JSON each time it shows a new image (horrible), this should be done on each app start in my opinion, like it does with the `Tips`.

I will be updating this PR, let me know what you think of this approach.