### PR TITLE
More retargeting tweaks

### DIFF
--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -285,6 +285,21 @@
 																		Foreground="Black"
 																		Icon="{Binding Icon}" />
 																</Grid>
+
+																<Grid
+																	Width="15"
+																	Height="15"
+																	Margin="0,-4,4,0"
+																	HorizontalAlignment="Right"
+																	VerticalAlignment="Bottom"
+																	Visibility="{Binding IsValid, Converter={StaticResource B2V}}">
+																	<Ellipse Fill="{DynamicResource PrimaryHueMidBrush}" Visibility="{Binding IsGPoseActor, Converter={StaticResource B2V}}" />
+																	<fa:IconImage
+																		Margin="2,1,1,2"
+																		Foreground="Black"
+																		Icon="Camera"
+																		Visibility="{Binding IsGPoseActor, Converter={StaticResource B2V}}"/>
+																</Grid>
 															</Grid>
 
 														</DataTemplate>

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -16,6 +16,8 @@ namespace Anamnesis
 	{
 		private const int TickDelay = 10;
 		private const int ActorTableSize = 424;
+		private const int GPoseIndexStart = 200;
+		private const int GPoseIndexEnd = 244;
 
 		private readonly IntPtr[] actorTable = new IntPtr[ActorTableSize];
 
@@ -38,6 +40,17 @@ namespace Anamnesis
 		}
 
 		public bool IsActorInTable(MemoryBase memory, bool refresh = false) => this.IsActorInTable(memory.Address, refresh);
+
+		public bool IsGPoseActor(int objectIndex) => objectIndex >= GPoseIndexStart && objectIndex < GPoseIndexEnd;
+
+		public bool IsGPoseActor(IntPtr actorAddress)
+		{
+			int objectIndex = this.GetActorTableIndex(actorAddress);
+			return this.IsGPoseActor(objectIndex);
+		}
+
+		public bool IsOverworldActor(int objectIndex) => !this.IsGPoseActor(objectIndex);
+		public bool IsOverworldActor(IntPtr actorAddress) => !this.IsGPoseActor(actorAddress);
 
 		public List<ActorBasicMemory> GetAllActors(bool refresh = false)
 		{

--- a/Anamnesis/Services/GposeService.cs
+++ b/Anamnesis/Services/GposeService.cs
@@ -19,7 +19,7 @@ namespace Anamnesis.Services
 		public static event GposeEvent? GposeStateChanged;
 
 		public bool IsGpose { get; private set; }
-		public bool IsOverworld { get; private set; }
+		public bool IsOverworld => !this.IsGpose;
 
 		public bool IsChangingState { get; private set; }
 
@@ -49,14 +49,12 @@ namespace Anamnesis.Services
 				{
 					this.initialized = true;
 					this.IsGpose = newGpose;
-					this.IsOverworld = !this.IsGpose;
 					continue;
 				}
 
 				if (newGpose != this.IsGpose)
 				{
 					this.IsGpose = newGpose;
-					this.IsOverworld = !this.IsGpose;
 
 					GposeStateChanging?.Invoke();
 					this.IsChangingState = true;


### PR DESCRIPTION
* Fixed #836 - hidden actors can now be pinned
* Better detection of gpose boundary for overworld actors, should fix certain failures to detect gpose transition
* GPose actors now have a camera icon on their pin to make it obvious which actor is targeted
* Upon startup, if the player is already in gpose their gpose actor will be pinned instead of overworld actor