### PR TITLE
Retargeting

### DIFF
--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -47,6 +47,7 @@
 	"Target_Mounts": "Mounts",
 	"Target_Ornaments": "Ornaments",
 	"Target_Other": "Others",
+	"Target_Hidden": "Show Hidden/Unloaded",
 	"Target_Gpose": "(GPose)",
 
 	"SubActor_Title": "Sub Actors",

--- a/Anamnesis/Memory/ActorBasicMemory.cs
+++ b/Anamnesis/Memory/ActorBasicMemory.cs
@@ -16,6 +16,12 @@ namespace Anamnesis.Memory
 	{
 		private ActorBasicMemory? owner;
 
+		public enum RenderModes : int
+		{
+			Draw = 0,
+			Unload = 2,
+		}
+
 		[Bind(0x030)] public Utf8String NameBytes { get; set; }
 		[Bind(0x074)] public uint ObjectId { get; set; }
 		[Bind(0x080)] public uint DataId { get; set; }
@@ -24,6 +30,7 @@ namespace Anamnesis.Memory
 		[Bind(0x08c, BindFlags.ActorRefresh)] public ActorTypes ObjectKind { get; set; }
 		[Bind(0x090)] public byte DistanceFromPlayerX { get; set; }
 		[Bind(0x092)] public byte DistanceFromPlayerY { get; set; }
+		[Bind(0x0104)] public RenderModes RenderMode { get; set; }
 
 		public string Id => $"n{this.NameHash}_d{this.DataId}_o{this.Address}";
 		public string IdNoAddress => $"n{this.NameHash}_d{this.DataId}";
@@ -40,6 +47,9 @@ namespace Anamnesis.Memory
 
 		[DependsOn(nameof(IsGPoseActor))]
 		public bool IsOverworldActor => !this.IsGPoseActor;
+
+		[DependsOn(nameof(RenderMode))]
+		public bool IsHidden => this.RenderMode != RenderModes.Draw;
 
 		[DependsOn(nameof(IsOverworldActor))]
 		public bool CanRefresh

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -17,12 +17,6 @@ namespace Anamnesis.Memory
 
 		private IntPtr? previousObjectKindAddressBeforeGPose;
 
-		public enum RenderModes : int
-		{
-			Draw = 0,
-			Unload = 2,
-		}
-
 		public enum CharacterModes : byte
 		{
 			None = 0,
@@ -38,7 +32,6 @@ namespace Anamnesis.Memory
 		[Bind(0x008D)] public byte SubKind { get; set; }
 		[Bind(0x0B4)] public float Scale { get; set; }
 		[Bind(0x00F0, BindFlags.Pointer)] public ActorModelMemory? ModelObject { get; set; }
-		[Bind(0x0104)] public RenderModes RenderMode { get; set; }
 		[Bind(0x01B4, BindFlags.ActorRefresh)] public int ModelType { get; set; }
 		[Bind(0x01E2)] public byte ClassJob { get; set; }
 		[Bind(0x07C4)] public bool IsAnimating { get; set; }

--- a/Anamnesis/Views/TargetSelectorView.xaml
+++ b/Anamnesis/Views/TargetSelectorView.xaml
@@ -20,6 +20,8 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto"/>
 			<RowDefinition />
+			<RowDefinition Height="Auto"/>
+			
 		</Grid.RowDefinitions>
 
 		<StackPanel
@@ -126,5 +128,15 @@
 			</cm3Drawers:SelectorDrawer.ItemTemplate>
 		</cm3Drawers:SelectorDrawer>
 
+		<Grid Grid.Row="4" Margin="10,6,2,6" HorizontalAlignment="Right">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition />
+				<ColumnDefinition />
+			</Grid.ColumnDefinitions>
+
+			<XivToolsWpf:TextBlock Key="Target_Hidden" Grid.Column="0" />
+			<CheckBox IsChecked="{Binding IncludeHidden}" Grid.Column="1" />
+		</Grid>
+		
 	</Grid>
 </UserControl>

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -25,6 +25,7 @@ namespace Anamnesis.Views
 		private static bool includeMounts = true;
 		private static bool includeOrnaments = true;
 		private static bool includeOther = false;
+		private static bool includeHidden = false;
 
 		public TargetSelectorView()
 		{
@@ -74,6 +75,12 @@ namespace Anamnesis.Views
 		{
 			get => includeOther;
 			set => includeOther = value;
+		}
+
+		public bool IncludeHidden
+		{
+			get => includeHidden;
+			set => includeHidden = value;
 		}
 
 		public void OnClosed()
@@ -131,6 +138,9 @@ namespace Anamnesis.Views
 					return false;
 
 				if (TargetService.IsPinned(actor))
+					return false;
+
+				if (!includeHidden && actor.IsHidden)
 					return false;
 
 				if (!includePlayers && actor.ObjectKind == Memory.ActorTypes.Player)


### PR DESCRIPTION
This needs a lot of testing

* Retargeting
   * GPose actors that were pinned during gpose are retargeted upon returning to the overworld
   * Overworld actors that were visible in the overworld but are no longer visible upon entering gpose are retargeted
   * Overworld actors that remain visible upon entering gpose are flagged so further refreshes won't cause them to retarget
   * Hidden actors are no longer eligible to be valid targets during retargeting (but can still be pinned manually)
 * UI Changes
    * Show/Hide hidden actors is now toggleable on the targeting pane
    * Hidden actors are by default not displayed (to avoid confusion with duplicate actors in gpose)