### PR TITLE
Include Mounts & Ornaments in TargetSelect

### DIFF
--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -44,6 +44,8 @@
 	"Target_Players": "Players",
 	"Target_Companions": "Companions",
 	"Target_Npc": "NPCs",
+	"Target_Mounts": "Mounts",
+	"Target_Ornaments": "Ornaments",
 	"Target_Other": "Others",
 	"Target_Gpose": "(GPose)",
 

--- a/Anamnesis/Views/TargetSelectorView.xaml
+++ b/Anamnesis/Views/TargetSelectorView.xaml
@@ -17,6 +17,7 @@
 	<Grid x:Name="ContentArea">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto"/>
 			<RowDefinition />
 		</Grid.RowDefinitions>
@@ -34,12 +35,24 @@
 			<CheckBox Margin="6,0" IsChecked="{Binding IncludeNPCs}">
 				<XivToolsWpf:TextBlock Key="Target_Npc" />
 			</CheckBox>
+		</StackPanel>
+
+		<StackPanel
+			Grid.Row="1"
+			Margin="4,6,4,0"
+			Orientation="Horizontal">
+			<CheckBox Margin="6,0" IsChecked="{Binding IncludeMounts}">
+				<XivToolsWpf:TextBlock Key="Target_Mounts" />
+			</CheckBox>
+			<CheckBox Margin="6,0" IsChecked="{Binding IncludeOrnaments}">
+				<XivToolsWpf:TextBlock Key="Target_Ornaments" />
+			</CheckBox>
 			<CheckBox Margin="6,0" IsChecked="{Binding IncludeOther}">
 				<XivToolsWpf:TextBlock Key="Target_Other" />
 			</CheckBox>
 		</StackPanel>
 
-		<Grid Grid.Row="1">
+		<Grid Grid.Row="2">
 
 			<Button Click="OnAddPlayerTargetActorClicked"
 					IsEnabled="{Binding TargetService.IsPlayerTargetPinnable}"
@@ -57,7 +70,7 @@
 
 		<cm3Drawers:SelectorDrawer
 			x:Name="Selector"
-			Grid.Row="2"
+			Grid.Row="3"
 			Close="OnClose"
 			Filter="OnFilter"
 			Sort="OnSort"

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -22,6 +22,8 @@ namespace Anamnesis.Views
 		private static bool includePlayers = true;
 		private static bool includeCompanions = true;
 		private static bool includeNPCs = true;
+		private static bool includeMounts = true;
+		private static bool includeOrnaments = true;
 		private static bool includeOther = false;
 
 		public TargetSelectorView()
@@ -54,6 +56,18 @@ namespace Anamnesis.Views
 		{
 			get => includeNPCs;
 			set => includeNPCs = value;
+		}
+
+		public bool IncludeMounts
+		{
+			get => includeMounts;
+			set => includeMounts = value;
+		}
+
+		public bool IncludeOrnaments
+		{
+			get => includeOrnaments;
+			set => includeOrnaments = value;
 		}
 
 		public bool IncludeOther
@@ -94,6 +108,12 @@ namespace Anamnesis.Views
 		{
 			if (a is ActorBasicMemory actorA && b is ActorBasicMemory actorB)
 			{
+				if (actorA.IsGPoseActor && !actorB.IsGPoseActor)
+					return -1;
+
+				if (!actorA.IsGPoseActor && actorB.IsGPoseActor)
+					return 1;
+
 				return actorA.DistanceFromPlayer.CompareTo(actorB.DistanceFromPlayer);
 			}
 
@@ -119,6 +139,12 @@ namespace Anamnesis.Views
 				if (!includeCompanions && actor.ObjectKind == Memory.ActorTypes.Companion)
 					return false;
 
+				if (!includeMounts && actor.ObjectKind == Memory.ActorTypes.Mount)
+					return false;
+
+				if (!includeOrnaments && actor.ObjectKind == Memory.ActorTypes.Ornament)
+					return false;
+
 				if (!includeNPCs && (actor.ObjectKind == Memory.ActorTypes.BattleNpc || actor.ObjectKind == Memory.ActorTypes.EventNpc))
 					return false;
 
@@ -126,7 +152,9 @@ namespace Anamnesis.Views
 					&& actor.ObjectKind != Memory.ActorTypes.Player
 					&& actor.ObjectKind != Memory.ActorTypes.Companion
 					&& actor.ObjectKind != Memory.ActorTypes.BattleNpc
-					&& actor.ObjectKind != Memory.ActorTypes.EventNpc)
+					&& actor.ObjectKind != Memory.ActorTypes.EventNpc
+					&& actor.ObjectKind != Memory.ActorTypes.Mount
+					&& actor.ObjectKind != Memory.ActorTypes.Ornament)
 				{
 					return false;
 				}


### PR DESCRIPTION
* Mounts and Ornaments are now included by default
* GPose actors appear in list first