### PR TITLE
Sub Actor Mount Fix

### DIFF
--- a/Anamnesis/Actor/Utilities/SubActorUtility.cs
+++ b/Anamnesis/Actor/Utilities/SubActorUtility.cs
@@ -65,7 +65,7 @@ public class SubActorUtility
 		try
 		{
 			CharacterFile apFile = npc.ToFile();
-			await apFile.Apply(targetActor, CharacterFile.SaveModes.None);
+			await apFile.Apply(targetActor, CharacterFile.SaveModes.EquipmentGear);
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Mounts which require gear like Chocobos and Amaros will be blank when selected as sub actors.
Now that gear selection for mounts is working, we should load the default gearsets for a mount.