### PR TITLE
Add option to mark items as owned

### DIFF
--- a/Anamnesis/Character/Items/DummyItem.cs
+++ b/Anamnesis/Character/Items/DummyItem.cs
@@ -54,6 +54,9 @@ namespace Anamnesis.Character.Items
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public virtual bool FitsInSlot(ItemSlots slot)
 		{
 			return true;

--- a/Anamnesis/Character/Items/DummyNoneItem.cs
+++ b/Anamnesis/Character/Items/DummyNoneItem.cs
@@ -31,6 +31,9 @@ namespace Anamnesis.Character.Items
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return true;

--- a/Anamnesis/Character/Items/InvisibleBodyItem.cs
+++ b/Anamnesis/Character/Items/InvisibleBodyItem.cs
@@ -31,6 +31,9 @@ namespace Anamnesis.Character.Items
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return slot == ItemSlots.Body;

--- a/Anamnesis/Character/Items/InvisibleHeadItem.cs
+++ b/Anamnesis/Character/Items/InvisibleHeadItem.cs
@@ -31,6 +31,9 @@ namespace Anamnesis.Character.Items
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return slot == ItemSlots.Head;

--- a/Anamnesis/Character/Items/NpcBodyItem.cs
+++ b/Anamnesis/Character/Items/NpcBodyItem.cs
@@ -31,6 +31,9 @@ namespace Anamnesis.Character.Items
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return slot == ItemSlots.Body || slot == ItemSlots.Feet || slot == ItemSlots.Hands || slot == ItemSlots.Legs;

--- a/Anamnesis/Character/Prop.cs
+++ b/Anamnesis/Character/Prop.cs
@@ -34,6 +34,9 @@ namespace Anamnesis.Character
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return slot == ItemSlots.MainHand || slot == ItemSlots.OffHand;

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml
@@ -120,95 +120,110 @@
 
 			<cm3Drawers:SelectorDrawer.ItemTemplate>
 				<DataTemplate>
-					<Grid>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-						<Grid.RowDefinitions>
-							<RowDefinition/>
-							<RowDefinition/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
 
-						<Border Width="32" Height="32" Background="#444444" Grid.RowSpan="3" CornerRadius="3"
+                        <Border Width="32" Height="32" Background="#444444" Grid.RowSpan="3" CornerRadius="3"
 								Visibility="{Binding Icon, Converter={StaticResource NotNullToVisibilityConverter}}">
-							<Grid>
-								<Image Source="{Binding Icon}" Margin="1"/>
-								<Image Source="/Assets/IconBorderSmall.png" Margin="-2, 0, -2, -4"/>
-							</Grid>
-						</Border>
+                            <Grid>
+                                <Image Source="{Binding Icon}" Margin="1"/>
+                                <Image Source="/Assets/IconBorderSmall.png" Margin="-2, 0, -2, -4"/>
+                            </Grid>
+                        </Border>
 
-						<TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Margin="6, 0, 0, 0" FontWeight="DemiBold" Foreground="{DynamicResource MaterialDesignBody}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Margin="6, 0, 0, 0" FontWeight="DemiBold" Foreground="{DynamicResource MaterialDesignBody}"/>
 
-						<StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0">
-							<TextBlock Text="{Binding Key}" Style="{StaticResource Label}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
-							<fa:IconBlock Icon="pen" FontSize="8" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-							<TextBlock Text="{Binding Description}" Style="{StaticResource Label}"/>
+                        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0">
+                            <TextBlock Text="{Binding Key}" Style="{StaticResource Label}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                            <fa:IconBlock Icon="pen" FontSize="8" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                            <TextBlock Text="{Binding Description}" Style="{StaticResource Label}"/>
 
-						</StackPanel>
+                        </StackPanel>
 
 
 
-						<Rectangle Grid.ColumnSpan="3" 
+                        <Rectangle Grid.ColumnSpan="3" 
 									   Grid.RowSpan="2" 
 									   Fill="Transparent" >
-							<ToolTipService.ToolTip>
-								<StackPanel Orientation="Vertical">
-									<TextBlock Text="{Binding Key}" FontWeight="DemiBold"/>
-									<TextBlock Text="{Binding Name}" FontWeight="DemiBold"/>
-									<TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                            <ToolTipService.ToolTip>
+                                <StackPanel Orientation="Vertical">
+                                    <TextBlock Text="{Binding Key}" FontWeight="DemiBold"/>
+                                    <TextBlock Text="{Binding Name}" FontWeight="DemiBold"/>
+                                    <TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
-									<Grid Grid.Column="1" Grid.Row="2" Margin="3, 3, 0, 0">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="Auto"/>
-											<ColumnDefinition/>
-										</Grid.ColumnDefinitions>
+                                    <Grid Grid.Column="1" Grid.Row="2" Margin="3, 3, 0, 0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
 
-										<Grid.RowDefinitions>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-											<RowDefinition/>
-										</Grid.RowDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                            <RowDefinition/>
+                                        </Grid.RowDefinitions>
 
-										<TextBlock Grid.Column="0" Grid.Row="0" Text="Item Id: " HorizontalAlignment="Left" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
-										<TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding Key}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="0" Text="Item Id: " HorizontalAlignment="Left" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
+                                        <TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding Key}" Visibility="{Binding Key, Converter={StaticResource NotZeroToVisibility}}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="1" Text="Set: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ModelSet}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="1" Text="Set: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding ModelSet}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="2" Text="Base: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding ModelBase}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="2" Text="Base: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="2" Text="{Binding ModelBase}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="3" Text="Variant: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding ModelVariant}"/>
+                                        <TextBlock Grid.Column="0" Grid.Row="3" Text="Variant: " HorizontalAlignment="Left" />
+                                        <TextBlock Grid.Column="1" Grid.Row="3" Text="{Binding ModelVariant}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="4" Text="Modded: " HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-										<TextBlock Grid.Column="1" Grid.Row="4" Text="{Binding Mod.ModPack.Name}" HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
-									</Grid>
-								</StackPanel>
-							</ToolTipService.ToolTip>
-						</Rectangle>
+                                        <TextBlock Grid.Column="0" Grid.Row="4" Text="Modded: " HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                                        <TextBlock Grid.Column="1" Grid.Row="4" Text="{Binding Mod.ModPack.Name}" HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+                                    </Grid>
+                                </StackPanel>
+                            </ToolTipService.ToolTip>
+                        </Rectangle>
 
