### PR TITLE
Animation Blending Improvements

### DIFF
--- a/Anamnesis/Character/Pages/ActionPage.xaml
+++ b/Anamnesis/Character/Pages/ActionPage.xaml
@@ -150,7 +150,7 @@
                                 <XivToolsWpf:TextBlock Key="Character_Action_AnimationApply"/>
                             </Button>
 
-							<Button Grid.Row="0" Grid.Column="1"  Click="OnResetOverrideAnimation" IsEnabled="{Binding Actor.IsAnimationOverriden}" Style="{StaticResource TransparentButton}">
+                            <Button Grid.Row="0" Grid.Column="1"  Click="OnResetOverrideAnimation" IsEnabled="{Binding Actor.IsAnimationOverridden}" Style="{StaticResource TransparentButton}">
                                 <XivToolsWpf:TextBlock Key="Character_Action_AnimationReset"/>
                             </Button>
 
@@ -168,7 +168,73 @@
                 </GroupBox>
             </StackPanel>
 
-            <StackPanel Grid.Row="2" IsEnabled="{Binding AnimationService.SpeedControlEnabled}">
+            <StackPanel Grid.Row="2">
+                <GroupBox Style="{StaticResource PanelGroupBox}">
+                    <GroupBox.Header>
+                        <XivToolsWpf:Header Key="Character_Action_AnimationBlending"
+											Icon="RulerCombined" />
+                    </GroupBox.Header>
+
+                    <Grid IsEnabled="{Binding Actor.IsAnimationOverridden}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <XivToolsWpf:TextBlock
+			                Key="Character_Action_AnimationId"
+			                Grid.Row="0"
+			                Grid.Column="0"
+			                Style="{StaticResource Label}"/>
+
+
+                        <Grid Grid.Row="0" Grid.Column="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+
+                            <Button Grid.Column="0" Click="OnBlendAnimationSearchClicked"  Style="{StaticResource TransparentButton}">
+                                <Button.ToolTip>
+                                    <XivToolsWpf:TextBlock Key="Character_Action_AnimationSearch"/>
+                                </Button.ToolTip>
+
+                                <XivToolsWpf:IconBlock Icon="Search"/>
+                            </Button>
+
+                            <XivToolsWpf:NumberBox Grid.Column="1"  Value="{Binding AnimationOverride.BlendAnimationId}"  Buttons="True"
+										   Minimum="0"
+										   TickFrequency="1" />
+                        </Grid>
+
+
+                        <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Click="OnBlendAnimation" IsEnabled="{Binding AnimationService.BlendLocked, Converter={StaticResource NotConverter}}" Style="{StaticResource TransparentButton}">
+                            <XivToolsWpf:TextBlock Key="Character_Action_AnimationBlend"/>
+                        </Button>
+
+                        <XivToolsWpf:TextBlock
+			                Key="Character_Action_AnimationBlendWarning"
+			                Grid.Row="2"
+			                Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            HorizontalAlignment="Left"
+                            FontSize="10"
+                            FontStyle="Italic"
+                            TextWrapping="Wrap"
+			                Style="{StaticResource Label}"/>
+
+                        <XivToolsWpf:InfoControl Visibility="{Binding Actor.IsAnimationOverridden, Converter={StaticResource !B2V}}" Grid.Row="0" Grid.ColumnSpan="2" Grid.RowSpan="3" Key="Character_Action_AnimationOverrideBlendBlocked" />
+                    </Grid>
+                </GroupBox>
+            </StackPanel>
+
+            <StackPanel Grid.Row="3" IsEnabled="{Binding AnimationService.SpeedControlEnabled}">
                 <GroupBox Style="{StaticResource PanelGroupBox}">
                     <GroupBox.Header>
                         <XivToolsWpf:Header Key="Character_Action_AnimationSpeedControl"
@@ -226,70 +292,6 @@
                         </Button>
 
                         <XivToolsWpf:InfoControl Visibility="{Binding AnimationService.SpeedControlEnabled, Converter={StaticResource !B2V}}" Grid.Row="0" Grid.ColumnSpan="4" Grid.RowSpan="2" Key="Character_Action_AnimationOverrideSpeedBlocked" />
