### PR TITLE
Select the existing pinned actor if it's already pinned

### DIFF
--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -27,7 +27,7 @@ namespace Anamnesis
 		public static event PinnedEvent? ActorUnPinned;
 
 		public ActorBasicMemory PlayerTarget { get; private set; } = new();
-		public bool IsPlayerTargetPinnable => CanPinActor(this.PlayerTarget);
+		public bool IsPlayerTargetPinnable => this.PlayerTarget.Address != IntPtr.Zero && CanPinActorType(this.PlayerTarget.ObjectKind);
 		public ActorMemory? SelectedActor { get; private set; }
 		public ObservableCollection<PinnedActor> PinnedActors { get; set; } = new ObservableCollection<PinnedActor>();
 
@@ -36,7 +36,7 @@ namespace Anamnesis
 			if (basicActor.Address == IntPtr.Zero)
 				return;
 
-			if (!CanPinActor(basicActor))
+			if (!CanPinActorType(basicActor.ObjectKind))
 			{
 				Log.Warning($"You cannot pin actor of type: {basicActor.ObjectKind}");
 				return;
@@ -49,6 +49,7 @@ namespace Anamnesis
 					if (basicActor.Address == otherActor.Pointer)
 					{
 						Log.Information($"Actor already pinned: {otherActor}");
+						Instance.SelectActor(otherActor);
 						return;
 					}
 				}
@@ -68,16 +69,6 @@ namespace Anamnesis
 			{
 				Log.Error(ex, "Failed to pin actor");
 			}
-		}
-
-		public static bool CanPinActor(ActorBasicMemory actorBasicMemory)
-		{
-			if(actorBasicMemory.Address != IntPtr.Zero)
-			{
-				return CanPinActorType(actorBasicMemory.ObjectKind);
-			}
-
-			return false;
 		}
 
 		public static bool CanPinActorType(ActorTypes actorType)


### PR DESCRIPTION
This is just a small QoL improvement, if an actor is already pinned and you try to pin it again it will select the actor instead of doing nothing (just makes the new targeting button a bit more friendly).