### PR TITLE
Implement file extension toggle

### DIFF
--- a/Anamnesis/Files/FileBase.cs
+++ b/Anamnesis/Files/FileBase.cs
@@ -17,6 +17,7 @@ namespace Anamnesis.Files
 		[JsonIgnore] public abstract string FileExtension { get; }
 		[JsonIgnore] public virtual string? FileRegex => null;
 		[JsonIgnore] public virtual Func<FileSystemInfo, string> GetFilename => (f) => Path.GetFileNameWithoutExtension(f.FullName);
+		[JsonIgnore] public virtual Func<FileSystemInfo, string> GetFullFilename => (f) => Path.GetFileName(f.FullName);
 
 		public abstract void Serialize(Stream stream);
 		public abstract FileBase Deserialize(Stream stream);
@@ -25,6 +26,7 @@ namespace Anamnesis.Files
 		{
 			FileFilter filter = new FileFilter(this.FileExtension, this.FileRegex);
 			filter.GetNameCallback = this.GetFilename;
+			filter.GetFullNameCallback = this.GetFullFilename;
 
 			return filter;
 		}

--- a/Anamnesis/Files/FileBrowserView.xaml
+++ b/Anamnesis/Files/FileBrowserView.xaml
@@ -68,6 +68,7 @@
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 
 			<Button Grid.Column="0"
@@ -91,7 +92,18 @@
 					   VerticalAlignment="Center"
 					   Text="{Binding CurrentPath}" />
 
-			<Button Grid.Column="2"
+			<ToggleButton Grid.Column="2"
+						  Margin="3"
+						  Width="32"
+						  IsChecked="{Binding ShowExtensions}"
+						  Style="{StaticResource OutlineToggleButton}"
+						  Visibility="{Binding SettingsService.Settings.ShowFileExtensions, Converter={StaticResource !B2V}}"
+						  Click="OnShowExtensionClicked">
+				<XivToolsWpf:TextBlock
+					Key="FileBrowser_ExtensionShort"/>
+			</ToggleButton>
+
+			<Button Grid.Column="3"
 					Margin="3"
 					Width="32"
 					Click="OnCreateFolderClicked"
@@ -107,7 +119,7 @@
 
 			<ToggleButton Width="32"
 						  Height="32"
-						  Grid.Column="3"
+						  Grid.Column="4"
 						  IsChecked="{Binding IsFlattened}"
 						  Style="{DynamicResource TransparentIconToggleButton}"
 						  VerticalAlignment="Bottom">
@@ -120,7 +132,7 @@
 									   Icon="Sitemap" />
 			</ToggleButton>
 
-			<ComboBox Grid.Column="4"
+			<ComboBox Grid.Column="5"
 					  Margin="6, 3, 6, 0"
 					  Height="22"
 					  Style="{StaticResource MaterialDesignDataGridComboBox}"

--- a/Anamnesis/Files/FileBrowserView.xaml.cs
+++ b/Anamnesis/Files/FileBrowserView.xaml.cs
@@ -151,6 +151,7 @@ namespace Anamnesis.GUI.Views
 			}
 		}
 
+		public SettingsService SettingsService => SettingsService.Instance;
 		public ObservableCollection<Shortcut> Shortcuts { get; } = new ObservableCollection<Shortcut>();
 
 		public bool UseFileBrowser { get; set; }
@@ -185,6 +186,8 @@ namespace Anamnesis.GUI.Views
 				Task.Run(this.UpdateEntries);
 			}
 		}
+
+		public bool ShowExtensions { get; set; } = false;
 
 		[AlsoNotifyFor(nameof(CanSelect))]
 		public string? FileName { get; set; }
@@ -502,6 +505,11 @@ namespace Anamnesis.GUI.Views
 			this.Selected.IsRenaming = true;
 		}
 
+		private void OnShowExtensionClicked(object sender, RoutedEventArgs e)
+		{
+			Task.Run(this.UpdateEntries);
+		}
+
 		private void CloseDrawer()
 		{
 			this.IsOpen = false;
@@ -543,10 +551,16 @@ namespace Anamnesis.GUI.Views
 					if (this.Entry is DirectoryInfo)
 						return this.Entry.Name;
 
-					if (this.Filter != null && this.Filter.GetNameCallback != null)
+					if (this.Filter != null && this.Filter.GetNameCallback != null && this.Filter.GetFullNameCallback != null)
 					{
+						if (SettingsService.Current.ShowFileExtensions || this.View.ShowExtensions)
+							return this.Filter.GetFullNameCallback(this.Entry);
+
 						return this.Filter.GetNameCallback(this.Entry);
 					}
+
+					if (SettingsService.Current.ShowFileExtensions || this.View.ShowExtensions)
+						return Path.GetFileName(this.Entry.Name);
 
 					return Path.GetFileNameWithoutExtension(this.Entry.Name);
 				}

--- a/Anamnesis/Files/FileFilter.xaml.cs
+++ b/Anamnesis/Files/FileFilter.xaml.cs
@@ -11,6 +11,7 @@ namespace Anamnesis.Files
 		public readonly string Extension;
 		public readonly string? Regex;
 		public Func<FileSystemInfo, string>? GetNameCallback;
