### PR TITLE
Pinning Improvements

### DIFF
--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace Anamnesis.GUI
 				if (value)
 					this.TargetService.ClearSelection();
 
-				this.showSettings = this.TargetService.SelectedActor == null;
+				this.showSettings = value;
 			}
 		}
 
@@ -161,6 +161,9 @@ namespace Anamnesis.GUI
 		private void OnActorSelected(ActorMemory? actor)
 		{
 			this.ShowSettings = false;
+
+			if (actor == null)
+				this.Tabs.SelectedIndex = 0;
 		}
 
 		private async Task OnShowDrawer(UserControl view, DrawerDirection direction)

--- a/Anamnesis/Memory/ActorBasicMemory.cs
+++ b/Anamnesis/Memory/ActorBasicMemory.cs
@@ -60,6 +60,9 @@ namespace Anamnesis.Memory
 				if (PoseService.Instance.IsEnabled)
 					return false;
 
+				if (PoseService.Instance.FreezeWorldPosition)
+					return false;
+
 				// If there is some sort of external refresh service
 				// assume we can always refresh.
 				if (SettingsService.Current.UseExternalRefresh)


### PR DESCRIPTION
* Pins are now never deselected even when they go invalid, the pose tabs etc will just disable but the pin remains selected
* This means what is pinned is never reshuffled if you enter/exit gpose or zone to a new area
* You can now select an invalid pin rather than it just doing nothing
* Also fixed that issue where a refresh with freeze world would cause the actor to render at 0,0,0 (by just not allowing refresh when world pos is frozen).