### PR TITLE
Actor and Camera World Position Freezing

### DIFF
--- a/Anamnesis/Character/Views/AnimationEditor.xaml
+++ b/Anamnesis/Character/Views/AnimationEditor.xaml
@@ -14,14 +14,25 @@
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto"/>
 			<ColumnDefinition Width="Auto"/>
+			<ColumnDefinition Width="Auto"/>
 			<ColumnDefinition/>
-			<ColumnDefinition/>
+			<ColumnDefinition Width="15"/>
 			<ColumnDefinition Width="Auto"/>
 			<ColumnDefinition Width="Auto"/>
 			<ColumnDefinition Width="Auto"/>
 		</Grid.ColumnDefinitions>
 
-		<Button Grid.Column="0" Click="OnDrawWeaponClicked" Style="{StaticResource TransparentIconButton}">
+		<ToggleButton Grid.Column="0" Style="{StaticResource TransparentIconToggleButton}"
+						  IsChecked="{Binding WorldService.FreezeWorldPosition}"
+						  Height="28"
+						  Width="28">
+			<ToggleButton.ToolTip>
+				<XivToolsWpf:TextBlock Key="Animation_FreezePosition"/>
+			</ToggleButton.ToolTip>
+			<XivToolsWpf:IconBlock Icon="LocationArrow"/>
+		</ToggleButton>
+
+		<Button Grid.Column="1" Click="OnDrawWeaponClicked" Style="{StaticResource TransparentIconButton}">
 			<Button.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_DrawWeapon"/>
 			</Button.ToolTip>
@@ -29,7 +40,7 @@
 			<XivToolsWpf:IconBlock Icon="HandSparkles"/>
 		</Button>
 
-		<Button Grid.Column="1" Click="OnSearchClicked" Style="{StaticResource TransparentIconButton}">
+		<Button Grid.Column="2" Click="OnSearchClicked" Style="{StaticResource TransparentIconButton}">
 			<Button.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_Search"/>
 			</Button.ToolTip>
@@ -37,19 +48,19 @@
 			<XivToolsWpf:IconBlock Icon="Search"/>
 		</Button>
 
-		<XivToolsWpf:NumberBox Value="{Binding AnimationId}" Grid.Column="2" Margin="0, 0, 0, -7">
+		<XivToolsWpf:NumberBox Value="{Binding AnimationId}" Grid.Column="3" Margin="0, 0, 0, -7">
 			<XivToolsWpf:NumberBox.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_AnimationId"/>
 			</XivToolsWpf:NumberBox.ToolTip>
 		</XivToolsWpf:NumberBox>
 
-		<XivToolsWpf:NumberBox Value="{Binding AnimationSpeed}" Grid.Column="3" Margin="5, 0, 0, -7">
+		<XivToolsWpf:NumberBox Value="{Binding AnimationSpeed}" Grid.Column="4" Margin="2, 0, 0, -7">
 			<XivToolsWpf:NumberBox.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_Speed"/>
 			</XivToolsWpf:NumberBox.ToolTip>
 		</XivToolsWpf:NumberBox>
 
-		<Button Grid.Column="4" Click="OnQueueClicked" Style="{StaticResource TransparentIconButton}">
+		<Button Grid.Column="5" Click="OnQueueClicked" Style="{StaticResource TransparentIconButton}">
 			<Button.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_Queue"/>
 			</Button.ToolTip>
@@ -57,7 +68,7 @@
 			<XivToolsWpf:IconBlock Icon="Plus"/>
 		</Button>
 
-		<Button Grid.Column="5" Click="OnPlayClicked" Style="{StaticResource TransparentIconButton}">
+		<Button Grid.Column="6" Click="OnPlayClicked" Style="{StaticResource TransparentIconButton}">
 			<Button.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_Play"/>
 			</Button.ToolTip>
@@ -65,7 +76,7 @@
 			<XivToolsWpf:IconBlock Icon="Play"/>
 		</Button>
 
-		<Button Grid.Column="6" Click="OnResetClicked" Style="{StaticResource TransparentIconButton}">
+		<Button Grid.Column="7" Click="OnResetClicked" Style="{StaticResource TransparentIconButton}">
 			<Button.ToolTip>
 				<XivToolsWpf:TextBlock Key="Animation_Reset"/>
 			</Button.ToolTip>

--- a/Anamnesis/Character/Views/AnimationEditor.xaml.cs
+++ b/Anamnesis/Character/Views/AnimationEditor.xaml.cs
@@ -25,6 +25,8 @@ namespace Anamnesis.Character.Views
 			this.ContentArea.DataContext = this;
 		}
 
