### PR TITLE
Set Last Animation Control

### DIFF
--- a/Anamnesis/Core/Memory/AddressService.cs
+++ b/Anamnesis/Core/Memory/AddressService.cs
@@ -36,6 +36,7 @@ namespace Anamnesis.Core.Memory
 		public static IntPtr TimeAsm { get; private set; }
 		public static IntPtr TimeReal { get; set; }
 		public static IntPtr PlayerTargetSystem { get; set; }
+		public static IntPtr ActorActionTable { get; set; }
 
 		public static IntPtr Camera
 		{
@@ -131,6 +132,7 @@ namespace Anamnesis.Core.Memory
 			tasks.Add(GetAddressFromSignature("GPose", "48 39 0D ?? ?? ?? ?? 75 28", 0, (p) => { GPose = p + 0x20; }));
 			tasks.Add(GetAddressFromSignature("Camera", "48 8D 35 ?? ?? ?? ?? 48 8B 09", 0, (p) => { cameraManager = p; })); // CameraAddress
 			tasks.Add(GetAddressFromSignature("PlayerTargetSystem", "48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 50 ?? 48 85 DB", 0, (p) => { PlayerTargetSystem = p; }));
+			tasks.Add(GetAddressFromSignature("ActorActionTable", "48 8B 0D ?? ?? ?? ?? 41 B1 0A", 0, (p) => { ActorActionTable = p; }));
 
 			tasks.Add(GetAddressFromTextSignature(
 				"TimeAsm",

--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -389,8 +389,8 @@
 						<TabItem.Header>
 							<fa:IconImage
 								Foreground="{DynamicResource MaterialDesignBodyLight}"
-								Icon="Ambulance"
-								ToolTip="Pose" />
+								Icon="Bicycle"
+								ToolTip="Animate" />
 						</TabItem.Header>
 
 						<views:ActorActionView />

--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -385,6 +385,16 @@
 
 						<posePages:PosePage DataContext="{Binding TargetService.SelectedActor}" />
 					</TabItem>
+					<TabItem IsEnabled="{Binding TargetService.SelectedActor, Converter={StaticResource NotNullToBoolConverter}}">
+						<TabItem.Header>
+							<fa:IconImage
+								Foreground="{DynamicResource MaterialDesignBodyLight}"
+								Icon="Ambulance"
+								ToolTip="Pose" />
+						</TabItem.Header>
+
+						<views:ActorActionView />
+					</TabItem>
 				</TabControl>
 			</Grid>
 

--- a/Anamnesis/Memory/ActorActionMemory.cs
+++ b/Anamnesis/Memory/ActorActionMemory.cs
@@ -12,6 +12,7 @@ namespace Anamnesis.Memory
 
 		public enum ActionTypes : byte
 		{
+			None = 0x0,
 			Emote = 0x1,
 			Action = 0x2,
 		}
@@ -20,5 +21,6 @@ namespace Anamnesis.Memory
 		[Bind(0x08)] public uint ActorObjectId { get; set; }
 		[Bind(0x10)] public ActionTypes ActionType { get; set; }
 		[Bind(0x14)] public ushort ActionId { get; set; }
+		[Bind(0x70)] public IntPtr GPoseActorPtr { get; set; }
 	}
 }

--- a/Anamnesis/Memory/ActorActionMemory.cs
+++ b/Anamnesis/Memory/ActorActionMemory.cs
@@ -1,0 +1,24 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Memory
+{
+	using System;
+
+	public class ActorActionMemory : MemoryBase
+	{
+		public static readonly int ActionMemoryLength = 0xA0;
+		public static readonly int EntriesInActionTable = 0x40;
+
+		public enum ActionTypes : byte
+		{
+			Emote = 0x1,
+			Action = 0x2,
+		}
+
+		[Bind(0x00)] public IntPtr ActorPtr { get; set; }
+		[Bind(0x08)] public uint ActorObjectId { get; set; }
+		[Bind(0x10)] public ActionTypes ActionType { get; set; }
+		[Bind(0x14)] public ushort ActionId { get; set; }
+	}
+}

--- a/Anamnesis/Memory/ActorActionMemory.cs
+++ b/Anamnesis/Memory/ActorActionMemory.cs
@@ -10,7 +10,7 @@ namespace Anamnesis.Memory
 		public static readonly int ActionMemoryLength = 0xA0;
 		public static readonly int EntriesInActionTable = 0x40;
 
-		public enum ActionTypes : byte
+		public enum ActionTypes : uint
 		{
 			None = 0x0,
 			Emote = 0x1,
@@ -20,7 +20,9 @@ namespace Anamnesis.Memory
 		[Bind(0x00)] public IntPtr ActorPtr { get; set; }
 		[Bind(0x08)] public uint ActorObjectId { get; set; }
 		[Bind(0x10)] public ActionTypes ActionType { get; set; }
-		[Bind(0x14)] public ushort ActionId { get; set; }
+		[Bind(0x14)] public uint ActionId { get; set; }
+		[Bind(0x40)] public uint SubActionType { get; set; }
+		[Bind(0x44)] public uint SubActionId { get; set; }
 		[Bind(0x70)] public IntPtr GPoseActorPtr { get; set; }
 	}
 }

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -67,6 +67,7 @@ namespace Anamnesis.Services
 			await Add<TipService>();
 			await Add<TexToolsService>();
 			await Add<FavoritesService>();