+		public Func<FileSystemInfo, string>? GetFullNameCallback;
 
 		public FileFilter(string extension, string? regex)
 		{

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -27,6 +27,7 @@
 	"FileBrowser_Browse": "Browse for a file",
 	"FileBrowser_ReplaceTitle": "Overwrite file",
 	"FileBrowser_ReplaceMessage": "Are you sure you want to overwrite the file: \"{0}\"?",
+	"FileBrowser_ExtensionShort": "Ext",
 
 	"FileBrowser_Sort": "Sorting mode",
 	"FileBrowser_SortAlpha": "By Name (A to Z)",
@@ -494,6 +495,7 @@
 	"Settings_WindowOpacity": "Window opacity",
 	"Settings_StayTransparent": "Stay transparent",
 	"Settings_WindowSize": "Window size",
+	"Settings_ShowFileExtensions": "Show File Extensions",
 	"Settings_UseWindowsExplorer": "Use Windows file browser",
 	"Settings_Directories": "Directories",
 	"Settings_Dir_Characters": "Characters",

--- a/Anamnesis/Services/Settings.cs
+++ b/Anamnesis/Services/Settings.cs
@@ -20,6 +20,7 @@ namespace Anamnesis.Services
 		public bool OverlayWindow { get; set; } = false;
 		public double Opacity { get; set; } = 1.0;
 		public double Scale { get; set; } = 1.0;
+		public bool ShowFileExtensions { get; set; } = false;
 		public bool UseWindowsExplorer { get; set; } = false;
 		public Point WindowPosition { get; set; }
 		public Point OverlayWindowPosition { get; set; }

--- a/Anamnesis/Views/SettingsView.xaml
+++ b/Anamnesis/Views/SettingsView.xaml
@@ -33,6 +33,7 @@
 				<RowDefinition Height="Auto"/>
 				<RowDefinition Height="Auto"/>
 				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
 				<RowDefinition />
 				<RowDefinition Height="Auto"/>
 			</Grid.RowDefinitions>
@@ -63,16 +64,19 @@
 			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="5" Key="Settings_WindowSize" Style="{StaticResource Label}"/>
 			<ComboBox x:Name="SizeSelector" SelectedValue="{Binding SettingsService.Settings.Scale}" Grid.Column="1" Grid.Row="5" Margin="6"/>
 
-			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="6" Key="Settings_UseWindowsExplorer" Style="{StaticResource Label}"/>
-			<CheckBox IsChecked="{Binding SettingsService.Settings.UseWindowsExplorer}" Grid.Column="1" Grid.Row="6" Margin="6"/>
-		
-			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="7" Key="Settings_Hyperlegible" Style="{StaticResource Label}"/>
-			<CheckBox IsChecked="{Binding SettingsService.Settings.UseHyperlegibleFont}" Grid.Column="1" Grid.Row="7" Margin="6"/>
-		
-			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="8" Key="Settings_WrapRotations" Style="{StaticResource Label}"/>
-			<CheckBox IsChecked="{Binding SettingsService.Settings.WrapRotationSliders}" Grid.Column="1" Grid.Row="8" Margin="6"/>
+			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="6" Key="Settings_ShowFileExtensions" Style="{StaticResource Label}"/>
+			<CheckBox IsChecked="{Binding SettingsService.Settings.ShowFileExtensions}" Grid.Column="1" Grid.Row="6" Margin="6"/>
 
-			<Grid Grid.Row="9" Grid.ColumnSpan="2" Margin="0, 0, 4, 0">
+			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="7" Key="Settings_UseWindowsExplorer" Style="{StaticResource Label}"/>
+			<CheckBox IsChecked="{Binding SettingsService.Settings.UseWindowsExplorer}" Grid.Column="1" Grid.Row="7" Margin="6"/>
+		
+			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="8" Key="Settings_Hyperlegible" Style="{StaticResource Label}"/>
+			<CheckBox IsChecked="{Binding SettingsService.Settings.UseHyperlegibleFont}" Grid.Column="1" Grid.Row="8" Margin="6"/>
+		
+			<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="9" Key="Settings_WrapRotations" Style="{StaticResource Label}"/>
+			<CheckBox IsChecked="{Binding SettingsService.Settings.WrapRotationSliders}" Grid.Column="1" Grid.Row="9" Margin="6"/>
+
+			<Grid Grid.Row="10" Grid.ColumnSpan="2" Margin="0, 0, 4, 0">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto"/>
 					<ColumnDefinition/>
@@ -95,7 +99,7 @@
 				<Button Grid.Row="1" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowseGallery"/>
 			</Grid>
 
-			<GroupBox Grid.Row="10" Grid.ColumnSpan="2">
+			<GroupBox Grid.Row="11" Grid.ColumnSpan="2">
 				<GroupBox.Header>
 					<XivToolsWPF:TextBlock Key="Settings_Directories"/>
 				</GroupBox.Header>
@@ -129,7 +133,7 @@
 				</Grid>
 			</GroupBox>
 
-			<GroupBox Grid.Row="11" Grid.ColumnSpan="2">
+			<GroupBox Grid.Row="12" Grid.ColumnSpan="2">
 				<GroupBox.Header>
 					<XivToolsWPF:TextBlock Key="Settings_Theme"/>
 				</GroupBox.Header>


### PR DESCRIPTION
Implements a toggle that enables file extensions in built in file browser.

Toggle in Settings is persistent while toggle in file browser only affects current File Browser. Toggle in file browser gets removed once user enables extensions in Settings.

https://user-images.githubusercontent.com/36460595/149146944-fedc1f6b-701a-49da-ac9f-ca00bb979d1a.mp4


