### PR TITLE
Camera Shot System

### DIFF
--- a/Anamnesis/Files/CameraShotFile.cs
+++ b/Anamnesis/Files/CameraShotFile.cs
@@ -30,16 +30,18 @@ namespace Anamnesis.Files
 			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
 			{
 				// First we use the 0 rotation position and rotate it around the actor by it's current rotation in local space
-				Quaternion actorRotation = actor.ModelObject.Transform.Rotation;
-				Vector rotatedRelativePosition = actorRotation * this.Position;
+				Vector actorEuler = actor.ModelObject.Transform.Rotation.ToEuler();
+
+				// We assume the actor is stood flat on the ground
+				actorEuler.X = 0;
+				actorEuler.Z = 0;
+
+				Vector rotatedRelativePosition = Quaternion.FromEuler(actorEuler) * this.Position;
 
 				// Adjust camera position to world space
 				camService.GPoseCamera.Position = actor.ModelObject.Transform.Position + rotatedRelativePosition;
 
 				// Now we apply the angle offset of the camera to the actor
-				Vector actorEuler = actorRotation.ToEuler();
-				actorEuler.X = 0;
-				actorEuler.Z = 0;
 				Vector adjusted = actorEuler + this.Rotation;
 				camService.Camera.Euler = adjusted.ToMedia3DVector();
 			}
@@ -55,21 +57,22 @@ namespace Anamnesis.Files
 			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
 			{
 				Quaternion actorRotation = actor.ModelObject.Transform.Rotation;
+				Vector actorEuler = actorRotation.ToEuler();
+
+				// We assume the actor is stood flat on the ground
+				actorEuler.Z = 0;
+				actorEuler.X = 0;
 
 				// First we get the local coords of the current camera position in relation to the actor
 				Vector localRelativePositon = camService.GPoseCamera.Position - actor.ModelObject.Transform.Position;
 
 				// Now we calculate what the position would be if the actor had a 0 rotation
-				Quaternion invertedActorRotation = actorRotation;
+				Quaternion invertedActorRotation = Quaternion.FromEuler(actorEuler);
 				invertedActorRotation.Invert();
 				Vector rotatedRelativePosition = invertedActorRotation * localRelativePositon;
 				this.Position = rotatedRelativePosition;
 
 				// We save the angle of the camera as an offset from the angle of the actor
-				Vector actorEuler = actorRotation.ToEuler();
-				actorEuler.Z = 0;
-				actorEuler.X = 0;
-
 				Vector cameraEuler = camService.Camera.Euler.ToCmVector();
 				this.Rotation = cameraEuler - actorEuler;
 			}

