### PR TITLE
Semantic version matching for DotNet install

### DIFF
--- a/Bootstrap/Bootstrap.csproj
+++ b/Bootstrap/Bootstrap.csproj
@@ -28,4 +28,8 @@
     <EmbeddedResource Include="..\Anamnesis\bin\publish\Anamnesis.exe" Link="Anamnesis.exe" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SemanticVersioning" Version="2.0.2" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This uses semantic versioning to check the DotNet install.
The current match I have added is basically `>=6.0.4 && <7.0.0`

Bumped the version it downloads to 6.0.5, it will only do this for people who don't have 6.0.4 yet though.

Seems like some folks are also timing out on the download with the default 100 second limit, I've bumped that to 60 minutes for now, but without a progress bar it may still be confusing to people.

Resolves #1088 