### PR TITLE
Unify actor type compatibility

### DIFF
--- a/Anamnesis/Character/Pages/AppearancePage.xaml
+++ b/Anamnesis/Character/Pages/AppearancePage.xaml
@@ -6,6 +6,7 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:views="clr-namespace:Anamnesis.Character.Views"
 			 xmlns:XivToolsWpf="clr-namespace:XivToolsWpf.Controls;assembly=XivToolsWpf"
+			 xmlns:anaMem="clr-namespace:Anamnesis.Memory"
 			 d:DesignHeight="600"
 			 d:DesignWidth="1024"
 			 DataContextChanged="OnDataContextChanged"
@@ -138,22 +139,18 @@
 						<Grid Grid.Row="2"
 							  Grid.Column="1"
 							  Margin="0,2,0,0">
-							<ComboBox SelectedIndex="{Binding Actor.ObjectKindInt}">
-								<ComboBoxItem IsEnabled="False">None</ComboBoxItem>
-								<ComboBoxItem>Player</ComboBoxItem>
-								<ComboBoxItem>Battle NPC</ComboBoxItem>
-								<ComboBoxItem>Event NPC</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Treasure</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Aetheryte</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Gathering Point</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Event Object</ComboBoxItem>
-								<ComboBoxItem>Mount</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Companion</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Retainer</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Area</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Housing</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">Cutscene</ComboBoxItem>
-								<ComboBoxItem IsEnabled="False">card Stand</ComboBoxItem>
+							<ComboBox ItemsSource="{Binding Source={x:Static anaMem:ActorType.AllActorTypes}}" SelectedIndex="{Binding Actor.ObjectKindInt}">
+								<ComboBox.ItemContainerStyle>
+									<Style TargetType="{x:Type ComboBoxItem}">
+										<Setter Property="IsEnabled" Value="{Binding IsTypeSupported}"/>
+									</Style>
+								</ComboBox.ItemContainerStyle>
+								
+								<ComboBox.ItemTemplate>
+									<DataTemplate>
+										<TextBlock Text="{Binding Name}" />
+									</DataTemplate>
+								</ComboBox.ItemTemplate>
 							</ComboBox>
 						</Grid>
 

--- a/Anamnesis/Core/Memory/Types/ActorTypes.cs
+++ b/Anamnesis/Core/Memory/Types/ActorTypes.cs
@@ -1,8 +1,10 @@
 ﻿// © Anamnesis.
 // Licensed under the MIT license.
-
 namespace Anamnesis.Memory
 {
+	using System;
+	using System.Collections.Generic;
+
 	public enum ActorTypes : byte
 	{
 		None = 0x00,
@@ -13,12 +15,59 @@ namespace Anamnesis.Memory
 		Aetheryte = 0x05,
 		GatheringPoint = 0x06,
 		EventObj = 0x07,
-		MountType = 0x08,
+		Mount = 0x08,
 		Companion = 0x09,
 		Retainer = 0x0A,
 		Area = 0x0B,
 		Housing = 0x0C,
 		Cutscene = 0x0D,
 		CardStand = 0x0E,
+	}
+
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Not the first type")]
+	public class ActorType
+	{
+		public ActorType(string name, ActorTypes value, bool isSupported)
+		{
+			this.Name = name;
+			this.Value = value;
+			this.IsTypeSupported = isSupported;
+		}
+
+		public static IEnumerable<ActorType> AllActorTypes
+		{
+			get
+			{
+				List<ActorType> actorTypes = new();
+
+				foreach (ActorTypes value in Enum.GetValues(typeof(ActorTypes)))
+				{
+					var name = Enum.GetName(typeof(ActorTypes), value);
+					var isSupported = IsActorTypeSupported(value);
+					actorTypes.Add(new ActorType(name!, value, isSupported));
+				}
+
+				return actorTypes;
+			}
+		}
+
+		public string Name { get; private set; }
+		public ActorTypes Value { get; private set; }
+		public bool IsTypeSupported { get; private set; }
+
+		public static bool IsActorTypeSupported(ActorTypes actorType)
+		{
+			switch (actorType)
+			{
+				case ActorTypes.Player:
+				case ActorTypes.BattleNpc:
+				case ActorTypes.EventNpc:
+				case ActorTypes.Companion:
+				case ActorTypes.Mount:
+					return true;
+			}
+
+			return false;
+		}
 	}
 }

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -30,7 +30,7 @@ namespace Anamnesis
 		public static event PinnedEvent? ActorUnPinned;
 
 		public ActorBasicMemory PlayerTarget { get; private set; } = new();
-		public bool IsPlayerTargetPinnable => this.PlayerTarget.Address != IntPtr.Zero && CanPinActorType(this.PlayerTarget.ObjectKind);
+		public bool IsPlayerTargetPinnable => this.PlayerTarget.Address != IntPtr.Zero && ActorType.IsActorTypeSupported(this.PlayerTarget.ObjectKind);
 		public ActorMemory? SelectedActor { get; private set; }
 		public ObservableCollection<PinnedActor> PinnedActors { get; set; } = new ObservableCollection<PinnedActor>();
 
@@ -39,7 +39,7 @@ namespace Anamnesis
 			if (basicActor.Address == IntPtr.Zero)
 				return;
 
-			if (!CanPinActorType(basicActor.ObjectKind))
+			if (!ActorType.IsActorTypeSupported(basicActor.ObjectKind))
 			{
 				Log.Warning($"You cannot pin actor of type: {basicActor.ObjectKind}");
 				return;
@@ -72,20 +72,6 @@ namespace Anamnesis
 			{
 				Log.Error(ex, "Failed to pin actor");
 			}
-		}
-
-		public static bool CanPinActorType(ActorTypes actorType)
-		{
-			switch (actorType)
-			{
-				case ActorTypes.Player:
-				case ActorTypes.BattleNpc:
-				case ActorTypes.EventNpc:
-				case ActorTypes.Companion:
-					return true;
-			}
-
-			return false;
 		}
 
 		public static async Task PinPlayerTargetedActor()


### PR DESCRIPTION
Not sure about the implementation on this one. Seems to work but there may be a cleaner way.
It unifies the handling of what actors are allowed between the targeting system and actor type dropdown. 

Should probably be extended to the pin filter as well.