### PR TITLE
Fix windows file loader extension filters

### DIFF
--- a/Anamnesis/Files/FileService.cs
+++ b/Anamnesis/Files/FileService.cs
@@ -305,14 +305,14 @@ namespace Anamnesis.Files
 			builder.Append("Any|");
 
 			foreach (Type type in types)
-				builder.Append("*" + GetFileTypeFilter(type) + ";");
+				builder.Append("*" + GetFileTypeFilter(type).Extension + ";");
 
 			foreach (Type type in types)
 			{
 				builder.Append("|");
 				builder.Append(GetFileTypeName(type));
 				builder.Append("|");
-				builder.Append("*" + GetFileTypeFilter(type));
+				builder.Append("*" + GetFileTypeFilter(type).Extension);
 			}
 
 			return builder.ToString();
@@ -323,7 +323,7 @@ namespace Anamnesis.Files
 			StringBuilder builder = new StringBuilder();
 			builder.Append(GetFileTypeName(type));
 			builder.Append("|");
-			builder.Append("*" + GetFileTypeFilter(type));
+			builder.Append("*" + GetFileTypeFilter(type).Extension);
 			return builder.ToString();
 		}
 

--- a/Anamnesis/Views/SceneView.xaml
+++ b/Anamnesis/Views/SceneView.xaml
@@ -148,7 +148,7 @@
 					<Grid Grid.Row="0"
 						  Grid.Column="0"
 						  Grid.ColumnSpan="2"
-						  IsEnabled="False"
+						  IsEnabled="True"
 						  Opacity="0.25">
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="Auto" />
@@ -213,12 +213,6 @@
 											   Minimum="0"
 											   Maximum="31" />
 					</Grid>
-
-					<XivToolsWpf:InfoControl Grid.Row="0"
-											 Grid.Column="0"
-											 Grid.ColumnSpan="2"
-											 Key="Common_Endwalker"
-											 VerticalAlignment="Center"/>
 
 					<XivToolsWpf:TextBlock Grid.Row="1"
 										   Key="Scene_World_Weather"


### PR DESCRIPTION
An earlier change broke the windows file browser filters. This fixes it, not sure if it's the best way to fix though.