### PR TITLE
Use different animation override offset

### DIFF
--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -37,7 +37,7 @@ namespace Anamnesis.Memory
 		[Bind(0x0DD8)] public ActorCustomizeMemory? Customize { get; set; }
 		[Bind(0x0F30)] public uint TargetAnimation { get; set; }
 		[Bind(0x0FA4)] public float AnimationSpeed { get; set; }
-		[Bind(0x1102)] public ushort AnimationOverride { get; set; }
+		[Bind(0x110C)] public ushort AnimationOverride { get; set; }
 		[Bind(0x18B8)] public float Transparency { get; set; }
 		[Bind(0x19C0)] public byte AnimationMode { get; set; }
 

--- a/Anamnesis/Services/AnimationService.cs
+++ b/Anamnesis/Services/AnimationService.cs
@@ -13,9 +13,9 @@ namespace Anamnesis.Services
 	[AddINotifyPropertyChangedInterface]
 	public class AnimationService : ServiceBase<AnimationService>
 	{
-		private const ushort ResetAnimationId = 0;
+		private const ushort ResetAnimationId = 3;
 		private const ushort DrawWeaponAnimationid = 190;
-		private const byte AnimationOverrideMode = 0x8;
+		private const byte AnimationOverrideMode = 16;
 
 		private NopHookViewModel? animationSpeedHook;
 


### PR DESCRIPTION
There are a bunch of animation related offsets around here. With the old one I found an edge case where certain looping emotes like the reaper AoEs were not overridden.

This one seems to override them all, but as usual we'll have to see if any edge cases pop up.