### PR TITLE
Dev mode nag window

### DIFF
--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -597,6 +597,9 @@
 	"Update_Title": "Update",
 	"Update_NoUpdate": "No updates found",
 
+	"DevBuild_Title": "Development Build",
+	"DevBuild_Body": "This is an experimental development build of Anamnesis and is not officially supported. These builds are likely to contain serious issues and should be avoided unless you know what you are doing.\n\nWould you like to continue using this build?\nSelecting no will offer you an update to the latest supported build.",
+
 	"Item_Unknown": "Unknown",
 	"Item_None": "None",
 	"Item_NoneDesc": "Nothing",

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -50,8 +50,8 @@ namespace Anamnesis.Services
 			await Add<LogService>();
 			await Add<SerializerService>();
 			await Add<SettingsService>();
-			await Add<Updater.UpdateService>();
 			await Add<LocalizationService>();
+			await Add<Updater.UpdateService>();
 			await Add<ViewService>();
 			await Add<MemoryService>();
 			await Add<AddressService>();

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -13,6 +13,7 @@ namespace Anamnesis.Updater
 	using System.Text.Json;
 	using System.Text.Json.Serialization;
 	using System.Threading.Tasks;
+	using Anamnesis.GUI.Dialogs;
 	using Anamnesis.Services;
 	using XivToolsWpf;
 
@@ -29,13 +30,27 @@ namespace Anamnesis.Updater
 		{
 			await base.Initialize();
 
-			// Don't check for updates if the VersionInfo hasn't been written by the build process.
+			bool skipTimeCheck = false;
+
+			// Determine if this is a dev build
 			if (VersionInfo.Date.Year <= 2000)
-				return;
+			{
+				// Don't show if there is a debugger attached
+				if (Debugger.IsAttached)
+					return;
+
+				// Prompt the user
+				var result = await GenericDialog.ShowLocalizedAsync("DevBuild_Body", "DevBuild_Title", System.Windows.MessageBoxButton.YesNo);
+				if (result == true)
+					return;
+
+				// Always skip the time check if they say no
+				skipTimeCheck = true;
+			}
 
 			DateTimeOffset lastCheck = SettingsService.Current.LastUpdateCheck;
 			TimeSpan elapsed = DateTimeOffset.Now - lastCheck;
-			if (elapsed.TotalHours < 6)
+			if (elapsed.TotalHours < 6 && !skipTimeCheck)
 			{
 				Log.Information("Last update check was less than 6 hours ago. Skipping.");
 				return;


### PR DESCRIPTION
Adds a nag window to the startup sequence that warns the user that they are running an unsupported development build.

Also gives them a path to get back onto a supported version (which will hopefully reduce how many people get stranded on a dev version without realizing they are behind until it breaks).

Does not trigger if a debugger is attached.

Up to you if you think this is needed or the right solution.