### PR TITLE
Fix animation crash

### DIFF
--- a/Anamnesis/Services/AnimationService.cs
+++ b/Anamnesis/Services/AnimationService.cs
@@ -43,6 +43,9 @@ namespace Anamnesis.Services
 		{
 			this.ClearAnimation(actor);
 
+			if (desiredAnimation >= GameDataService.ActionTimelines.RowCount)
+				return;
+
 			ActorAnimation animationEntry = new()
 			{
 				Actor = actor,


### PR DESCRIPTION
If you specify an animation id that is higher than the rows in the `ActionTimeline` sheet, FFXIV will CTD.