### PR TITLE
Initial implementation of ActorService and ActorRef

### DIFF
--- a/Anamnesis/Memory/ActorBasicMemory.cs
+++ b/Anamnesis/Memory/ActorBasicMemory.cs
@@ -96,7 +96,7 @@ namespace Anamnesis.Memory
 
 			this.owner = null;
 
-			List<ActorBasicMemory>? actors = TargetService.GetAllActors();
+			List<ActorBasicMemory>? actors = ActorService.Instance.GetAllActors();
 
 			foreach(ActorBasicMemory actor in actors)
 			{

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -170,7 +170,7 @@ namespace Anamnesis.Memory
 
 		public bool CanHasNpcFace()
 		{
-			int index = TargetService.GetActorTableIndex(this.Address);
+			int index = ActorService.Instance.GetActorTableIndex(this.Address);
 
 			// only the local player should get npc faces!
 			if (index != 0)

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -55,6 +55,7 @@ namespace Anamnesis.Services
 			await Add<ViewService>();
 			await Add<MemoryService>();
 			await Add<AddressService>();
+			await Add<ActorService>();
 			await Add<TargetService>();
 			await Add<FileService>();
 			await Add<TerritoryService>();

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -1,0 +1,116 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Collections.ObjectModel;
+	using System.Threading.Tasks;
+	using Anamnesis.Core.Memory;
+	using Anamnesis.Memory;
+	using PropertyChanged;
+
+	[AddINotifyPropertyChangedInterface]
+	public class ActorService : ServiceBase<ActorService>
+	{
+		private const int TickDelay = 10;
+		private const int ActorTableSize = 424;
+
+		private readonly IntPtr[] actorTable = new IntPtr[ActorTableSize];
+
+		public ReadOnlyCollection<IntPtr> ActorTable => Array.AsReadOnly(this.actorTable);
+
+		public int GetActorTableIndex(IntPtr pointer, bool refresh = false)
+		{
+			if (pointer == IntPtr.Zero)
+				return -1;
+
+			if (refresh)
+				this.UpdateActorTable();
+
+			return Array.IndexOf(this.actorTable, pointer);
+		}
+
+		public bool IsActorInTable(IntPtr ptr, bool refresh = false)
+		{
+			return this.GetActorTableIndex(ptr, refresh) != -1;
+		}
+
+		public bool IsActorInTable(MemoryBase memory, bool refresh = false) => this.IsActorInTable(memory.Address, refresh);
+
+		public List<ActorBasicMemory> GetAllActors(bool refresh = false)
+		{
+			if (refresh)
+				this.UpdateActorTable();
+
+			List<ActorBasicMemory> results = new();
+
+			foreach(var ptr in this.ActorTable)
+			{
+				if (ptr == IntPtr.Zero)
+					continue;
+
+				try
+				{
+					ActorBasicMemory actor = new();
+					actor.SetAddress(ptr);
+					results.Add(actor);
+				}
+				catch (Exception ex)
+				{
+					Log.Warning(ex, $"Failed to create Actor Basic View Model for address: {ptr}");
+				}
+			}
+
+			return results;
+		}
+
+		public void ForceRefresh()
+		{
+			this.UpdateActorTable();
+		}
+
+		public override async Task Initialize()
+		{
+			await base.Initialize();
+		}
+
+		public override Task Start()
+		{
+			this.UpdateActorTable();
+
+			_ = Task.Run(this.TickTask);
+			return base.Start();
+		}
+
+		public override async Task Shutdown()
+		{
+			await base.Shutdown();
+		}
+
+		private async Task TickTask()
+		{
+			while (this.IsAlive)
+			{
+				await Task.Delay(TickDelay);
+
+				this.ForceRefresh();
+			}
+		}
+
+		private void UpdateActorTable()
+		{
+			lock(this.actorTable)
+			{
+				for (int i = 0; i < ActorTableSize; i++)
+				{
+					IntPtr ptr = MemoryService.ReadPtr(AddressService.ActorTable + (i * 8));
+					this.actorTable[i] = ptr;
+				}
+			}
+
+			this.RaisePropertyChanged(nameof(this.ActorTable));
+		}
+	}
+}

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -120,66 +120,6 @@ namespace Anamnesis
 			return GetPinned(actor) != null;
 		}
 
