### PR TITLE
Refresh System

### DIFF
--- a/Anamnesis/Actor/Posing/Services/PoseService.cs
+++ b/Anamnesis/Actor/Posing/Services/PoseService.cs
@@ -35,6 +35,7 @@ public class PoseService : ServiceBase<PoseService>
 	public delegate void PoseEvent(bool value);
 
 	public static event PoseEvent? EnabledChanged;
+	public static event PoseEvent? FreezeWorldPositionsEnabledChanged;
 
 	public static string? SelectedBoneName { get; set; }
 
@@ -124,6 +125,7 @@ public class PoseService : ServiceBase<PoseService>
 			this.freezeGposeTargetPosition2?.SetEnabled(value);
 			this.RaisePropertyChanged(nameof(PoseService.FreezeWorldPosition));
 			this.RaisePropertyChanged(nameof(PoseService.WorldPositionNotFrozen));
+			FreezeWorldPositionsEnabledChanged?.Invoke(this.IsEnabled);
 		}
 	}
 

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -1,0 +1,44 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Actor.Refresh;
+
+using System.Threading.Tasks;
+using Anamnesis.Memory;
+using static Anamnesis.Memory.ActorBasicMemory;
+
+public class AnamnesisActorRefresher : IActorRefresher
+{
+	public bool CanRefresh(ActorMemory actor)
+	{
+		// Ana can't refresh gpose actors
+		if (actor.IsGPoseActor)
+			return false;
+
+		return true;
+	}
+
+	public async Task RefreshActor(ActorMemory actor)
+	{
+		await Task.Delay(16);
+
+		if (actor.ObjectKind == ActorTypes.Player)
+		{
+			actor.ObjectKind = ActorTypes.BattleNpc;
+			actor.RenderMode = RenderModes.Unload;
+			await Task.Delay(75);
+			actor.RenderMode = RenderModes.Draw;
+			await Task.Delay(75);
+			actor.ObjectKind = ActorTypes.Player;
+			actor.RenderMode = RenderModes.Draw;
+		}
+		else
+		{
+			actor.RenderMode = RenderModes.Unload;
+			await Task.Delay(75);
+			actor.RenderMode = RenderModes.Draw;
+		}
+
+		await Task.Delay(150);
+	}
+}

--- a/Anamnesis/Actor/Refresh/IActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/IActorRefresher.cs
@@ -1,0 +1,13 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Actor.Refresh;
+
+using System.Threading.Tasks;
+using Anamnesis.Memory;
+
+public interface IActorRefresher
+{
+	public bool CanRefresh(ActorMemory actor);
+	public Task RefreshActor(ActorMemory actor);
+}

--- a/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
@@ -1,0 +1,44 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Actor.Refresh;
+
+using System.Threading.Tasks;
+using Anamnesis.Memory;
+using Anamnesis.Services;
+using static Anamnesis.Memory.ActorBasicMemory;
+
+public class PenumbraActorRefresher : IActorRefresher
+{
+	public bool CanRefresh(ActorMemory actor)
+	{
+		// Only if Penumbra integration is really enabled
+		if (!SettingsService.Current.UseExternalRefresh)
+			return false;
+
+		// Penumbra can't refresh overworld actors in gpose
+		if (GposeService.Instance.IsGpose && actor.IsOverworldActor)
+			return false;
+
+		// Only if the actor has a name
+		if (string.IsNullOrEmpty(actor.Name))
+			return false;
+
+		return true;
+	}
+
+	public async Task RefreshActor(ActorMemory actor)
+	{
+		if (actor.ObjectKind == ActorTypes.Player)
+		{
+			actor.ObjectKind = ActorTypes.BattleNpc;
+			await Penumbra.Penumbra.Redraw(actor.Name);
+			await Task.Delay(200);
+			actor.ObjectKind = ActorTypes.Player;
+		}
+		else
+		{
+			await Penumbra.Penumbra.Redraw(actor.Name);
+		}
+	}
+}

