### PR TITLE
Go through logic when clicking without a bone selected

### DIFF
--- a/Anamnesis/Posing/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Posing/Pages/PosePage.xaml.cs
@@ -6,6 +6,7 @@ namespace Anamnesis.PoseModule.Pages
 	using System;
 	using System.Collections.Generic;
 	using System.IO;
+	using System.Linq;
 	using System.Threading.Tasks;
 	using System.Windows;
 	using System.Windows.Controls;
@@ -525,7 +526,7 @@ namespace Anamnesis.PoseModule.Pages
 			{
 				if (this.Skeleton != null && !this.Skeleton.HasHover)
 				{
-					this.Skeleton?.ClearSelection();
+					this.Skeleton.Select(Enumerable.Empty<IBone>());
 				}
 			}
 


### PR DESCRIPTION
This one is a bit of a pet peeve of mine. If you are holding shift to select multiple bones in the GUI view and you accidently click off a bone, it deselects them all.

This switches the logic so it goes through the same flow as any other click (with the handling of shift holds) just with an empty bone list.

The existing behavior for multi selects and toggles seems unaffected.