+		public WorldService WorldService => WorldService.Instance;
+
 		public ActorMemory? Actor { get; private set; }
 		public AnimationService AnimationService => AnimationService.Instance;
 		public ushort AnimationId { get; set; } = 8047;

--- a/Anamnesis/Core/Memory/AddressService.cs
+++ b/Anamnesis/Core/Memory/AddressService.cs
@@ -29,6 +29,9 @@ namespace Anamnesis.Core.Memory
 		public static IntPtr SkeletonFreezePhysics { get; private set; }    // PhysicsOffset
 		public static IntPtr SkeletonFreezePhysics2 { get; private set; }   // PhysicsOffset2
 		public static IntPtr SkeletonFreezePhysics3 { get; private set; }   // PhysicsOffset3
+		public static IntPtr WorldPositionFreeze { get; set; }
+		public static IntPtr WorldRotationFreeze { get; set; }
+		public static IntPtr GPoseCameraTargetPositionFreeze { get; set; }
 		public static IntPtr GposeCheck { get; private set; }   // GPoseCheckOffset
 		public static IntPtr GposeCheck2 { get; private set; }   // GPoseCheck2Offset
 		public static IntPtr Territory { get; private set; }
@@ -123,6 +126,9 @@ namespace Anamnesis.Core.Memory
 			tasks.Add(GetAddressFromTextSignature("SkeletonFreezePosition", "41 0F 29 24 12", (p) => { SkeletonFreezePosition = p; }));   // SkeletonAddress5
 			tasks.Add(GetAddressFromTextSignature("SkeletonFreezeScale2", "43 0F 29 44 18 20", (p) => { SkeletonFreezeScale2 = p; }));  // SkeletonAddress6
 			tasks.Add(GetAddressFromTextSignature("SkeletonFreezePosition2", "43 0f 29 24 18", (p) => { SkeletonFreezePosition2 = p; }));  // SkeletonAddress7
+			tasks.Add(GetAddressFromTextSignature("WorldPositionFreeze", "F3 0F 11 78 ?? F3 0F 11 70 ?? F3 44 0F 11 40 ?? 48 83 48 ?? 02", (p) => { WorldPositionFreeze = p; }));
+			tasks.Add(GetAddressFromTextSignature("WorldRotationFreeze", "0F 11 40 ?? 48 8B 8B ?? ?? ?? ?? 0F B6 81 ?? ?? ?? ?? 24 0F 3C 03 75 ?? 48 8B 01 B2 01 FF 50 ?? 48 8B 83 ?? ?? ?? ??", (p) => { WorldRotationFreeze = p; }));
+			tasks.Add(GetAddressFromTextSignature("GPoseCameraTargetPositionFreeze", "F3 0F 11 89 ?? ?? ?? ?? 48 8B D9 F3 0F 11 91 ?? ?? ?? ??", (p) => { GPoseCameraTargetPositionFreeze = p; }));
 			tasks.Add(GetAddressFromTextSignature("AnimationSpeedPatch", "F3 0F 11 94 ?? ?? ?? ?? ?? 80 89 ?? ?? ?? ?? 01", (p) => { AnimationSpeedPatch = p; }));
 			tasks.Add(GetAddressFromSignature("Territory", "8B 1D ?? ?? ?? ?? 0F 45 D8 39 1D", 2, (p) => { Territory = p; }));
 			tasks.Add(GetAddressFromSignature("Weather", "49 8B 9D ?? ?? ?? ?? 48 8D 0D", 0, (p) => { Weather = p + 0x8; }));

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -485,6 +485,7 @@
 	"Animation_Speed": "Speed",
 	"Animation_AnimationId": "Animation Id",
 	"Animation_Reset": "Reset Animation",
+	"Animation_FreezePosition": "Freeze Actor/Camera World Position",
 
 	"Settings_Header": "Settings",
 	"Settings_Language": "Language",

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -23,12 +23,6 @@ namespace Anamnesis.Memory
 			Unload = 2,
 		}
 
-		public enum AnimationModes : int
-		{
-			Normal = 0x3F,
-			SlowMotion = 0x3E,
-		}
-
 		[Bind(0x008D)] public byte SubKind { get; set; }
 		[Bind(0x00F0, BindFlags.Pointer)] public ActorModelMemory? ModelObject { get; set; }
 		[Bind(0x0104)] public RenderModes RenderMode { get; set; }

--- a/Anamnesis/Posing/Pages/PosePage.xaml
+++ b/Anamnesis/Posing/Pages/PosePage.xaml
@@ -136,19 +136,8 @@
 							Grid.ColumnSpan="2"
 							Visibility="{Binding Skeleton.CurrentBone, Converter={StaticResource NullToVisibilityConverter}}">
 
