### PR TITLE
Ensure app opens fully inside Virtual Screen space

### DIFF
--- a/Anamnesis/App.xaml.cs
+++ b/Anamnesis/App.xaml.cs
@@ -120,6 +120,16 @@ namespace Anamnesis
 				Window oldwindow = this.MainWindow;
 				this.MainWindow = new Anamnesis.GUI.MainWindow();
 				this.MainWindow.Show();
+
+				if (this.MainWindow.Left < SystemParameters.VirtualScreenLeft)
+					this.MainWindow.Left = SystemParameters.VirtualScreenLeft;
+				if (this.MainWindow.Top < SystemParameters.VirtualScreenTop)
+					this.MainWindow.Top = SystemParameters.VirtualScreenTop;
+				if (this.MainWindow.Left + this.MainWindow.Width > SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth)
+					this.MainWindow.Left = SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth - this.MainWindow.Width;
+				if (this.MainWindow.Top + this.MainWindow.Height > SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight)
+					this.MainWindow.Top = SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight - this.MainWindow.Height;
+
 				oldwindow.Close();
 			}
 			catch (Exception ex)


### PR DESCRIPTION
This change ensures that main window (after splash screen) will never load fully or partially outside of Virtual Screen (bounding rectangle of all display monitors). If it does it will be moved to the edge of the Virtual Screen.

This will address the possibility of window opening out of bounds and applies to majority of multi-monitor setups but:

- It will not bring window into view if user has a monitor/TV that remains active when turned off (basically asleep), this means GPU will think display is active and report as such to OS and so OS will account for that and include that display as a part of Virtual Screen even if technically it's not accessible by user visually. 

- This will not bring back the window into view reliably if user has an unusual monitor setup in Windows where maybe secondary display is in a top right corner of primary display accessed by 10 pixels in the very corner. In this example it means Virtual Screen will have combined height and width of both displays and so placing window for example below secondary display and on the right of primary display is valid as it's within rectangle created by the displays even though it's technically not a usable screen space. 