### PR TITLE
fix: don't trim directory names

### DIFF
--- a/Anamnesis/Files/FileBrowserView.xaml.cs
+++ b/Anamnesis/Files/FileBrowserView.xaml.cs
@@ -498,7 +498,7 @@ namespace Anamnesis.GUI.Views
 				this.View = view;
 			}
 
-			public string Name => Path.GetFileNameWithoutExtension(this.Entry.Name);
+			public string Name => this.Entry is DirectoryInfo ? this.Entry.Name : Path.GetFileNameWithoutExtension(this.Entry.Name);
 			public DateTime? DateModified => this.Entry.LastWriteTime;
 
 			public string Icon


### PR DESCRIPTION
Just because I use `00. Folder Name` and `01. Folder Name` for sorting, and it made my folders become nammed `00` and `01` in Anamnesis.