### PR TITLE
Prevent user from closing MiniWindow

### DIFF
--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -284,8 +284,6 @@ namespace Anamnesis.GUI
 
 		private async void Window_Closing(object sender, CancelEventArgs e)
 		{
-			this.mini?.Close();
-
 			if (PoseService.Exists && PoseService.Instance.IsEnabled)
 			{
 				bool? result = await GenericDialog.Show(LocalizationService.GetString("Pose_WarningQuit"), LocalizationService.GetString("Common_Confirm"), MessageBoxButton.OKCancel);
@@ -302,6 +300,8 @@ namespace Anamnesis.GUI
 
 			SettingsService.Current.WindowPosition = new Point(this.Left, this.Top);
 			SettingsService.Save();
+
+			Application.Current.Shutdown();
 		}
 
 		private void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)

--- a/Anamnesis/Windows/MiniWindow.xaml.cs
+++ b/Anamnesis/Windows/MiniWindow.xaml.cs
@@ -129,7 +129,14 @@ namespace Anamnesis.Windows
 
 		private void OnClosing(object sender, CancelEventArgs e)
 		{
-			this.main.Deactivated -= this.Main_Deactivated;
+			if (!SettingsService.Current.OverlayWindow)
+			{
+				this.main.Deactivated -= this.Main_Deactivated;
+			}
+			else
+			{
+				e.Cancel = true;
+			}
 		}
 
 		private async Task Ping()


### PR DESCRIPTION
Those changes should prevent users from closing MiniWindow which in turn could cause Anamnesis to run in background without any possibility of closing other than killing the process if MiniWindow was closed when MainWindow was hidden.

Since we are dealing with app shutdown I did some tests but I am not entirely sure if I checked everything

1. Close Anamnesis from MainWindow with mini mode turned off - works, turns off app
2. Close Anamnesis from MainWindow with mini mode turned on - works, turns off app and MiniWindow
3. Close MiniWindow from taskbar when MainWindow is visible (should fail) - works, app does not turn off
4. Close MiniWindow from taskbar when MainWindow is not visible (should fail) - works, app does not turn off
5. Toggle mini mode on and off since it calls close on MiniWindow - works, MiniWindow shows and closes as expected.


this.main.Deactivated -= this.Main_Deactivated; will not happen when user closes Main Window like it used to before but this shouldn't matter as we are shutting down everything anyway.

Also compared to previous approach this will not close MiniWindow when condition (result != true) during Pose check returns true which I believe (I have not checked it) would cause MiniWindow to close even tho MainWindow would not close.

Application.Current.Shutdown(); ignores the fact that MiniWindow cancels it's Closing event so it will shut down entire app as expected.