-		public static List<ActorBasicMemory> GetAllActors()
-		{
-			List<ActorBasicMemory> results = new();
-
-			for (int i = 0; i < 424; i++)
-			{
-				IntPtr ptr = MemoryService.ReadPtr(AddressService.ActorTable + (i * 8));
-
-				if (ptr == IntPtr.Zero)
-					continue;
-
-				try
-				{
-					ActorBasicMemory actor = new();
-					actor.SetAddress(ptr);
-					results.Add(actor);
-				}
-				catch (Exception ex)
-				{
-					Log.Warning(ex, $"Failed to create Actor Basic View Model for address: {ptr}");
-				}
-			}
-
-			return results;
-		}
-
-		public static int GetActorTableIndex(IntPtr pointer)
-		{
-			for (int i = 0; i < 424; i++)
-			{
-				IntPtr ptr = MemoryService.ReadPtr(AddressService.ActorTable + (i * 8));
-
-				if (ptr == pointer)
-				{
-					return i;
-				}
-			}
-
-			return -1;
-		}
-
-		public static bool IsActorInActorTable(IntPtr pointer)
-		{
-			return GetActorTableIndex(pointer) != -1;
-		}
-
-		public static List<IntPtr> GetActorTable()
-		{
-			List<IntPtr> results = new();
-
-			for (int i = 0; i < 424; i++)
-			{
-				IntPtr ptr = MemoryService.ReadPtr(AddressService.ActorTable + (i * 8));
-				if(ptr != IntPtr.Zero)
-					results.Add(ptr);
-			}
-
-			return results;
-		}
-
 		public static void SetPlayerTarget(PinnedActor actor)
 		{
 			if (actor.IsValid)
@@ -187,7 +127,7 @@ namespace Anamnesis
 				IntPtr? ptr = actor.Pointer;
 				if (ptr != null && ptr != IntPtr.Zero)
 				{
-					if (IsActorInActorTable((IntPtr)ptr))
+					if (ActorService.Instance.IsActorInTable((IntPtr)ptr))
 					{
 						if (GposeService.Instance.IsGpose)
 						{
@@ -253,7 +193,7 @@ namespace Anamnesis
 			{
 				try
 				{
-					List<ActorBasicMemory> allActors = GetAllActors();
+					List<ActorBasicMemory> allActors = ActorService.Instance.GetAllActors();
 
 					foreach (ActorBasicMemory actor in allActors)
 					{
@@ -462,7 +402,7 @@ namespace Anamnesis
 					if (this.Memory == null || this.Memory.Address == IntPtr.Zero)
 						return;
 
-					if (!IsActorInActorTable(this.Memory.Address))
+					if (!ActorService.Instance.IsActorInTable(this.Memory.Address))
 					{
 						Log.Information($"Actor: {this} was not in actor table");
 						this.Retarget();
@@ -510,7 +450,7 @@ namespace Anamnesis
 					ActorBasicMemory? newBasic = null;
 					bool isGPose = GposeService.GetIsGPose();
 
-					List<ActorBasicMemory> allActors = TargetService.GetAllActors();
+					List<ActorBasicMemory> allActors = ActorService.Instance.GetAllActors();
 
 					// Search for an exact match first
 					foreach (ActorBasicMemory actor in allActors)

--- a/Anamnesis/Utils/ActorRef.cs
+++ b/Anamnesis/Utils/ActorRef.cs
@@ -1,0 +1,90 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Utils
+{
+	using System;
+	using System.ComponentModel;
+	using System.Diagnostics.CodeAnalysis;
+	using Anamnesis.Memory;
+	using PropertyChanged;
+
+	[AddINotifyPropertyChangedInterface]
+	public class ActorRef<T> : INotifyPropertyChanged
+		where T : ActorBasicMemory
+	{
+		private readonly T memory;
+		private readonly uint objectId;
+		private readonly IntPtr address;
+
+		private bool isValid;
+
+		public ActorRef(T memory)
+		{
+			this.memory = memory;
+			this.objectId = memory.ObjectId;
+			this.address = memory.Address;
+
+			this.UpdateIsValid();
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		public T? Memory
+		{
+			get
+			{
+				if(this.IsValid)
+					return this.memory;
+
+				return null;
+			}
+		}
+
+		public bool IsValid
+		{
+			get
+			{
+				this.UpdateIsValid();
+				return this.isValid;
+			}
+		}
+
+		public bool TryGetMemory([NotNullWhen(true)] out T? outMemory)
+		{
+			outMemory = this.Memory;
+			return outMemory != null;
+		}
+
+		public override bool Equals(object? obj)
+		{
+			if ((obj == null) || !this.GetType().Equals(obj.GetType()))
+			{
+				return false;
+			}
+			else
+			{
+				ActorRef<T> p = (ActorRef<T>)obj;
+				return this.objectId == p.objectId && this.address == p.address;
+			}
+		}
+
+		public override int GetHashCode()
+		{
+			return Tuple.Create(this.address, this.objectId).GetHashCode();
+		}
+
+		private void UpdateIsValid()
+		{
+			var wasValid = this.isValid;
+			this.isValid = this.address != IntPtr.Zero &&
+					this.memory.Address != IntPtr.Zero &&
+					this.memory.Address == this.address &&
+					this.memory.ObjectId == this.objectId &&
+					ActorService.Instance.ActorTable[this.memory.ObjectIndex] == this.address;
+
+			if(wasValid != this.isValid)
+				this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.IsValid)));
+		}
+	}
+}

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -74,7 +74,7 @@ namespace Anamnesis.Views
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			this.Selector.AddItems(TargetService.GetAllActors());
+			this.Selector.AddItems(ActorService.Instance.GetAllActors());
 			this.Selector.FilterItems();
 		}
 


### PR DESCRIPTION
This is an initial implementation of `ActorService` and `ActorRef`.

For `ActorService`, this version caches the table and does a full scan every 10ms. You can also force a refresh with an optional argument where you really need to reload the table. 

`ActorRef` is a lightweight wrapper which tries to ensure that actor you are pointing to is really still the same actor and still valid. 
It compares the address, objectId and checks that the actor's concept of where it is in the table is correct (when actors get detached the table updates but the actor does not).

I've replaced all references to ActorMemory being stored in the Animation service with `ActorRef` and it seems to work well and definitely simplifies that code. I haven't replaced anywhere else yet.

I've done a pass of the whole codebase to remove references to the old ActorTable stuff in `TargetManager` and now everything uses `ActorService`.

This is a fairly quick and naive implementation as we have maintenance tonight, but it's a good start I think.

I think the next step would be for `ActorService.GetAllActors` to return `List<ActorRef<ActorBasicMemory>>` instead of `List<ActorBasicMemory>`. But that would require handling it where we currently call for UI etc.