### PR TITLE
Allow for URI with spaces to be opened & fix empty local gallery crash

### DIFF
--- a/Anamnesis/Utils/UrlUtility.cs
+++ b/Anamnesis/Utils/UrlUtility.cs
@@ -13,7 +13,7 @@ namespace Anamnesis
 		{
 			try
 			{
-				Process.Start(new ProcessStartInfo(@"cmd", $"/c start {url}") { CreateNoWindow = true });
+				Process.Start(new ProcessStartInfo(@"cmd", $"/c start \"\" \"{url}\"") { CreateNoWindow = true });
 			}
 			catch (Exception ex)
 			{

--- a/Anamnesis/Views/Gallery.xaml.cs
+++ b/Anamnesis/Views/Gallery.xaml.cs
@@ -139,7 +139,7 @@ namespace Anamnesis.Views
 					if (this.currentIndex >= entries.Count)
 						this.currentIndex = 0;
 
-					if (this == null || entries == null)
+					if (this == null || entries == null || entries.Count == 0)
 						return;
 
 					await this.Show(entries[this.currentIndex], rnd);


### PR DESCRIPTION
I have added check for case where gallery is loaded but empty which previously would cause a crash, most likely a more robust check is possible but this does the job without any bigger pieces of code or major rewrites.

Also modified the way images from local gallery are being opened, previous approach would not respect URI with spaces, this approach allows it as it adds quotes around URI (first quotes have to be empty since if we use quotes with start command it expects first quotes to have command prompt window name)