-						<Grid Grid.Column="2" Grid.RowSpan="2">
+                        <Grid Grid.Column="2" Grid.RowSpan="2">
+                            <Grid.RowDefinitions>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                            </Grid.RowDefinitions>
 
-							<ToggleButton Style="{StaticResource InvisibleToggleButton}" IsChecked="{Binding IsFavorite}" Margin="6,0,0,0" Padding="0">
-								<Grid>
-									<fa:IconBlock Icon="Star" FontSize="13" Opacity="0.25"
-												   Visibility="{Binding IsFavorite, Converter={StaticResource !B2V}}"/>
-									<XivToolsWpf:IconBlock Icon="Star" FontSize="13"
-										  Visibility="{Binding IsFavorite, Converter={StaticResource B2V}}"/>
-								</Grid>
-							</ToggleButton>
+                            <ToggleButton Grid.Row="0" Style="{StaticResource InvisibleToggleButton}" IsChecked="{Binding IsFavorite}" Margin="6,0,0,0" Padding="0">
+                                <Grid>
+                                    <fa:IconBlock Icon="Star" FontSize="13" Opacity="0.25"
+										Visibility="{Binding IsFavorite, Converter={StaticResource !B2V}}"/>
+                                    <XivToolsWpf:IconBlock Icon="Star" FontSize="13"
+										Visibility="{Binding IsFavorite, Converter={StaticResource B2V}}"/>
+                                </Grid>
+                            </ToggleButton>
 
-						</Grid>
-
-					</Grid>
-				</DataTemplate>
+                            <ToggleButton Grid.Row="1" Style="{StaticResource InvisibleToggleButton}" IsChecked="{Binding IsOwned}" Margin="6,0,0,0" Padding="0"
+								Visibility="{Binding IsOwnable, Converter={StaticResource B2V}}">
+                                <ToggleButton.ToolTip>
+                                    <XivToolsWpf:TextBlock Key="EquipmentSelector_OwnedTip"/>
+                                </ToggleButton.ToolTip>
+                                <Grid>
+                                    <fa:IconBlock Icon="Check" FontSize="13" Opacity="0.25"
+										Visibility="{Binding IsOwned, Converter={StaticResource !B2V}}"/>
+                                    <fa:IconBlock Icon="Check"  FontSize="13"
+										Visibility="{Binding IsOwned, Converter={StaticResource B2V}}"/>
+                                </Grid>
+                            </ToggleButton>
+                        </Grid>
+                    </Grid>
+                </DataTemplate>
 			</cm3Drawers:SelectorDrawer.ItemTemplate>
 		</cm3Drawers:SelectorDrawer>
 	</Grid>

--- a/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Character/Views/EquipmentSelector.xaml.cs
@@ -230,7 +230,7 @@ namespace Anamnesis.Character.Views
 
 			// Always let uncategorized items through, otherwise there would be no way to get to them
 			bool categoryFiltered = itemCategory == ItemCategories.None;
-			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Standard) && itemCategory.HasFlag(ItemCategories.Standard);
+			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Standard) && (itemCategory.HasFlag(ItemCategories.Standard) || item.IsOwned);
 			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Premium) && itemCategory.HasFlag(ItemCategories.Premium);
 			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Limited) && itemCategory.HasFlag(ItemCategories.Limited);
 			categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Deprecated) && itemCategory.HasFlag(ItemCategories.Deprecated);

--- a/Anamnesis/GameData/Interfaces/IItem.cs
+++ b/Anamnesis/GameData/Interfaces/IItem.cs
@@ -25,7 +25,9 @@ namespace Anamnesis.GameData
 		bool IsWeapon { get; }
 
 		Mod? Mod { get; }