--- a/Anamnesis/Files/CameraShotFile.cs
+++ b/Anamnesis/Files/CameraShotFile.cs
@@ -29,13 +29,12 @@ namespace Anamnesis.Files
 
 			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
 			{
-				// First we use the 0 rotation position and rotate it around the actor by it's current rotation in local space
-				Vector actorEuler = actor.ModelObject.Transform.Rotation.ToEuler();
-
 				// We assume the actor is stood flat on the ground
+				Vector actorEuler = actor.ModelObject.Transform.Rotation.ToEuler();
 				actorEuler.X = 0;
 				actorEuler.Z = 0;
 
+				// First we use the 0 rotation position and rotate it around the actor by it's current rotation in local space
 				Vector rotatedRelativePosition = Quaternion.FromEuler(actorEuler) * this.Position;
 
 				// Adjust camera position to world space
@@ -56,10 +55,8 @@ namespace Anamnesis.Files
 
 			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
 			{
-				Quaternion actorRotation = actor.ModelObject.Transform.Rotation;
-				Vector actorEuler = actorRotation.ToEuler();
-
 				// We assume the actor is stood flat on the ground
+				Vector actorEuler = actor.ModelObject.Transform.Rotation.ToEuler();
 				actorEuler.Z = 0;
 				actorEuler.X = 0;
 

--- a/Anamnesis/Files/CameraShotFile.cs
+++ b/Anamnesis/Files/CameraShotFile.cs
@@ -1,0 +1,78 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Files
+{
+	using System;
+	using Anamnesis.Memory;
+	using Anamnesis.PoseModule;
+
+	[Serializable]
+	public class CameraShotFile : JsonFileBase
+	{
+		public override string FileExtension => ".shot";
+		public override string TypeName => "Anamnesis Camera Shot";
+
+		public bool DelimitCamera { get; set; }
+		public float Zoom { get; set; }
+		public float FieldOfView { get; set; }
+		public Vector2D Pan { get; set; }
+		public Vector Position { get; set; }
+		public Vector Rotation { get; set; }
+
+		public void Apply(CameraService camService, ActorMemory actor)
+		{
+			camService.DelimitCamera = this.DelimitCamera;
+			camService.Camera.Zoom = this.Zoom;
+			camService.Camera.FieldOfView = this.FieldOfView;
+			camService.Camera.Pan = this.Pan;
+
+			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
+			{
+				// First we use the 0 rotation position and rotate it around the actor by it's current rotation in local space
+				Quaternion actorRotation = actor.ModelObject.Transform.Rotation;
+				Vector rotatedRelativePosition = actorRotation * this.Position;
+
+				// Adjust camera position to world space
+				camService.GPoseCamera.Position = actor.ModelObject.Transform.Position + rotatedRelativePosition;
+
+				// Now we apply the angle offset of the camera to the actor
+				Vector actorEuler = actorRotation.ToEuler();
+				actorEuler.X = 0;
+				actorEuler.Z = 0;
+				Vector adjusted = actorEuler + this.Rotation;
+				camService.Camera.Euler = adjusted.ToMedia3DVector();
+			}
+		}
+
+		public void WriteToFile(CameraService camService, ActorMemory actor)
+		{
+			this.DelimitCamera = camService.DelimitCamera;
+			this.Zoom = camService.Camera.Zoom;
+			this.FieldOfView = camService.Camera.FieldOfView;
+			this.Pan = camService.Camera.Pan;
+
+			if (actor.ModelObject?.Transform?.Rotation != null && actor.ModelObject?.Transform?.Position != null)
+			{
+				Quaternion actorRotation = actor.ModelObject.Transform.Rotation;
+
+				// First we get the local coords of the current camera position in relation to the actor
+				Vector localRelativePositon = camService.GPoseCamera.Position - actor.ModelObject.Transform.Position;
+
+				// Now we calculate what the position would be if the actor had a 0 rotation
+				Quaternion invertedActorRotation = actorRotation;
+				invertedActorRotation.Invert();
+				Vector rotatedRelativePosition = invertedActorRotation * localRelativePositon;
+				this.Position = rotatedRelativePosition;
+
+				// We save the angle of the camera as an offset from the angle of the actor
+				Vector actorEuler = actorRotation.ToEuler();
+				actorEuler.Z = 0;
+				actorEuler.X = 0;
+
+				Vector cameraEuler = camService.Camera.Euler.ToCmVector();
+				this.Rotation = cameraEuler - actorEuler;
+			}
+		}
+	}
+}

--- a/Anamnesis/Files/FileService.cs
+++ b/Anamnesis/Files/FileService.cs
@@ -44,6 +44,11 @@ namespace Anamnesis.Files
 			"Shortcuts/Anamnesis.png",
 			"Shortcut_AnamnesisCharacter");
 
+		public static Shortcut DefaultCameraDirectory => new Shortcut(
+			new DirectoryInfo(ParseToFilePath(SettingsService.Current.DefaultCameraShotDirectory)),
+			"Shortcuts/Anamnesis.png",
+			"Shortcut_AnamnesisScenes");
+
 		public static Shortcut DefaultSceneDirectory => new Shortcut(
 			new DirectoryInfo(ParseToFilePath(SettingsService.Current.DefaultSceneDirectory)),
 			"Shortcuts/Anamnesis.png",

--- a/Anamnesis/Languages/cn.json
+++ b/Anamnesis/Languages/cn.json
@@ -561,6 +561,7 @@
 	"Settings_Directories": "文件夹位置",
 	"Settings_Dir_Characters": "角色",
 	"Settings_Dir_Poses": "动作造型",
+	"Settings_Dir_CameraShots": "相机拍摄",
 	"Settings_Dir_Scenes": "场景",
 	"Settings_GalleryHeader": "画廊",
 	"Settings_Gallery": "模式",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -566,6 +566,7 @@
 	"Settings_Directories": "Directories",
 	"Settings_Dir_Characters": "Characters",
 	"Settings_Dir_Poses": "Poses",
+	"Settings_Dir_CameraShots": "Cam Shots",
 	"Settings_Dir_Scenes": "Scenes",
 	"Settings_GalleryHeader": "Gallery",
 	"Settings_Gallery": "Mode",

--- a/Anamnesis/Memory/CameraMemory.cs
+++ b/Anamnesis/Memory/CameraMemory.cs
@@ -32,6 +32,27 @@ namespace Anamnesis.Memory
 			}
 		}
 
