### PR TITLE
UI Event Firing Fix

### DIFF
--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -369,6 +369,7 @@ namespace Anamnesis
 			{
 				// Raise the event in case the underlying memory changed
 				this.RaisePropertyChanged(nameof(TargetService.CurrentlyPinned));
+				this.RaisePropertyChanged(nameof(TargetService.SelectedActor));
 				return;
 			}
 


### PR DESCRIPTION
Seems like raising an event like this doesn't trigger a DependsOn, this resolves that,

This causes issues with the change I made earlier so this fix is required to cover all cases.

I'm almost certain this is the cause (well, similar in the old pinning system) of that weird bug where it would still think you are in gpose #876. This combined with the earlier UI fix should resolve it.