-		bool IsFavorite { get; set;  }
+		bool IsFavorite { get; set; }
+		bool IsOwnable { get; }
+		bool IsOwned { get; set; }
 
 		bool FitsInSlot(ItemSlots slot);
 	}

--- a/Anamnesis/GameData/ViewModels/ItemViewModel.cs
+++ b/Anamnesis/GameData/ViewModels/ItemViewModel.cs
@@ -56,6 +56,13 @@ namespace Anamnesis.GameData.ViewModels
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => true;
+		public bool IsOwned
+		{
+			get => OwnedService.IsOwned(this);
+			set => OwnedService.SetOwned(this, value);
+		}
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return this.Value.EquipSlotCategory.Value?.Contains(slot) ?? false;

--- a/Anamnesis/GameData/ViewModels/PerformViewModel.cs
+++ b/Anamnesis/GameData/ViewModels/PerformViewModel.cs
@@ -46,6 +46,9 @@ namespace Anamnesis.GameData.ViewModels
 			set => FavoritesService.SetFavorite(this, value);
 		}
 
+		public bool IsOwnable => false;
+		public bool IsOwned { get; set; }
+
 		public bool FitsInSlot(ItemSlots slot)
 		{
 			return slot == ItemSlots.MainHand;

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -38,6 +38,7 @@
 	"EquipmentSelector_Ambidextrous": "Allow all weapons in either hand",
 	"EquipmentSelector_AutoOffhand": "Auto-equip offhand",
 	"EquipmentSelector_AutoOffhandTip": "Automatically equip paired weapons in the offhand, and unequip the offhand when equipping two-handed weapons",
+	"EquipmentSelector_OwnedTip": "Mark as owned; all owned items are included in the Standard Items category",
 
 	"EquipmentSelector_Categories": "Categories",
 	"EquipmentSelector_Standard": "Standard Items",

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -66,6 +66,7 @@ namespace Anamnesis.Services
 			await Add<TipService>();
 			await Add<TexToolsService>();
 			await Add<FavoritesService>();
+			await Add<OwnedService>();
 
 			IsInitialized = true;
 

--- a/Anamnesis/Services/OwnedService.cs
+++ b/Anamnesis/Services/OwnedService.cs
@@ -1,0 +1,94 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Services
+{
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Threading.Tasks;
+	using System.Windows;
+	using Anamnesis.Files;
+	using Anamnesis.GameData;
+	using Anamnesis.GUI.Dialogs;
+	using Anamnesis.Serialization;
+	using PropertyChanged;
+
+	[AddINotifyPropertyChangedInterface]
+	public class OwnedService : ServiceBase<OwnedService>
+	{
+		private static readonly string FilePath = FileService.ParseToFilePath(FileService.StoreDirectory + "/Owned.json");
+
+		public Owned? Current { get; set; }
+
+		public static bool IsOwned(IItem item)
+		{
+			if (Instance.Current == null)
+				return false;
+
+			return Instance.Current.Items.Contains(item);
+		}
+
+		public static void SetOwned(IItem item, bool owned)
+		{
+			if (Instance.Current == null)
+				return;
+
+			bool isOwned = IsOwned(item);
+
+			if (owned == isOwned)
+				return;
+
+			if (owned)
+			{
+				Instance.Current.Items.Add(item);
+			}
+			else
+			{
+				Instance.Current.Items.Remove(item);
+			}
+
+			Instance.RaisePropertyChanged(nameof(Owned.Items));
+			Save();
+		}
+
+		public static void Save()
+		{
+			if (Instance.Current == null)
+				return;
+
+			string json = SerializerService.Serialize(Instance.Current);
+			File.WriteAllText(FilePath, json);
+		}
+
+		public override async Task Initialize()
+		{
+			await base.Initialize();
+
+			if (!File.Exists(FilePath))
+			{
+				this.Current = new Owned();
+				Save();
+			}
+			else
+			{
+				try
+				{
+					string json = File.ReadAllText(FilePath);
+					this.Current = SerializerService.Deserialize<Owned>(json);
+				}
+				catch (Exception)
+				{
+					await GenericDialog.Show("Failed to load owned items. Your owned items have been reset.", "Error", MessageBoxButton.OK);
+					Save();
+				}
+			}
+		}
+
+		[Serializable]
+		public class Owned
+		{
+			public List<IItem> Items { get; set; } = new List<IItem>();
+		}
+	}
+}


### PR DESCRIPTION
Adds a button to all real items in the equipment selector next to the Favorite button which marks them as being owned. Any item marked as owned will be included in the Standard Items category filter. The purpose of this is so limited and premium items can be hidden from the list while still including the ones you actually have, in the service of more convenient glamour testing as usual.

![Anamnesis_3E4IuVpKvg](https://user-images.githubusercontent.com/28029167/131217502-83a1fbdf-5446-4646-8f44-e2c52d760bd5.png)
