### PR TITLE
Eorzea Time Corrections

### DIFF
--- a/Anamnesis/Services/TimeService.cs
+++ b/Anamnesis/Services/TimeService.cs
@@ -67,7 +67,7 @@ namespace Anamnesis
 						long timeVal = this.timeMemory!.CurrentTime % 2764800;
 						long secondInDay = timeVal % 86400;
 						this.TimeOfDay = (long)(secondInDay / 60f);
-						this.DayOfMonth = (byte)(timeVal / 86400f);
+						this.DayOfMonth = (byte)(Math.Floor(timeVal / 86400f) + 1);
 					}
 
 					var displayTime = TimeSpan.FromMinutes(this.TimeOfDay);

--- a/Anamnesis/Views/SceneView.xaml
+++ b/Anamnesis/Views/SceneView.xaml
@@ -208,8 +208,8 @@
 											   IsEnabled="{Binding TimeService.Freeze}"
 											   Buttons="True"
 											   Slider="Absolute"
-											   Minimum="0"
-											   Maximum="31" />
+											   Minimum="1"
+											   Maximum="32" />
 					</Grid>
 
 					<XivToolsWpf:TextBlock Grid.Row="1"


### PR DESCRIPTION
Since 6.05 the engine is way more sensitive to time values being exactly valid, and rendering goes crazy when it isn't.

I believe this should now account correctly for the fact Eorzea Time is 4 weeks of 8 days totalling 32 days (0-31 in engine).