+			await Add<ActorActionsService>();
 			await Add<AnamnesisConnectService>();
 
 			IsInitialized = true;

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -54,7 +54,7 @@ namespace Anamnesis.Services
 				// Next we search for an empty entry
 				foreach (var entry in table)
 				{
-					if (entry.ActorPtr == IntPtr.Zero)
+					if (entry.ActorPtr == IntPtr.Zero && entry.ActorObjectId == 0xE0000000)
 					{
 						toSet = entry;
 						break;

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -19,7 +19,7 @@ namespace Anamnesis.Services
 			await base.Start();
 		}
 
-		public bool SetAction(ActorBasicMemory actor, ActorActionMemory.ActionTypes actionType, ushort actionId)
+		public bool SetAction(ActorBasicMemory actor, ActorActionMemory.ActionTypes actionType, uint actionId)
 		{
 			ActorActionMemory? targetAction = null;
 
@@ -51,6 +51,12 @@ namespace Anamnesis.Services
 			// Update table entry
 			targetAction.ActionType = actionType;
 			targetAction.ActionId = actionId;
+
+			if(actionType == ActorActionMemory.ActionTypes.Action)
+			{
+				targetAction.SubActionType = 1;
+				targetAction.SubActionId = actionId;
+			}
 
 			return true;
 		}

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -52,6 +52,7 @@ namespace Anamnesis.Services
 			targetAction.ActionType = actionType;
 			targetAction.ActionId = actionId;
 
+			// This is pretty hacky, but when using an action it always seems to set this. Would be nice to understand what this does a little more
 			if(actionType == ActorActionMemory.ActionTypes.Action)
 			{
 				targetAction.SubActionType = 1;

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -3,14 +3,14 @@
 
 namespace Anamnesis.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Anamnesis.Core.Memory;
-    using Anamnesis.Memory;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Threading.Tasks;
+	using Anamnesis.Core.Memory;
+	using Anamnesis.Memory;
 
-    public class ActorActionsService : ServiceBase<ActorActionsService>
+	public class ActorActionsService : ServiceBase<ActorActionsService>
 	{
 		private IEnumerable<ActorActionMemory>? actionTable = null;
 
@@ -26,24 +26,19 @@ namespace Anamnesis.Services
 			// Make sure we have the latest version
 			this.RefreshTable();
 
-			// First search for an existing entry
-			foreach (var entry in this.actionTable!)
-			{
-				if (entry.ActorPtr == actor.Address && entry.ActorObjectId == actor.ObjectId)
-				{
-					targetAction = entry;
-					break;
-				}
-			}
+			// First search for an existing entry in both overworld and gpose
+			targetAction = this.GetAction(actor);
 
-			if (targetAction == null)
+			// If no match and not in gpose we search for a blank entry (you can't add a new entry during gpose as we don't have a handle to the overworld actor anymore)
+			if (targetAction == null && !GposeService.Instance.IsGpose)
 			{
-				// Next we search for an empty entry
 				foreach (var entry in this.actionTable!)
 				{
 					if (entry.ActorPtr == IntPtr.Zero && entry.ActorObjectId == 0xE0000000)
 					{
 						targetAction = entry;
+						targetAction.ActorPtr = actor.Address;
+						targetAction.ActorObjectId = actor.ObjectId;
 						break;
 					}
 				}
@@ -54,12 +49,27 @@ namespace Anamnesis.Services
 				return false;
 
 			// Update table entry
-			targetAction.ActorPtr = actor.Address;
-			targetAction.ActorObjectId = actor.ObjectId;
 			targetAction.ActionType = actionType;
 			targetAction.ActionId = actionId;
 
 			return true;
+		}
+
+		public ActorActionMemory? GetAction(ActorBasicMemory actor, bool searchOverworld = true, bool searchGPose = true, bool refresh = false)
+		{
+			if (refresh || this.actionTable == null)
+				this.RefreshTable();
+
+			foreach (var entry in this.actionTable!)
+			{
+				if ((searchOverworld && (entry.ActorPtr == actor.Address && entry.ActorObjectId == actor.ObjectId))
+					|| (searchGPose && (entry.GPoseActorPtr == actor.Address)))
+				{
+					return entry;
+				}
+			}
+
+			return null;
 		}
 
 		public IEnumerable<ActorActionMemory> GetTable(bool refresh = false)
@@ -89,7 +99,7 @@ namespace Anamnesis.Services
 			IntPtr tableStart = MemoryService.ReadPtr(AddressService.ActorActionTable) + 0x5B0;
 
 			List<ActorActionMemory> result = new();
-			for(int i = 0; i < ActorActionMemory.EntriesInActionTable; ++i)
+			for (int i = 0; i < ActorActionMemory.EntriesInActionTable; ++i)
 			{
 				IntPtr address = tableStart + (i * ActorActionMemory.ActionMemoryLength);
 				ActorActionMemory actorActionMemory = new();

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -39,19 +39,10 @@ namespace Anamnesis.Services
 			ActorActionMemory? toSet = null;
 			var table = this.GetTable();
 
-			foreach (var entry in table.Take(5))
-			{
-				toSet = entry;
-				toSet.ActorPtr = actor.Address;
-				toSet.ActorObjectId = actor.ObjectId;
-				toSet.ActionType = actionType;
-				toSet.ActionId = actionId;
-			}
-
 			// First search for an existing entry
 			foreach (var entry in table)
 			{
-				if (entry.ActorPtr == actor.Address || entry.ActorObjectId == actor.ObjectId)
+				if (entry.ActorPtr == actor.Address && entry.ActorObjectId == actor.ObjectId)
 				{
 					toSet = entry;
 					break;
@@ -63,7 +54,7 @@ namespace Anamnesis.Services
 				// Next we search for an empty entry
 				foreach (var entry in table)
 				{
-					if (entry.ActorPtr == IntPtr.Zero || entry.ActorObjectId == 0xE)
+					if (entry.ActorPtr == IntPtr.Zero)
 					{
 						toSet = entry;
 						break;

--- a/Anamnesis/Services/ActorActionsService.cs
+++ b/Anamnesis/Services/ActorActionsService.cs
@@ -1,0 +1,84 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Anamnesis.Core.Memory;
+    using Anamnesis.Memory;
+
+    public class ActorActionsService : ServiceBase<ActorActionsService>
+	{
+		public override Task Start()
+		{
+			return base.Start();
+		}
+
+		public IEnumerable<ActorActionMemory> GetTable()
+		{
+			IntPtr tableStart = MemoryService.ReadPtr(AddressService.ActorActionTable) + 0x5B0;
+
+			List<ActorActionMemory> result = new();
+			for(int i = 0; i < ActorActionMemory.EntriesInActionTable; ++i)
+			{
+				IntPtr address = tableStart + (i * ActorActionMemory.ActionMemoryLength);
+				ActorActionMemory actorActionMemory = new();
+				actorActionMemory.SetAddress(address);
+
+				result.Add(actorActionMemory);
+			}
+
+			return result;
+		}
+
+		public void SetActorAction(ActorBasicMemory actor, ActorActionMemory.ActionTypes actionType, ushort actionId)
+		{
+			ActorActionMemory? toSet = null;
+			var table = this.GetTable();
+
+			foreach (var entry in table.Take(5))
+			{
+				toSet = entry;
+				toSet.ActorPtr = actor.Address;
+				toSet.ActorObjectId = actor.ObjectId;
+				toSet.ActionType = actionType;
+				toSet.ActionId = actionId;
+			}
+
+			// First search for an existing entry
+			foreach (var entry in table)
+			{
+				if (entry.ActorPtr == actor.Address || entry.ActorObjectId == actor.ObjectId)
+				{
+					toSet = entry;
+					break;
+				}
+			}
+
+			if (toSet == null)
+			{
+				// Next we search for an empty entry
+				foreach (var entry in table)
+				{
+					if (entry.ActorPtr == IntPtr.Zero || entry.ActorObjectId == 0xE)
+					{
+						toSet = entry;
+						break;
+					}
+				}
+			}
+
+			// If there is no space maybe we should write a random one?
+			if (toSet == null)
+				return;
+
+			toSet.ActorPtr = actor.Address;
+			toSet.ActorObjectId = actor.ObjectId;
+			toSet.ActionType = actionType;
+			toSet.ActionId = actionId;
+		}
+	}
+}

--- a/Anamnesis/Views/ActorActionView.xaml
+++ b/Anamnesis/Views/ActorActionView.xaml
@@ -20,7 +20,7 @@
 
 		<TextBlock Grid.Column="0" Grid.Row="0">Type</TextBlock>
 		<ComboBox Grid.Column="1" Grid.Row="0" SelectedIndex="{Binding ActionType, Mode=TwoWay}">
-			<ComboBoxItem IsEnabled="false">None</ComboBoxItem>
+			<ComboBoxItem>None</ComboBoxItem>
 			<ComboBoxItem>Emote</ComboBoxItem>
 			<ComboBoxItem>Action</ComboBoxItem>
 		</ComboBox>

--- a/Anamnesis/Views/ActorActionView.xaml
+++ b/Anamnesis/Views/ActorActionView.xaml
@@ -19,7 +19,7 @@
 		</Grid.RowDefinitions>
 
 		<TextBlock Grid.Column="0" Grid.Row="0">Type</TextBlock>
-		<ComboBox Grid.Column="1" Grid.Row="0" SelectedValue="{Binding ActionType, Mode=TwoWay}">
+		<ComboBox Grid.Column="1" Grid.Row="0" SelectedIndex="{Binding ActionType, Mode=TwoWay}">
 			<ComboBoxItem IsEnabled="false">None</ComboBoxItem>
 			<ComboBoxItem>Emote</ComboBoxItem>
 			<ComboBoxItem>Action</ComboBoxItem>

--- a/Anamnesis/Views/ActorActionView.xaml
+++ b/Anamnesis/Views/ActorActionView.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="Anamnesis.Views.ActorActionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Anamnesis.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid Margin="150">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition/>
+			<ColumnDefinition/>
+		</Grid.ColumnDefinitions>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Column="0" Grid.Row="0">Type</TextBlock>
+		<ComboBox Grid.Column="1" Grid.Row="0" SelectedValue="{Binding ActionType, Mode=TwoWay}">
+			<ComboBoxItem IsEnabled="false">None</ComboBoxItem>
+			<ComboBoxItem>Emote</ComboBoxItem>
+			<ComboBoxItem>Action</ComboBoxItem>
+		</ComboBox>
+
+		<TextBlock Grid.Column="0" Grid.Row="1">ID</TextBlock>
+		<TextBox Grid.Column="1" Grid.Row="1" Style="{StaticResource MaterialDesignTextBox}" Text="{Binding ActionId}" />
+
+		<Button Grid.Row="2" Grid.Column="1" Click="ApplyAction_Click">Apply</Button>
+	</Grid>
+</UserControl>

--- a/Anamnesis/Views/ActorActionView.xaml.cs
+++ b/Anamnesis/Views/ActorActionView.xaml.cs
@@ -23,7 +23,7 @@ namespace Anamnesis.Views
 			var selectedActor = TargetService.Instance.SelectedActor;
 			if (selectedActor != null)
 			{
-				ActorActionsService.Instance.SetActorAction(selectedActor, (ActorActionMemory.ActionTypes)this.ActionType, this.ActionId);
+				ActorActionsService.Instance.SetAction(selectedActor, (ActorActionMemory.ActionTypes)this.ActionType, this.ActionId);
 			}
 		}
 	}

--- a/Anamnesis/Views/ActorActionView.xaml.cs
+++ b/Anamnesis/Views/ActorActionView.xaml.cs
@@ -1,0 +1,30 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Views
+{
+    using System.Windows.Controls;
+    using Anamnesis.Memory;
+    using Anamnesis.Services;
+
+    public partial class ActorActionView : UserControl
+	{
+		public ActorActionView()
+		{
+			this.DataContext = this;
+			this.InitializeComponent();
+		}
+
+		public ActorActionMemory.ActionTypes ActionType { get; set; } = ActorActionMemory.ActionTypes.Emote;
+		public ushort ActionId { get; set; } = 232;
+
+		private void ApplyAction_Click(object sender, System.Windows.RoutedEventArgs e)
+		{
+			var selectedActor = TargetService.Instance.SelectedActor;
+			if (selectedActor != null)
+			{
+				ActorActionsService.Instance.SetActorAction(selectedActor, this.ActionType, this.ActionId);
+			}
+		}
+	}
+}

--- a/Anamnesis/Views/ActorActionView.xaml.cs
+++ b/Anamnesis/Views/ActorActionView.xaml.cs
@@ -15,7 +15,7 @@ namespace Anamnesis.Views
 			this.InitializeComponent();
 		}
 
-		public ActorActionMemory.ActionTypes ActionType { get; set; } = ActorActionMemory.ActionTypes.Emote;
+		public int ActionType { get; set; } = (int)ActorActionMemory.ActionTypes.Emote;
 		public ushort ActionId { get; set; } = 232;
 
 		private void ApplyAction_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -23,7 +23,7 @@ namespace Anamnesis.Views
 			var selectedActor = TargetService.Instance.SelectedActor;
 			if (selectedActor != null)
 			{
-				ActorActionsService.Instance.SetActorAction(selectedActor, this.ActionType, this.ActionId);
+				ActorActionsService.Instance.SetActorAction(selectedActor, (ActorActionMemory.ActionTypes)this.ActionType, this.ActionId);
 			}
 		}
 	}

--- a/Anamnesis/Views/Gallery.xaml.cs
+++ b/Anamnesis/Views/Gallery.xaml.cs
@@ -135,6 +135,10 @@ namespace Anamnesis.Views
 					}
 
 					this.currentIndex++;
+
+					if (this.currentIndex >= entries.Count)
+						this.currentIndex = 0;
+
 					await this.Show(entries[this.currentIndex], rnd);
 
 					this.forceUpdate = false;


### PR DESCRIPTION
The idea here is that before entering gpose you set the "Last Emote/Action" value for a character which is read by gpose once you enter. This will force them to play this anim/action in gpose. 

It supports both emotes and actions (the ID is the one from the `Emote` and `Action` sheets respectively). Which actions will play on which characters is kind of fiddly. It only supports actors which are copied upon entering gpose (party members, squadron, housing, chocobo, carby etc).

As far as I am aware this is an entirely new method to control animations for posing so it will need extensive testing. It likely also needs a UI using the above sheets allowing the user to select them rather than knowing the type/id. The current UI is just placeholder.

The code is still pretty janky and can likely be improved significantly, but this is a quick and dirty functional version to iterate on.

*Additional Notes*
It actually will replace the animation you are doing in gpose if there was an emote set for that character (either using this, or one they actually used before entering) and it's not an infinite loop, but I think that's pretty confusing from a user friendliness pov so I'd suggest making it only available in the overworld like changing gear. 

There appears to be a similar table specifically for gpose which is structured a little different and functions as the override table, so I am going to look into that more but it's not clear if it will improve things further (especially for looping anims) so it may be a bust.

Interestingly, the engine writes the gpose actor address into this table as well, so assuming an actor has an emote you have a 1:1 relationship between overworld and gpose.