### PR TITLE
Add missing language labels and fix typos

### DIFF
--- a/Anamnesis/Languages/cn.json
+++ b/Anamnesis/Languages/cn.json
@@ -12,7 +12,7 @@
 	"Common_LinkVector": "同时调节XYZ值",
 	"Common_Confirm": "确定",
 
-	"ProcessSelector_AllWarning": "若选择DirectX 11模式的最终幻想XIV以外的进程会导致所选进程和Anmnesis崩溃",
+	"ProcessSelector_AllWarning": "若选择DirectX 11模式的最终幻想XIV以外的进程会导致所选进程和Anamnesis崩溃",
 	"ProcessSelector_NotFound": "没有找到最终幻想XIV进程 (ffxiv_dx11)。",
 	"ProcessSelector_NotFound2": "请确保游戏正在运行，并处于DirectX 11模式。",
 

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -12,7 +12,7 @@
 	"Common_LinkVector": "Link X, Y, and Z axes together",
 	"Common_Confirm": "Confirm",
 
-	"ProcessSelector_AllWarning": "Selecting a process other than the DirectX 11 Final Fantasy XIV process can cause the selected process and Anmnesis to crash",
+	"ProcessSelector_AllWarning": "Selecting a process other than the DirectX 11 Final Fantasy XIV process can cause the selected process and Anamnesis to crash",
 	"ProcessSelector_NotFound": "Final Fantasy XIV process (ffxiv_dx11) not found.",
 	"ProcessSelector_NotFound2": "Please ensure the game is running, and is in DirectX 11 mode.",
 

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -69,7 +69,7 @@
 	"EquipmentSelector_ModdedTip": "Items that have been modified",
 	"EquipmentSelector_Favorites": "Favourites",
 	"EquipmentSelector_FavoritesTip": "Items marked as a favourite",
-	"EquipmentSelector_FavoriteToggleTip": "Mark this item a a favourite",
+	"EquipmentSelector_FavoriteToggleTip": "Mark this item as a favourite",
 	"EquipmentSelector_Owned": "Owned",
 	"EquipmentSelector_OwnedTip": "Premium or Limited Items marked as owned",
 	"EquipmentSelector_OwnedToggleTip": "Mark this premium or limited item as owned",

--- a/Anamnesis/Languages/es.json
+++ b/Anamnesis/Languages/es.json
@@ -1,4 +1,6 @@
 {
+	"Language": "Español",
+
 	"Common_OpenFile": "Cargar",
 	"Common_SaveFile": "Guardar",
 	"Common_OpenDir": "Abrir",
@@ -10,7 +12,7 @@
 	"Common_LinkVector": "Agrupar los ejes X, Y y Z ",
 	"Common_Confirm": "Confirmar",
 
-	"ProcessSelector_AllWarning": "Seleccionar otro proceso que no sea el proceso DirectX11 de Final Fantasy XIV puede causer el cierre del proceso seleccionado y Anamensis",
+	"ProcessSelector_AllWarning": "Seleccionar otro proceso que no sea el proceso DirectX11 de Final Fantasy XIV puede causer el cierre del proceso seleccionado y Anamnesis",
 
 	"Error_NotInGame": "No ha iniciado sesion",
 	"Error_WrongVersion": "Version del juego no compatible: {0}. ¿Ha salido un parche recientemente?\nUsar Anamnesis con versiones no compatibles puede provocar cierres del juego/aplicación.\nTendremos una actualización tan pronto como no sea posible. ¡Gracias por su paciencia!",

--- a/Anamnesis/Languages/fr.json
+++ b/Anamnesis/Languages/fr.json
@@ -1,4 +1,6 @@
 {
+	"Language": "Français",
+
 	"Common_OpenFile": "Ouvrir",
 	"Common_SaveFile": "Sauvegarder",
 	"Common_OpenDir": "Ouvrir",

--- a/Anamnesis/Languages/id.json
+++ b/Anamnesis/Languages/id.json
@@ -12,7 +12,7 @@
 	"Common_LinkVector": "Menyambungkan titik sumbu X, Y, dan Z menjadi satu.",
 	"Common_Confirm": "Konfirmasi",
 
-	"ProcessSelector_AllWarning": "Memilih proses lain selain Final Fantasy XIV pada mode DirectX 11 dapat menyebabkan aplikasi Anamesis berhenti secara paksa",
+	"ProcessSelector_AllWarning": "Memilih proses lain selain Final Fantasy XIV pada mode DirectX 11 dapat menyebabkan aplikasi Anamnesis berhenti secara paksa",
 	"ProcessSelector_NotFound": "Proses Final Fantasy XIV (ffxiv_dx11) tidak ditemukan.",
 	"ProcessSelector_NotFound2": "Tolong pastikan gamenya telah berjalan dan dalam mode DirectX 11.",
 

--- a/Anamnesis/Languages/ko.json
+++ b/Anamnesis/Languages/ko.json
@@ -1,4 +1,6 @@
 {
+	"Language": "한국어",
+
 	"Common_OpenFile": "불러오기",
 	"Common_SaveFile": "저장",
 	"Common_OpenDir": "열기",
@@ -10,7 +12,7 @@
 	"Common_LinkVector": "X, Y, Z축을 연동",
 	"Common_Confirm": "확인",
 
-	"ProcessSelector_AllWarning": "DirectX 11 Final Fantasy XIV가 아닌 다른 프로세스를 선택하면 해당 프로세스와 Anmnesis가 충돌하게 됩니다.",
+	"ProcessSelector_AllWarning": "DirectX 11 Final Fantasy XIV가 아닌 다른 프로세스를 선택하면 해당 프로세스와 Anamnesis가 충돌하게 됩니다.",
 	"ProcessSelector_NotFound": "Final Fantasy XIV 프로세스 (ffxiv_dx11) 찾을 수 없습니다.",
 	"ProcessSelector_NotFound2": "게임이 DirectX 11 모드로 실행 중인지 확인하세요.",
 


### PR DESCRIPTION
There was a typo in English instance of ProcessSelector_AllWarning which seems to have affected some translations.

Also added missing language labels to stop language picker dropdown from showing language codes

-Edit-
Also fixed typo in EquipmentSelector_FavoriteToggleTip