### PR TITLE
Fix risky animation issues

### DIFF
--- a/Anamnesis/Character/Views/AnimationEditor.xaml
+++ b/Anamnesis/Character/Views/AnimationEditor.xaml
@@ -9,7 +9,7 @@
              d:DesignHeight="35" d:DesignWidth="200"
 			 DataContextChanged="OnDataContextChanged">
 
-	<Grid x:Name="ContentArea">
+	<Grid x:Name="ContentArea" IsEnabled="{Binding ActorRef.Memory.CanAnimate}">
 
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto"/>

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -115,6 +115,9 @@ namespace Anamnesis.Memory
 			set => this.ObjectKind = (ActorTypes)value;
 		}
 
+		[DependsOn(nameof(ObjectIndex), nameof(CharacterMode))]
+		public bool CanAnimate => (this.CharacterMode == CharacterModes.Normal || this.CharacterMode == CharacterModes.AnimLock) || !ActorService.Instance.IsLocalOverworldPlayer(this.ObjectIndex);
+
 		/// <summary>
 		/// Refresh the actor to force the game to load any changed values for appearance.
 		/// </summary>
@@ -207,10 +210,8 @@ namespace Anamnesis.Memory
 
 		public bool CanHasNpcFace()
 		{
-			int index = ActorService.Instance.GetActorTableIndex(this.Address);
-
 			// only the local player should get npc faces!
-			if (index != 0 && index != 201)
+			if (!ActorService.Instance.IsLocalPlayer(this.Address))
 				return false;
 
 			if (this.Customize?.Head > 10)

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -18,6 +18,8 @@ namespace Anamnesis
 		private const int ActorTableSize = 424;
 		private const int GPoseIndexStart = 200;
 		private const int GPoseIndexEnd = 244;
+		private const int OverworldPlayerIndex = 0;
+		private const int GPosePlayerIndex = 201;
 
 		private readonly IntPtr[] actorTable = new IntPtr[ActorTableSize];
 
@@ -46,11 +48,40 @@ namespace Anamnesis
 		public bool IsGPoseActor(IntPtr actorAddress)
 		{
 			int objectIndex = this.GetActorTableIndex(actorAddress);
+
+			if (objectIndex == -1)
+				return false;
+
 			return this.IsGPoseActor(objectIndex);
 		}
 
 		public bool IsOverworldActor(int objectIndex) => !this.IsGPoseActor(objectIndex);
 		public bool IsOverworldActor(IntPtr actorAddress) => !this.IsGPoseActor(actorAddress);
+
+		public bool IsLocalOverworldPlayer(int objectIndex) => objectIndex == OverworldPlayerIndex;
+		public bool IsLocalOverworldPlayer(IntPtr actorAddress)
+		{
+			int objectIndex = this.GetActorTableIndex(actorAddress);
+
+			if (objectIndex == -1)
+				return false;
+
+			return this.IsLocalOverworldPlayer(objectIndex);
+		}
+
+		public bool IsLocalGPosePlayer(int objectIndex) => objectIndex == GPosePlayerIndex;
+		public bool IsLocalGPosePlayer(IntPtr actorAddress)
+		{
+			int objectIndex = this.GetActorTableIndex(actorAddress);
+
+			if (objectIndex == -1)
+				return false;
+
+			return this.IsLocalGPosePlayer(objectIndex);
+		}
+
+		public bool IsLocalPlayer(int objectIndex) => this.IsLocalOverworldPlayer(objectIndex) || this.IsLocalGPosePlayer(objectIndex);
+		public bool IsLocalPlayer(IntPtr actorAddress) => this.IsLocalOverworldPlayer(actorAddress) || this.IsLocalGPosePlayer(actorAddress);
 
 		public List<ActorBasicMemory> GetAllActors(bool refresh = false)
 		{

--- a/Anamnesis/Services/GposeService.cs
+++ b/Anamnesis/Services/GposeService.cs
@@ -19,6 +19,8 @@ namespace Anamnesis.Services
 		public static event GposeEvent? GposeStateChanged;
 
 		public bool IsGpose { get; private set; }
+
+		[DependsOn(nameof(IsGpose))]
 		public bool IsOverworld => !this.IsGpose;
 
 		public bool IsChangingState { get; private set; }


### PR DESCRIPTION
This is a first pass at fixing the risky animation issues recently discovered such as #879, the goal here is to make sure we aren't doing anything server or other player detectable.

You are no longer able to apply an animation to your local character unless you are in "Normal" mode (No animation loop etc). 

Overall I think animation probably needs an overhaul at some point but this should address any concerns in the short term.