### PR TITLE
Fix save/load disable for appearances in gpose mode

### DIFF
--- a/Anamnesis/Character/Pages/AppearancePage.xaml
+++ b/Anamnesis/Character/Pages/AppearancePage.xaml
@@ -211,7 +211,7 @@
 
 			<Menu Grid.Row="1"
 				  Margin="0,3, 3, 4"
-				  IsEnabled="{Binding GposeService.IsGpose}"
+				  IsEnabled="{Binding GPoseService.IsGpose, Converter={StaticResource NotConverter}}"
 				  Style="{StaticResource AnaMenu}">
 
 				<MenuItem Header="Common_OpenFile"

--- a/Anamnesis/Character/Pages/AppearancePage.xaml
+++ b/Anamnesis/Character/Pages/AppearancePage.xaml
@@ -211,7 +211,7 @@
 
 			<Menu Grid.Row="1"
 				  Margin="0,3, 3, 4"
-				  IsEnabled="{Binding GPoseService.IsGpose, Converter={StaticResource NotConverter}}"
+				  IsEnabled="{Binding GPoseService.IsOverworld}"
 				  Style="{StaticResource AnaMenu}">
 
 				<MenuItem Header="Common_OpenFile"


### PR DESCRIPTION
I believe this binding was likely intended to disable save/load of appearances in GPose mode but it was binding to nothing. 

Not sure if disabling saving is necessarily desirable as presumably that would still work? But loading definitely won't.