-                    </Grid>
-                </GroupBox>
-            </StackPanel>
-
-            <StackPanel Grid.Row="3">
-                <GroupBox Style="{StaticResource PanelGroupBox}">
-                    <GroupBox.Header>
-                        <XivToolsWpf:Header Key="Character_Action_AnimationBlending"
-											Icon="RulerCombined" />
-                    </GroupBox.Header>
-
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-
-                        <XivToolsWpf:TextBlock
-			                Key="Character_Action_AnimationId"
-			                Grid.Row="0"
-			                Grid.Column="0"
-			                Style="{StaticResource Label}"/>
-
-
-                        <Grid Grid.Row="0" Grid.Column="1">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition/>
-                            </Grid.ColumnDefinitions>
-                            
-                            <Button Grid.Column="0" Click="OnBlendAnimationSearchClicked"  Style="{StaticResource TransparentButton}">
-                                <Button.ToolTip>
-                                    <XivToolsWpf:TextBlock Key="Character_Action_AnimationSearch"/>
-                                </Button.ToolTip>
-
-                                <XivToolsWpf:IconBlock Icon="Search"/>
-                            </Button>
-
-                            <XivToolsWpf:NumberBox Grid.Column="1"  Value="{Binding AnimationOverride.BlendAnimationId}"  Buttons="True"
-										   Minimum="0"
-										   TickFrequency="1" />
-                        </Grid>
-                        
-
-                        <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Click="OnBlendAnimation" Style="{StaticResource TransparentButton}">
-                            <XivToolsWpf:TextBlock Key="Character_Action_AnimationBlend"/>
-                        </Button>
-
-                        <XivToolsWpf:TextBlock
-			                Key="Character_Action_AnimationBlendWarning"
-			                Grid.Row="2"
-			                Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            HorizontalAlignment="Left"
-                            FontSize="10"
-                            FontStyle="Italic"
-                            TextWrapping="Wrap"
-			                Style="{StaticResource Label}"/>
                     </Grid>
                 </GroupBox>
             </StackPanel>

--- a/Anamnesis/Character/Pages/ActionPage.xaml.cs
+++ b/Anamnesis/Character/Pages/ActionPage.xaml.cs
@@ -71,7 +71,7 @@ namespace Anamnesis.Character.Pages
 				}
 				else
 				{
-					if (actor.IsAnimationOverriden == true)
+					if (actor.IsAnimationOverridden == true)
 					{
 						this.AnimationOverride = new();
 						this.AnimationOverride.BaseAnimationId = actor.BaseAnimationOverride;

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -50,7 +50,7 @@
 	"Shortcut_FfxivAppearance": "FFXIV saved appearances",
 	"Shortcut_Desktop": "Desktop",
 
-	"Target_AddActor":  "Add Actor",
+	"Target_AddActor": "Add Actor",
 	"Target_Players": "Players",
 	"Target_Companions": "Companions",
 	"Target_Npc": "NPCs",
@@ -251,6 +251,7 @@
 	"Character_Action_AnimationStatus": "Animation Status",
 	"Character_Action_AnimationOverride": "Animation Override",
 	"Character_Action_AnimationOverrideBlocked": "Animation Override is only available for your local overworld player when you are idle. Please stop any emotes or actions you are performing.",
+	"Character_Action_AnimationOverrideBlendBlocked": "Animation Blending is only avaiable once you have overidden the base animation in the Animation Override section above.",
 	"Character_Action_AnimationSpeedControl": "Animation Speed Control",
 	"Character_Action_AnimationBlending": "Animation Blending",
 	"Character_Action_GlobalSettings": "Global Settings",

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -119,7 +119,7 @@ namespace Anamnesis.Memory
 		public bool CanAnimate => (this.CharacterMode == CharacterModes.Normal || this.CharacterMode == CharacterModes.AnimLock) || !ActorService.Instance.IsLocalOverworldPlayer(this.ObjectIndex);
 
 		[DependsOn(nameof(CharacterMode))]
-		public bool IsAnimationOverriden => this.CharacterMode == CharacterModes.AnimLock;
+		public bool IsAnimationOverridden => this.CharacterMode == CharacterModes.AnimLock;
 
 		[DependsOn(nameof(BaseAnimationSpeedInternal))]
 		public float BaseAnimationSpeed
@@ -128,7 +128,7 @@ namespace Anamnesis.Memory
 			set
 			{
 				this.BaseAnimationSpeedInternal = value;
-				this.AnimationSpeedTrigger = this.AnimationSpeedTrigger == 0.0f ? 1.0f : 0.0f;
+				this.AnimationSpeedTrigger = value;
 			}
 		}
 
@@ -139,7 +139,7 @@ namespace Anamnesis.Memory
 			set
 			{
 				this.LipAnimationSpeedInternal = value;
-				this.AnimationSpeedTrigger = this.AnimationSpeedTrigger == 0.0f ? 1.0f : 0.0f;
+				this.AnimationSpeedTrigger = (this.AnimationSpeedTrigger > this.BaseAnimationSpeedInternal) ? this.BaseAnimationSpeed : this.BaseAnimationSpeed + 0.001f;
 			}
 		}
 


### PR DESCRIPTION
* The base animation speed now applies to the blend
* Spamming the blend button could get the character stuck, so it's now locked until the blend is applied
* Blending is only available after overriding the base animation (and the UI reflects this with a warning)
* Put blending under base animation seeing as they are so related, speed moved to bottom
* Some general tidy up as well