### PR TITLE
Fix gallery internet bandwidth issue

### DIFF
--- a/Anamnesis/Views/Gallery.xaml
+++ b/Anamnesis/Views/Gallery.xaml
@@ -48,7 +48,7 @@
 				<Grid>
 					<Rectangle Fill="White" Margin="-3"/>
 					<TextBlock Text="Oops! No Image!" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Black" Margin="0, 0, 0, 20"/>
-					<Image Source="{Binding Image1Path}" x:Name="Image1" Margin="0, 0, 0, 20"/>
+					<Image Source="{Binding Image1Bitmap}" x:Name="Image1" Margin="0, 0, 0, 20"/>
 					<TextBlock Text="{Binding Image1Author}" HorizontalAlignment="Right" VerticalAlignment="Bottom" Foreground="Black" Margin="2, 4, 2, 0"/>
 				</Grid>
 			</Border>
@@ -65,7 +65,7 @@
 				<Grid>
 					<Rectangle Fill="White" Margin="-3"/>
 					<TextBlock Text="Oops! No Image!" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Black" Margin="0, 0, 0, 20"/>
-					<Image Source="{Binding Image2Path}" x:Name="Image2" Margin="0, 0, 0, 20"/>
+					<Image Source="{Binding Image2Bitmap}" x:Name="Image2" Margin="0, 0, 0, 20"/>
 					<TextBlock Text="{Binding Image2Author}" HorizontalAlignment="Right" VerticalAlignment="Bottom" Foreground="Black" Margin="2, 4, 2, 0"/>
 				</Grid>
 			</Border>


### PR DESCRIPTION
Current approach to gallery is causing heavy bandwidth usage since every single image has to be downloaded even when viewed again. JSON file with images currently contains links to total of 1.2GB of images. This is bad when we start to use tens of gigabytes just for a gallery, especially for users with data caps. It's also not great if we'd suddenly start using 1.2GB of space for long term storage of images.

This should address #843 

If user picks Local gallery, Anamnesis will generate entries for all images and read them from the drive, just like it did so far.

If user picks Curated gallery, Anamnesis will:
1) Only pick 20 random images from list of ~520 images
2) Download them and store as BitmapImage
3) Show Images in UI by loading them from Dictionary (if there is no matching BitmapImage value for URL key, it will fallback and attempt to load from URL directly)

Also now if gallery is not visible Anamnesis will freeze it completely on next image, no point in moving further if user doesn't see the images.