### PR TITLE
Make Retainer valid type

### DIFF
--- a/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
+++ b/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
@@ -18,6 +18,7 @@ namespace Anamnesis.Styles
 				case ActorTypes.Companion:
 				case ActorTypes.Mount:
 				case ActorTypes.Ornament:
+				case ActorTypes.Retainer:
 					return true;
 			}
 


### PR DESCRIPTION
Seems like pinning a retainer or setting an actor to retainer type is safe.

It's useful for 2 reasons:
1. You may want to get the appearance from your retainer (Which you can do by pinning while you are using a summoning bell).
2. Retainers are never copied to GPose so for example you can turn your Carby into a Retainer and continue to change their clothes in GPose.