### PR TITLE
Add support for switching ingame target from Anamnesis

### DIFF
--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -232,6 +232,9 @@
 																		<ContextMenu>
 																			<MenuItem Click="OnUnpinActorClicked"
 																					  Header="Unpin" />
+
+																			<MenuItem Click="OnTargetActorClicked"
+																					  Header="Target" />
 																		</ContextMenu>
 																	</ToggleButton.ContextMenu>
 

--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -258,6 +258,14 @@ namespace Anamnesis.GUI
 			}
 		}
 
+		private void OnTargetActorClicked(object sender, RoutedEventArgs e)
+		{
+			if (sender is FrameworkElement el && el.DataContext is TargetService.PinnedActor actor)
+			{
+				TargetService.SetPlayerTarget(actor);
+			}
+		}
+
 		private void OnActorPinPreviewMouseUp(object sender, MouseButtonEventArgs e)
 		{
 			if (e.ChangedButton == MouseButton.Middle)

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -22,6 +22,9 @@ namespace Anamnesis
 	[AddINotifyPropertyChangedInterface]
 	public class TargetService : ServiceBase<TargetService>
 	{
+		public static readonly int OverworldPlayerTargetOffset = 0x80;
+		public static readonly int GPosePlayerTargetOffset = 0x98;
+
 		public static event SelectionEvent? ActorSelected;
 		public static event PinnedEvent? ActorPinned;
 		public static event PinnedEvent? ActorUnPinned;
@@ -201,6 +204,22 @@ namespace Anamnesis
 			return false;
 		}
 
+		public static void SetPlayerTarget(PinnedActor actor)
+		{
+			var ptr = actor?.Pointer;
+			if (ptr != null)
+			{
+				if (GposeService.Instance.IsGpose)
+				{
+					MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, GPosePlayerTargetOffset), (IntPtr)ptr, "Update player target");
+				}
+				else
+				{
+					MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, OverworldPlayerTargetOffset), (IntPtr)ptr, "Update player target");
+				}
+			}
+		}
+
 		public void UpdatePlayerTarget()
 		{
 			IntPtr currentPlayerTargetPtr = IntPtr.Zero;
@@ -209,11 +228,11 @@ namespace Anamnesis
 			{
 				if (GposeService.Instance.IsGpose)
 				{
-					currentPlayerTargetPtr = MemoryService.Read<IntPtr>(AddressService.PlayerTargetSystem + 0xC0);
+					currentPlayerTargetPtr = MemoryService.Read<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, GPosePlayerTargetOffset));
 				}
 				else
 				{
-					currentPlayerTargetPtr = MemoryService.Read<IntPtr>(AddressService.PlayerTargetSystem + 0x80);
+					currentPlayerTargetPtr = MemoryService.Read<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, OverworldPlayerTargetOffset));
 				}
 			}
 			catch


### PR DESCRIPTION
This change allows a user to right click a pinned actor and select "Target".
It will update the target ingame in both the Overworld and GPose.

GPose offset is new as the previous one seems to derive from this one but not update the camera. I haven't seen this offset used in any other tools but it seems reliable across multiple runs from what I can tell testing.