### PR TITLE
Dev Address Copying

### DIFF
--- a/Anamnesis/Tabs/DeveloperTab.xaml
+++ b/Anamnesis/Tabs/DeveloperTab.xaml
@@ -36,5 +36,27 @@
 			
 		</GroupBox>
 
-	</Grid>
+        <GroupBox Style="{StaticResource PanelGroupBox}" Grid.Column="1">
+            <GroupBox.Header>
+                <controls:Header Icon="Running" Text="Actor"/>
+            </GroupBox.Header>
+
+            <StackPanel>
+                <Button Content="Copy Actor Address"
+                        IsEnabled="{Binding TargetService.PlayerTarget.IsValid}"
+						Style="{StaticResource TransparentButton}"
+						Height="32"
+						Click="OnCopyActorAddressClicked"/>
+                
+                <Button Content="Copy Associated Addresses"
+                        IsEnabled="{Binding TargetService.PlayerTarget.IsValid}"
+						Style="{StaticResource TransparentButton}"
+						Height="32"
+						Click="OnCopyAssociatedAddressesClick"/>
+
+            </StackPanel>
+
+        </GroupBox>
+
+    </Grid>
 </UserControl>

--- a/Anamnesis/Tabs/DeveloperTab.xaml.cs
+++ b/Anamnesis/Tabs/DeveloperTab.xaml.cs
@@ -9,6 +9,8 @@ using Anamnesis.Memory;
 using Anamnesis.Services;
 using Anamnesis.Utils;
 using Anamnesis.Views;
+using Serilog;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using XivToolsWpf.Selectors;
@@ -23,6 +25,8 @@ public partial class DeveloperTab : UserControl
 		this.InitializeComponent();
 		this.ContentArea.DataContext = this;
 	}
+
+	public TargetService TargetService => TargetService.Instance;
 
 	private void OnNpcNameSearchClicked(object sender, RoutedEventArgs e)
 	{
@@ -48,5 +52,55 @@ public partial class DeveloperTab : UserControl
 
 			NpcAppearanceSearch.Search(memory);
 		});
+	}
+
+	private void OnCopyActorAddressClicked(object sender, RoutedEventArgs e)
+	{
+		ActorBasicMemory memory = this.TargetService.PlayerTarget;
+
+		if (!memory.IsValid)
+		{
+			Log.Warning("Actor is invalid");
+			return;
+		}
+
+		string address = memory.Address.ToString("X");
+
+		ClipboardUtility.CopyToClipboard(address);
+	}
+
+	private void OnCopyAssociatedAddressesClick(object sender, RoutedEventArgs e)
+	{
+		ActorBasicMemory abm = this.TargetService.PlayerTarget;
+
+		if (!abm.IsValid)
+		{
+			Log.Warning("Actor is invalid");
+			return;
+		}
+
+		try
+		{
+			ActorMemory memory = new();
+			memory.SetAddress(abm.Address);
+
+			StringBuilder sb = new();
+
+			sb.AppendLine("Base: " + memory.Address.ToString("X"));
+			sb.AppendLine("Model: " + (memory.ModelObject?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Extended Appearance: " + (memory.ModelObject?.ExtendedAppearance?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Skeleton: " + (memory.ModelObject?.Skeleton?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Main Hand Model: " + (memory.MainHand?.Model?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Off Hand Model: " + (memory.OffHand?.Model?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Mount: " + (memory.Mount?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Companion: " + (memory.Companion?.Address.ToString("X") ?? "0"));
+			sb.AppendLine("Ornament: " + (memory.Ornament?.Address.ToString("X") ?? "0"));
+
+			ClipboardUtility.CopyToClipboard(sb.ToString());
+		}
+		catch
+		{
+			Log.Warning("Could not read addresses");
+		}
 	}
 }


### PR DESCRIPTION
This adds the ability to copy some common memory addresses from the dev tab which are super useful when working out new offsets. 
It copies for the currently targeted actor. 