### PR TITLE
Multiple MiniWindow behaviour fixes

### DIFF
--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -46,6 +46,8 @@ namespace Anamnesis.GUI
 			GameService.Instance.PropertyChanged += this.OnGameServicePropertyChanged;
 		}
 
+		public bool IsClosing { get; private set; } = false;
+
 		public GameService GameService => GameService.Instance;
 		public SettingsService SettingsService => SettingsService.Instance;
 		public GposeService GposeService => GposeService.Instance;
@@ -284,8 +286,6 @@ namespace Anamnesis.GUI
 
 		private async void Window_Closing(object sender, CancelEventArgs e)
 		{
-			this.mini?.Close();
-
 			if (PoseService.Exists && PoseService.Instance.IsEnabled)
 			{
 				bool? result = await GenericDialog.Show(LocalizationService.GetString("Pose_WarningQuit"), LocalizationService.GetString("Common_Confirm"), MessageBoxButton.OKCancel);
@@ -296,6 +296,9 @@ namespace Anamnesis.GUI
 					return;
 				}
 			}
+
+			this.IsClosing = true;
+			this.mini?.Close();
 
 			SettingsService.SettingsChanged -= this.OnSettingsChanged;
 			ViewService.ShowingDrawer -= this.OnShowDrawer;

--- a/Anamnesis/Windows/MiniWindow.xaml.cs
+++ b/Anamnesis/Windows/MiniWindow.xaml.cs
@@ -8,6 +8,7 @@ namespace Anamnesis.Windows
 	using System.Windows;
 	using System.Windows.Input;
 	using System.Windows.Media.Animation;
+	using Anamnesis.GUI;
 	using Anamnesis.Services;
 	using Anamnesis.Utils;
 	using Serilog;
@@ -18,13 +19,13 @@ namespace Anamnesis.Windows
 	/// </summary>
 	public partial class MiniWindow : Window
 	{
-		private readonly Window main;
+		private readonly MainWindow main;
 		private bool isHidden = false;
 		private Point downPos;
 		private bool mouseDown = false;
 		private bool isDeactivating = false;
 
-		public MiniWindow(Window main)
+		public MiniWindow(MainWindow main)
 		{
 			this.main = main;
 			this.InitializeComponent();
@@ -95,6 +96,10 @@ namespace Anamnesis.Windows
 			this.OnLocationChanged(null, null);
 			((Storyboard)this.Resources["AnimateOpenStoryboard"]).Begin(this);
 			this.main.Show();
+
+			if (this.main.WindowState == WindowState.Minimized)
+				this.main.WindowState = WindowState.Normal;
+
 			this.isHidden = false;
 		}
 
@@ -129,7 +134,14 @@ namespace Anamnesis.Windows
 
 		private void OnClosing(object sender, CancelEventArgs e)
 		{
-			this.main.Deactivated -= this.Main_Deactivated;
+			if (!this.main.IsClosing && SettingsService.Current.OverlayWindow)
+			{
+				e.Cancel = true;
+			}
+			else
+			{
+				this.main.Deactivated -= this.Main_Deactivated;
+			}
 		}
 
 		private async Task Ping()


### PR DESCRIPTION
This should fix 2 issues

1. It should make it impossible to close MiniWindow through normal means to avoid user having Anamnesis run in background with no means to close it other than killing the process.

2. It should ensure MainWindow is restored when user presses MiniWindow. User can minimize MainWindow which means that pressing MiniWindow would bring it up minimized. This will ensure it's restored properly.