### PR TITLE
Fix save button hardcoded width

### DIFF
--- a/Anamnesis/Character/Pages/AppearancePage.xaml
+++ b/Anamnesis/Character/Pages/AppearancePage.xaml
@@ -281,14 +281,12 @@
 
 				</Menu>
 
-				<Menu Style="{StaticResource AnaMenu}" Margin="0,3, 3, 4" HorizontalAlignment="Right">
-					<MenuItem Header="Common_SaveFile"
-							  Icon="Save"
-							  Width="238"
-							  Style="{StaticResource ButtonMenuItem}"
-							  Click="OnSaveClicked" />
-				</Menu>
-			</StackPanel>
+                <MenuItem Header="Common_SaveFile"
+                          Icon="Save"
+                          Margin="2, 3, 3, 4"
+                          Style="{StaticResource ButtonMenuItem}"
+                          Click="OnSaveClicked" />
+            </StackPanel>
 
 			
 


### PR DESCRIPTION
Save button had fixed width to align with set of buttons above in English. This approach breaks the button for other locales since this set of buttons can change in width depending on length of translations which would cause buttons to misalign. 

This change allows for MenuItem to fill entire width, margins were moved to button and adjusted to ensure it'll fit with surrounding buttons.

English before change
![enPRE](https://user-images.githubusercontent.com/36460595/148310761-2ed6e63a-9a48-44fc-8e70-f11516760e9b.png)

German before change
![dePRE](https://user-images.githubusercontent.com/36460595/148310769-42c89791-1e7c-4fde-a2b8-873929f0c504.png)

German after change
![dePOST](https://user-images.githubusercontent.com/36460595/148310771-50f13c8b-3c26-4f18-903a-b6222d2842fa.png)

