### PR TITLE
Make world freezing behave as expected

### DIFF
--- a/Anamnesis/Posing/Services/PoseService.cs
+++ b/Anamnesis/Posing/Services/PoseService.cs
@@ -171,8 +171,6 @@ namespace Anamnesis.PoseModule
 			if (enabled && !GposeService.Instance.IsGpose)
 				throw new Exception("Attempt to enable posing outside of gpose");
 
-			this.FreezeWorldPosition = enabled; // This one can be toggled externally so we always set it
-
 			if (this.isEnabled == enabled)
 				return;
 
@@ -250,7 +248,10 @@ namespace Anamnesis.PoseModule
 		private void OnGposeStateChanging()
 		{
 			if (GposeService.Instance.IsOverworld)
+			{
 				this.SetEnabled(false);
+				this.FreezeWorldPosition = false;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #868 by making the world freezing behave as expected. It must be enabled by the user and will not be automatically disabled until you leave GPose.