### PR TITLE
Eorzea Time Control

### DIFF
--- a/Anamnesis/Core/Memory/AddressService.cs
+++ b/Anamnesis/Core/Memory/AddressService.cs
@@ -132,13 +132,12 @@ namespace Anamnesis.Core.Memory
 			tasks.Add(GetAddressFromSignature("Camera", "48 8D 35 ?? ?? ?? ?? 48 8B 09", 0, (p) => { cameraManager = p; })); // CameraAddress
 			tasks.Add(GetAddressFromSignature("PlayerTargetSystem", "48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 50 ?? 48 85 DB", 0, (p) => { PlayerTargetSystem = p; }));
 
-			// Mising Signature for Endwalker
 			tasks.Add(GetAddressFromTextSignature(
-				"TimeStop",
-				"48 89 5C 24 ?? 57 48 83 EC 30 4C 8B 15",
+				"TimeAsm",
+				"48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 48 8B DA 48 81 C1 ?? ?? ?? ?? E8 ?? ?? ?? ?? 4C 8B 87",
 				(p) =>
 				{
-					TimeAsm = p + 0x19;
+					TimeAsm = p + 0xE5;
 				}));
 
 			tasks.Add(GetAddressFromTextSignature(
@@ -146,9 +145,11 @@ namespace Anamnesis.Core.Memory
 				"48 C7 05 ?? ?? ?? ?? 00 00 00 00 E8 ?? ?? ?? ?? 48 8D ?? ?? ?? 00 00 E8 ?? ?? ?? ?? 48 8D",
 				(p) =>
 				{
-					int fwOffset = MemoryService.Read<int>(p + 3);
-					TimeReal = MemoryService.ReadPtr(p + 11 + fwOffset);
-					TimeReal += 0x1770;
+					int frameworkOffset = MemoryService.Read<int>(p + 3);
+					IntPtr frameworkPtr = MemoryService.ReadPtr(p + 11 + frameworkOffset);
+					TimeReal = frameworkPtr + 0x1770;
+
+					// For reference, gpose time is at frameworkPtr + 0x1798 if it's ever needed
 				}));
 
 			tasks.Add(GetAddressFromTextSignature("SkeletonFreezePhysics (1/2/3)", "0F 29 48 10 41 0F 28 44 24 20 0F 29 40 20 48 8B 46", (p) =>

--- a/Anamnesis/Memory/TimeMemory.cs
+++ b/Anamnesis/Memory/TimeMemory.cs
@@ -5,22 +5,24 @@ namespace Anamnesis.Memory
 {
 	using System;
 
+	using Anamnesis.Core.Memory;
+
 	public class TimeMemory
 	{
-		private readonly IntPtr address;
-		private readonly byte[] originalValue;
-		private readonly byte[] newTimeAsm = new byte[] { 0x49, 0xC7, 0xC1, 0x00, 0x00, 0x00, 0x00 };
+		private readonly byte[] originalTimeAsm;
+
+		private readonly byte[] newTimeAsm = new byte[] { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 };
 
 		private bool value;
 
-		public TimeMemory(IntPtr address)
+		public TimeMemory()
 		{
-			this.address = address;
+			this.originalTimeAsm = new byte[this.newTimeAsm.Length];
 
-			this.originalValue = new byte[7];
-
-			MemoryService.Read(this.address, this.originalValue, this.originalValue.Length);
+			MemoryService.Read(AddressService.TimeAsm, this.originalTimeAsm, this.originalTimeAsm.Length);
 		}
+
+		public long CurrentTime => MemoryService.Read<long>(AddressService.TimeReal);
 
 		public bool Freeze
 		{
@@ -42,20 +44,20 @@ namespace Anamnesis.Memory
 
 			if (enabled)
 			{
-				// Write new function
-				MemoryService.Write(this.address, this.newTimeAsm);
+				// We disable the game code which updates Eorzea Time
+				MemoryService.Write(AddressService.TimeAsm, this.newTimeAsm);
 			}
 			else
 			{
-				// Write the original value
-				MemoryService.Write(this.address, this.originalValue);
+				// We write the Eorzea time update code back
+				MemoryService.Write(AddressService.TimeAsm, this.originalTimeAsm);
 			}
 		}
 
-		public void SetTime(uint newTime)
+		public void SetTime(long newTime)
 		{
-			// Write time into the function
-			MemoryService.Write(this.address + 0x3, BitConverter.GetBytes(newTime));
+			// As long as Eorzea Time updating is disabled we can just set it directly
+			MemoryService.Write(AddressService.TimeReal, BitConverter.GetBytes(newTime));
 		}
 	}
 }

--- a/Anamnesis/Services/TimeService.cs
+++ b/Anamnesis/Services/TimeService.cs
@@ -17,7 +17,7 @@ namespace Anamnesis
 
 		public TimeSpan Time { get; private set; }
 		public string TimeString { get; private set; } = "00:00";
-		public uint TimeOfDay { get; set; }
+		public long TimeOfDay { get; set; }
 		public byte DayOfMonth { get; set; }
 
 		public bool Freeze
@@ -30,7 +30,7 @@ namespace Anamnesis
 		{
 			await base.Initialize();
 
-			this.timeMemory = new TimeMemory(AddressService.TimeAsm);
+			this.timeMemory = new TimeMemory();
 
 			_ = Task.Run(this.CheckTime);
 		}
@@ -61,16 +61,15 @@ namespace Anamnesis
 
 					if (this.Freeze)
 					{
-						uint newTime = (uint)((this.TimeOfDay * 60) + (86400 * (this.DayOfMonth - 1)));
+						long newTime = (long)((this.TimeOfDay * 60) + (86400 * (this.DayOfMonth - 1)));
 						this.Time = TimeSpan.FromSeconds(newTime);
 						this.timeMemory?.SetTime(newTime);
 					}
 					else
 					{
-						long timeVal = MemoryService.Read<long>(AddressService.TimeReal) % 2764800;
+						long timeVal = this.timeMemory!.CurrentTime % 2764800;
 						this.Time = TimeSpan.FromSeconds(timeVal);
-
-						this.TimeOfDay = (uint)((uint)this.Time.TotalMinutes - (long)(this.Time.Days * 24 * 60));
+						this.TimeOfDay = (long)(this.Time.TotalMinutes - (this.Time.Days * 24 * 60));
 						this.DayOfMonth = (byte)this.Time.Days;
 					}
 


### PR DESCRIPTION
This switches Time Control back to using/modifying Eorzea Time. This means that things like the music, as well as the time when entering gpose, are correct for the set time of day. Basically it behaves like it did before Endwalker from a user perspective and that seems to be what people want/expect.

Basically the approach I took here was to find out where the game writes the time to the well known Eorzea Time location and patch out that mov/copy when time control is enabled so we can control it directly. 

Like with my last PR, these are fresh sigs and offsets so I've ensured they run across multiple process launches for me but some Alpha testing to verify it works for everyone as well as ensuring it doesn't impact something I didn't think to check would be good. 

One other note, when developing this I discovered the offset for gpose time. I haven't hooked into it because there is some weirdness that it must be 0 outside of gpose so it'd have to track when it's set, when to clear it and all that and it seems unnecessary as setting time directly in gpose has never been supported without unchecking. However, I thought this might be useful for Scenes or similar where it's a one time set, so left a comment with the offset.