### PR TITLE
Make face hack more tolerant to failure

### DIFF
--- a/Anamnesis/Services/NpcFaceHackService.cs
+++ b/Anamnesis/Services/NpcFaceHackService.cs
@@ -40,9 +40,23 @@ namespace Anamnesis.Services
 					if (pinnedActor.Memory.ObjectKind != ActorTypes.Player)
 						continue;
 
-					var actor = new Actor(pinnedActor);
-					this.actors.Add(actor);
-					actor.ChangeToNpc();
+					Actor? actor = null;
+
+					try
+					{
+						actor = new Actor(pinnedActor);
+					}
+					catch (Exception ex)
+					{
+						Log.Error(ex, "Face hack timing failure");
+						continue;
+					}
+
+					if(actor != null)
+					{
+						this.actors.Add(actor);
+						actor.ChangeToNpc();
+					}
 				}
 			}
 			else
@@ -78,7 +92,7 @@ namespace Anamnesis.Services
 				var memory = pinned.GetMemory();
 
 				if (memory == null)
-					throw new Exception("Unable to get memory from piunned actor");
+					throw new Exception("Unable to get memory from pinned actor");
 
 				this.Pinned = pinned;
 				this.Memory = memory;


### PR DESCRIPTION
It's possible Ana will crash if the timing is bad when you go into the face hack.

Between the first check if pinnedActor.Memory is null and creating the Actor object, it can flip to null before you get to modify it (you most often see it in debug builds), which causes a fatal exception.