-							<!--  Actor transforms in gpose  -->
-							<Grid Visibility="{Binding GposeService.IsGpose, Converter={StaticResource B2V}}">
-								<controls:TransformEditor IsEnabled="{Binding TargetService.SelectedActor.IsAnimating, Converter={StaticResource NotConverter}}" Value="{Binding TargetService.SelectedActor.ModelObject.Transform}" />
-
-								<XivToolsWpf:InfoControl
-									Key="Pose_WarningNotFrozen"
-									Margin="0,2"
-									Visibility="{Binding TargetService.SelectedActor.IsAnimating, Converter={StaticResource B2V}}"/>
-
-							</Grid>
-
-							<!--  Actor transform outside of gpose  -->
-							<Grid Visibility="{Binding GposeService.IsGpose, Converter={StaticResource !B2V}}">
+							<!--  Actor transform -->
+							<Grid>
 								<controls:TransformEditor Value="{Binding TargetService.SelectedActor.ModelObject.Transform}"/>
 							</Grid>
 

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -70,6 +70,7 @@ namespace Anamnesis.Services
 			await Add<AnimationService>();
 			await Add<AnamnesisConnectService>();
 			await Add<ActorRefreshService>();
+			await Add<WorldService>();
 
 			IsInitialized = true;
 

--- a/Anamnesis/Services/WorldService.cs
+++ b/Anamnesis/Services/WorldService.cs
@@ -1,0 +1,68 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Services
+{
+	using System.Threading.Tasks;
+	using Anamnesis.Core.Memory;
+	using Anamnesis.Memory;
+	using PropertyChanged;
+
+	[AddINotifyPropertyChangedInterface]
+	public class WorldService : ServiceBase<WorldService>
+	{
+		private NopHookViewModel? freezeWorldPosition;
+		private NopHookViewModel? freezeWorldRotation;
+		private NopHookViewModel? freezeGposeTargetPosition1;
+		private NopHookViewModel? freezeGposeTargetPosition2;
+
+		public bool FreezeWorldPosition
+		{
+			get
+			{
+				return this.freezeWorldPosition?.Enabled ?? false;
+			}
+			set
+			{
+				this.freezeWorldPosition?.SetEnabled(value);
+				this.freezeWorldRotation?.SetEnabled(value);
+				this.freezeGposeTargetPosition1?.SetEnabled(value);
+				this.freezeGposeTargetPosition2?.SetEnabled(value);
+				this.RaisePropertyChanged(nameof(WorldService.FreezeWorldPosition));
+			}
+		}
+
+		public override async Task Initialize()
+		{
+			await base.Initialize();
+
+			this.freezeWorldPosition = new NopHookViewModel(AddressService.WorldPositionFreeze, 16);
+			this.freezeWorldRotation = new NopHookViewModel(AddressService.WorldRotationFreeze, 4);
+
+			// We need to keep the MOV in the middle here otherwise we invalidate the ptr, but we patch the rest:
+			//     MOVSS dword ptr[RCX + 0xa0],XMM1
+			//     MOV RBX,RCX
+			//     MOVSS dword ptr[RCX + 0xa4],XMM2
+			//     MOVSS dword ptr[RCX + 0xa8],XMM3
+			this.freezeGposeTargetPosition1 = new NopHookViewModel(AddressService.GPoseCameraTargetPositionFreeze, 8);
+			this.freezeGposeTargetPosition2 = new NopHookViewModel(AddressService.GPoseCameraTargetPositionFreeze + 8 + 3, 16);
+
+			GposeService.GposeStateChanging += this.OnGposeStateChanging;
+		}
+
+		public override async Task Shutdown()
+		{
+			await base.Shutdown();
+
+			GposeService.GposeStateChanging -= this.OnGposeStateChanging;
+
+			this.FreezeWorldPosition = false;
+		}
+
+		private void OnGposeStateChanging()
+		{
+			if (GposeService.Instance.IsOverworld)
+				this.FreezeWorldPosition = false;
+		}
+	}
+}


### PR DESCRIPTION
This allows you to freeze the position and rotation of all actors in gpose as well the target position for the GPose camera.
This stops the snapping of the camera (back to the character) and character (position and rotation resetting) when motion is enabled. Also addresses the flickering issue with just resetting the value over and over.

I just disabled the check for motion for now as I couldn't work out how to get a `motion disabled or freeze enabled` working in WPF.

You must disable character positioning before camera position freezing works, so it doesn't make a lot of sense to put them behind a separate toggle, as such I just combined all 3 patches into one. 