--- a/Anamnesis/Memory/ActorBasicMemory.cs
+++ b/Anamnesis/Memory/ActorBasicMemory.cs
@@ -16,7 +16,7 @@ public class ActorBasicMemory : MemoryBase
 {
 	private ActorBasicMemory? owner;
 
-	public enum RenderModes : int
+	public enum RenderModes : uint
 	{
 		Draw = 0,
 		Unload = 2,
@@ -34,7 +34,7 @@ public class ActorBasicMemory : MemoryBase
 	[Bind(0x0104)] public RenderModes RenderMode { get; set; }
 
 	public string Id => $"n{this.NameHash}_d{this.DataId}_o{this.Address}";
-	public string IdNoAddress => $"n{this.NameHash}_d{this.DataId}";
+	public string IdNoAddress => $"n{this.NameHash}_d{this.DataId}_k{this.ObjectKind}";
 
 	public IconChar Icon => this.ObjectKind.GetIcon();
 	public double DistanceFromPlayer => Math.Sqrt(((int)this.DistanceFromPlayerX ^ 2) + ((int)this.DistanceFromPlayerY ^ 2));
@@ -51,26 +51,6 @@ public class ActorBasicMemory : MemoryBase
 
 	[DependsOn(nameof(RenderMode))]
 	public bool IsHidden => this.RenderMode != RenderModes.Draw;
-
-	[DependsOn(nameof(IsOverworldActor))]
-	public bool CanRefresh
-	{
-		get
-		{
-			if (PoseService.Instance.IsEnabled)
-				return false;
-
-			if (PoseService.Instance.FreezeWorldPosition)
-				return false;
-
-			// If there is some sort of external refresh service
-			// assume we can always refresh.
-			if (SettingsService.Current.UseExternalRefresh)
-				return true;
-
-			return this.IsOverworldActor;
-		}
-	}
 
 	/// <summary>
 	/// Gets the Nickname or if not set, the Name.

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Anamnesis.Actor;
 using Anamnesis.Core.Memory;
 using Anamnesis.Keyboard;
 using Anamnesis.Memory;
@@ -219,6 +220,10 @@ public class TargetService : ServiceBase<TargetService>
 		HotkeyService.RegisterHotkeyHandler("TargetService.NextPinned", () => this.NextPinned());
 		HotkeyService.RegisterHotkeyHandler("TargetService.PrevPinned", () => this.PrevPinned());
 
+		GposeService.GposeStateChanged += this.GposeService_GposeStateChanged;
+		PoseService.EnabledChanged += this.PoseService_EnabledChanged;
+		PoseService.FreezeWorldPositionsEnabledChanged += this.PoseService_EnabledChanged;
+
 #if DEBUG
 		if (MemoryService.Process == null)
 		{
@@ -259,6 +264,14 @@ public class TargetService : ServiceBase<TargetService>
 		}
 
 		_ = Task.Run(this.TickPinnedActors);
+	}
+
+	public override Task Shutdown()
+	{
+		GposeService.GposeStateChanged -= this.GposeService_GposeStateChanged;
+		PoseService.EnabledChanged -= this.PoseService_EnabledChanged;
+		PoseService.FreezeWorldPositionsEnabledChanged -= this.PoseService_EnabledChanged;
+		return base.Shutdown();
 	}
 
 	public void ClearSelection()
@@ -400,6 +413,21 @@ public class TargetService : ServiceBase<TargetService>
 			this.UpdatePlayerTarget();
 		}
 	}
+
+	private void RefreshActorRefreshStatus()
+	{
+		foreach(var pin in this.PinnedActors)
+		{
+			if(pin.Memory?.IsValid == true)
+			{
+				pin.Memory.RaiseRefreshChanged();
+			}
+		}
+	}
+
+	private void GposeService_GposeStateChanged(bool newState) => this.RefreshActorRefreshStatus();
+
+	private void PoseService_EnabledChanged(bool value) => this.RefreshActorRefreshStatus();
 
 	[AddINotifyPropertyChangedInterface]
 	public class PinnedActor : INotifyPropertyChanged
@@ -594,10 +622,6 @@ public class TargetService : ServiceBase<TargetService>
 						// Don't consider hidden actors for retargeting
 						if (actor.IsHidden)
 							continue;
-
-						// Don't consider overworld actors while we are in gpose
-						////if (isGPose && actor.IsOverworldActor)
-						////	continue;
 
 						// Is this actor memory already pinned to a differnet pin?
 						PinnedActor? pinned = TargetService.GetPinned(actor);

--- a/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
+++ b/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
@@ -38,7 +38,7 @@ public static class ActorTypesExtensions
 			case ActorTypes.Retainer: return IconChar.ConciergeBell;
 			case ActorTypes.Housing: return IconChar.Chair;
 			case ActorTypes.Mount: return IconChar.Horse;
-			case ActorTypes.Ornament: return IconChar.PiedPiperHat;
+			case ActorTypes.Ornament: return IconChar.HatCowboy;
 		}
 
 		return IconChar.Question;


### PR DESCRIPTION
This is a fairly major reshuffle of how refresh works.

`IActorRefresher` represents a specific type of actor refresh (Say `AnamnesisActorRefresh` vs `PenumbraActorRefresh`). They have a priority and the system will determine the first refresher in the list that can refresh an actor of a given type/state and then use that.

This allows us to have custom logic, so for example Penumbra can't refresh actors without a name such as Mounts, so Ana refresh will be used in those cases where it can be. If no service can refresh then it's considered CanRefresh is false.

Also hooked up some more events to correctly update the UI when Pose Mode, Freeze World Position etc is toggled, the refresh status will be checked again. 

Also enables us to add new Refreshers into that priority list really easily, and the logic is self contained for each refresher.

This fixes a ton of issues that are currently present when you have only Penum or Ana refresh.