### PR TITLE
Fix a targeting related FFXIV crash

### DIFF
--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -233,7 +233,8 @@
 																			<MenuItem Click="OnUnpinActorClicked"
 																					  Header="Unpin" />
 
-																			<MenuItem Click="OnTargetActorClicked"
+																			<MenuItem Visibility="{Binding IsValid, Converter={StaticResource B2V}}" 
+																					  Click="OnTargetActorClicked"
 																					  Header="Target" />
 																		</ContextMenu>
 																	</ToggleButton.ContextMenu>

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -192,16 +192,22 @@ namespace Anamnesis
 
 		public static void SetPlayerTarget(PinnedActor actor)
 		{
-			var ptr = actor?.Pointer;
-			if (ptr != null)
+			if (actor.IsValid)
 			{
-				if (GposeService.Instance.IsGpose)
+				IntPtr? ptr = actor.Pointer;
+				if (ptr != null && ptr != IntPtr.Zero)
 				{
-					MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, GPosePlayerTargetOffset), (IntPtr)ptr, "Update player target");
-				}
-				else
-				{
-					MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, OverworldPlayerTargetOffset), (IntPtr)ptr, "Update player target");
+					if (IsActorInActorTable((IntPtr)ptr))
+					{
+						if (GposeService.Instance.IsGpose)
+						{
+							MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, GPosePlayerTargetOffset), (IntPtr)ptr, "Update player target");
+						}
+						else
+						{
+							MemoryService.Write<IntPtr>(IntPtr.Add(AddressService.PlayerTargetSystem, OverworldPlayerTargetOffset), (IntPtr)ptr, "Update player target");
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a crash when you try and target an actor that doesn't exist anymore. 9/10 you either select nothing or a random new actor, but occasionally it's an invalid pointer and will cause a CTD of FFXIV.

Also generally improved it so the target button doesn't even appear if the pinned actor isn't valid anymore. 