+		[AlsoNotifyFor(nameof(CameraMemory.Angle), nameof(CameraMemory.Rotation))]
+		public Vector3D Euler
+		{
+			get
+			{
+				Vector3D camEuler = default;
+				camEuler.Y = (float)MathUtils.RadiansToDegrees((double)this.Angle.X);
+				camEuler.Z = (float)MathUtils.RadiansToDegrees((double)this.Angle.Y);
+				camEuler.X = (float)MathUtils.RadiansToDegrees((double)this.Rotation);
+				return camEuler;
+			}
+
+			set
+			{
+				this.Rotation = (float)MathUtils.DegreesToRadians(value.X);
+				var angleX = (float)MathUtils.DegreesToRadians(value.Y);
+				var angleY = (float)MathUtils.DegreesToRadians(value.Z);
+				this.Angle = new Vector2D(angleX, angleY);
+			}
+		}
+
 		public bool FreezeAngle
 		{
 			get => this.IsFrozen(nameof(CameraMemory.Angle));

--- a/Anamnesis/Services/Settings.cs
+++ b/Anamnesis/Services/Settings.cs
@@ -36,6 +36,7 @@ namespace Anamnesis.Services
 		public Point OverlayWindowPosition { get; set; }
 		public string DefaultPoseDirectory { get; set; } = "%MyDocuments%/Anamnesis/Poses/";
 		public string DefaultCharacterDirectory { get; set; } = "%MyDocuments%/Anamnesis/Characters/";
+		public string DefaultCameraShotDirectory { get; set; } = "%MyDocuments%/Anamnesis/CameraShots/";
 		public string DefaultSceneDirectory { get; set; } = "%MyDocuments%/Anamnesis/Scenes/";
 		public bool ShowAdvancedOptions { get; set; } = true;
 		public bool FlipPoseGuiSides { get; set; } = false;

--- a/Anamnesis/Views/SceneView.xaml
+++ b/Anamnesis/Views/SceneView.xaml
@@ -297,8 +297,9 @@
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="Auto" />
-                        <RowDefinition />
-                    </Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+						<RowDefinition />
+					</Grid.RowDefinitions>
 
 					<XivToolsWpf:TextBlock Grid.Row="0"
 										   Key="Scene_Camera_Delimit"
@@ -412,6 +413,11 @@
 										   Minimum="-40"
 										   Maximum="100"
 										   TickFrequency="1" />
+
+					<Menu Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource AnaMenu}" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+						<MenuItem Header="Common_OpenFile" Icon="FolderOpen" Click="OnLoadCamera" Style="{StaticResource ButtonMenuItem}" Margin="1" MinWidth="75"/>
+						<MenuItem Header="Common_SaveFile" Icon="Save" Click="OnSaveCamera" Style="{StaticResource ButtonMenuItem}" Margin="1" MinWidth="75"/>
+					</Menu>
 
 
                     <XivToolsWpf:InfoControl Grid.RowSpan="10"

--- a/Anamnesis/Views/SceneView.xaml.cs
+++ b/Anamnesis/Views/SceneView.xaml.cs
@@ -3,8 +3,12 @@
 
 namespace Anamnesis.Views
 {
+	using System;
+	using System.IO;
 	using System.Windows;
 	using System.Windows.Controls;
+	using Anamnesis.Files;
+	using Anamnesis.Memory;
 	using Anamnesis.Services;
 	using Anamnesis.Styles.Drawers;
 	using PropertyChanged;
@@ -16,6 +20,9 @@ namespace Anamnesis.Views
 	[AddINotifyPropertyChangedInterface]
 	public partial class SceneView : UserControl
 	{
+		private static DirectoryInfo? lastLoadDir;
+		private static DirectoryInfo? lastSaveDir;
+
 		public SceneView()
 		{
 			this.InitializeComponent();
@@ -46,6 +53,66 @@ namespace Anamnesis.Views
 			{
 				this.TerritoryService.CurrentWeather = w;
 			});
+		}
+
+		private async void OnLoadCamera(object sender, RoutedEventArgs e)
+		{
+			ActorBasicMemory? targetActor = this.TargetService.PlayerTarget;
+			if (targetActor == null || !targetActor.IsValid)
+				return;
+			ActorMemory actorMemory = new ActorMemory();
+			actorMemory.SetAddress(targetActor.Address);
+
+			try
+			{
+				Shortcut[]? shortcuts = new[]
+				{
+					FileService.DefaultCameraDirectory,
+				};
+
+				Type[] types = new[]
+				{
+						typeof(CameraShotFile),
+				};
+
+				OpenResult result = await FileService.Open(lastLoadDir, shortcuts, types);
+
+				if (result.File == null)
+					return;
+
+				lastLoadDir = result.Directory;
+
+				if (result.File is CameraShotFile camFile)
+				{
+					camFile.Apply(CameraService.Instance, actorMemory);
+				}
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Failed to load camera");
+			}
+		}
+
+		private async void OnSaveCamera(object sender, RoutedEventArgs e)
+		{
+			ActorBasicMemory? targetActor = this.TargetService.PlayerTarget;
+			if (targetActor == null || !targetActor.IsValid)
+				return;
+			ActorMemory actorMemory = new ActorMemory();
+			actorMemory.SetAddress(targetActor.Address);
+
+			SaveResult result = await FileService.Save<CameraShotFile>(lastSaveDir, FileService.DefaultCameraDirectory);
+
+			if (result.Path == null)
+				return;
+
+			lastSaveDir = result.Directory;
+
+			CameraShotFile file = new CameraShotFile();
+			file.WriteToFile(CameraService.Instance, actorMemory);
+
+			using FileStream stream = new FileStream(result.Path.FullName, FileMode.Create);
+			file.Serialize(stream);
 		}
 	}
 }

