### PR TITLE
Speed control link tooltip

### DIFF
--- a/Anamnesis/Actor/Pages/ActionPage.xaml
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml
@@ -201,7 +201,7 @@
 
                         <ToggleButton Grid.Column="0" Grid.Row="0" Style="{StaticResource TransparentIconToggleButton}" IsChecked="{Binding Actor.Animation.LinkSpeeds}">
                             <ToggleButton.ToolTip>
-                                <XivToolsWpf:TextBlock Key="Common_LinkVector"/>
+                                <XivToolsWpf:TextBlock Key="Character_Action_LinkSpeed"/>
                             </ToggleButton.ToolTip>
 
                             <Grid>

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -301,6 +301,7 @@
 	"Character_Action_GlobalFreezeWorldPositions": "Freeze Positions",
 	"Character_Action_GlobalFreezeWorldPositionsTooltip": "Freeze Actor/Camera World Positions",
 	"Character_Action_GlobalSpeedControl": "Speed Control",
+	"Character_Action_LinkSpeed": "Link speed control for all animation slots",
 	"Pose_WarningNotGPose": "Posing is only available while in Group Pose. Type /gpose in chat.",
 	"Pose_WarningNotFrozen": "Actor motion must be disabled in the Group Pose settings, or Freeze Positions must be enabled in the pose options.",
 	"Pose_WarningQuit": "Are you sure you want to quit? Current pose will be lost.",


### PR DESCRIPTION
Was showing the vector axis text still which is obviously incorrect in this case.