### PR TITLE
fixes pose flipping no longer working

### DIFF
--- a/Anamnesis/Posing/Pages/PosePage.xaml
+++ b/Anamnesis/Posing/Pages/PosePage.xaml
@@ -108,7 +108,7 @@
 										<XivToolsWpf:TextBlock Text="Select Children" />
 									</Button>
 
-									<!--<Button
+									<Button
 										Grid.Column="2"
 										Grid.ColumnSpan="2"
 										Margin="2"
@@ -116,7 +116,7 @@
 										Click="OnFlipClicked"
 										Style="{StaticResource TransparentButton}">
 										<XivToolsWpf:TextBlock Key="Pose_Flip" />
-									</Button>-->
+									</Button>
 
 								</Grid>
 							</Border>

--- a/Anamnesis/Posing/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Posing/Pages/PosePage.xaml.cs
@@ -92,10 +92,14 @@ namespace Anamnesis.PoseModule.Pages
 				CmQuaternion newRotation = targetBone.TransformMemory.Rotation.Mirror(); // character-relative transform
 				if (shouldFlip && targetBone.BoneName.EndsWith("_l"))
 				{
-					BoneVisual3d? rightBone = targetBone.Skeleton.GetBone(targetBone.BoneName.Replace("_l", "_r"));
+					string rightBoneString = targetBone.BoneName.Substring(0, targetBone.BoneName.Length - 2) + "_r"; // removes the "_l" and replaces it with "_r"
+					/*	Useful debug lines to make sure the correct bones are grabbed...
+					 *	Log.Information("flipping: " + targetBone.BoneName);
+					 *	Log.Information("right flip target: " + rightBoneString); */
+					BoneVisual3d? rightBone = targetBone.Skeleton.GetBone(rightBoneString);
 					if (rightBone != null)
 					{
-						CmQuaternion rightRot = rightBone.Rotation.Mirror();
+						CmQuaternion rightRot = rightBone.TransformMemory.Rotation.Mirror();
 						foreach (TransformMemory transformMemory in targetBone.TransformMemories)
 						{
 							transformMemory.Rotation = rightRot;
@@ -376,7 +380,7 @@ namespace Anamnesis.PoseModule.Pages
 				{
 					// if targeted bone is a limb don't switch the respective left and right sides
 					BoneVisual3d targetBone = this.Skeleton.CurrentBone;
-					if (targetBone.BoneName.EndsWith("Left") || targetBone.BoneName.EndsWith("Right"))
+					if (targetBone.BoneName.EndsWith("_l") || targetBone.BoneName.EndsWith("_r"))
 					{
 						this.FlipBone(targetBone, false);
 					}


### PR DESCRIPTION
#610 looks this should fix the pose flipping (didn't thoroughly test it but looks to be working as expected now)
ended up being one of the rotations not getting updated to the new TransformMemory system and updating to the new bone naming convention