--- a/Anamnesis/Views/SettingsView.xaml
+++ b/Anamnesis/Views/SettingsView.xaml
@@ -208,6 +208,7 @@
 								<RowDefinition/>
 								<RowDefinition/>
 								<RowDefinition/>
+								<RowDefinition/>
 							</Grid.RowDefinitions>
 
 							<XivToolsWPF:TextBlock Grid.Row="0" Grid.Column="0" Key="Settings_Dir_Characters" Style="{StaticResource Label}"/>
@@ -216,7 +217,11 @@
 
 							<XivToolsWPF:TextBlock Grid.Row="1" Grid.Column="0" Key="Settings_Dir_Poses" Style="{StaticResource Label}"/>
 							<TextBox Grid.Row="1" Grid.Column="1" Margin="3, 0, 0, 0" Style="{StaticResource MaterialDesignTextBox}" Text="{Binding SettingsService.Settings.DefaultPoseDirectory}" IsEnabled="False"/>
-                            <Button Grid.Row="1" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowsePose"/>
+							<Button Grid.Row="1" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowsePose"/>
+
+                            <XivToolsWPF:TextBlock Grid.Row="2" Grid.Column="0" Key="Settings_Dir_CameraShots" Style="{StaticResource Label}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1" Margin="3, 0, 0, 0" Style="{StaticResource MaterialDesignTextBox}" Text="{Binding SettingsService.Settings.DefaultCameraShotDirectory}" IsEnabled="False"/>
+                            <Button Grid.Row="2" Grid.Column="2" Margin="6, 3, 0, 0" Style="{StaticResource TransparentButton}" Content="..." Click="OnBrowseCamera"/>
 
                             <!--
 							<ana:TextBlock Grid.Row="2" Grid.Column="0" Key="Settings_Dir_Scenes" Style="{StaticResource Label}"/>

--- a/Anamnesis/Views/SettingsView.xaml.cs
+++ b/Anamnesis/Views/SettingsView.xaml.cs
@@ -162,6 +162,18 @@ namespace Anamnesis.GUI.Views
 			SettingsService.Current.DefaultPoseDirectory = FileService.ParseFromFilePath(dlg.SelectedPath);
 		}
 
+		private void OnBrowseCamera(object sender, RoutedEventArgs e)
+		{
+			FolderBrowserDialog dlg = new FolderBrowserDialog();
+			dlg.SelectedPath = FileService.ParseToFilePath(SettingsService.Current.DefaultCameraShotDirectory);
+			DialogResult result = dlg.ShowDialog();
+
+			if (result != DialogResult.OK)
+				return;
+
+			SettingsService.Current.DefaultCameraShotDirectory = FileService.ParseFromFilePath(dlg.SelectedPath);
+		}
+
 		private void OnBrowseScene(object sender, RoutedEventArgs e)
 		{
 			FolderBrowserDialog dlg = new FolderBrowserDialog();


### PR DESCRIPTION
Ok, this is take 2 for this.

So after more investigation I figured out that all the math was correct.

The issue is that it's impossible to recreate some shots when you consider the actor rotation as the camera can't go over the head or under the legs fully (if you were flat in the world, the restriction is in world space).

The approach I have taken this time is to just assume the character is always flat on the ground (so we only consider the direction they are facing in one plane).

This way, you will get the overall camera relative to the actor, and you just need to load a pose on them that includes the other rotations and then they will be framed correctly.

I think overall this is a good compromise as it gets you 100% of what you want in most cases, and 99% of the way in the few cases where the actual actor is rotated forward/backward or side/side in the world.