### PR TITLE
Show window title in process selector

### DIFF
--- a/Anamnesis/Windows/ProcessSelector.xaml
+++ b/Anamnesis/Windows/ProcessSelector.xaml
@@ -58,8 +58,17 @@
 								</DataTemplate>
 							</DataGridTemplateColumn.CellTemplate>
 						</DataGridTemplateColumn>
-
-						<DataGridTextColumn Header="Process" Binding="{Binding Name}" Width="256"/>
+						<DataGridTemplateColumn Header="Process" Width="256">
+							<DataGridTemplateColumn.CellTemplate>
+								<DataTemplate>
+									<StackPanel Orientation="Horizontal">
+										<TextBlock Text="{Binding Name}"></TextBlock>
+										<TextBlock Text="  "></TextBlock>
+										<TextBlock Text="{Binding WindowTitle}"></TextBlock>
+									</StackPanel>
+								</DataTemplate>
+							</DataGridTemplateColumn.CellTemplate>
+						</DataGridTemplateColumn>
 						<DataGridTextColumn Header="Started" Binding="{Binding StartTime}"/>
 					</DataGrid.Columns>
 				</DataGrid>

--- a/Anamnesis/Windows/ProcessSelector.xaml.cs
+++ b/Anamnesis/Windows/ProcessSelector.xaml.cs
@@ -185,6 +185,7 @@ public partial class ProcessSelector : UserControl
 		{
 			this.Process = process;
 			this.Name = process.ProcessName;
+			this.WindowTitle = process.MainWindowTitle;
 			this.Id = process.Id;
 
 			try
@@ -210,6 +211,7 @@ public partial class ProcessSelector : UserControl
 
 		public bool Locked { get; }
 		public string Name { get; }
+		public string WindowTitle { get; }
 		public int Id { get; }
 		public DateTime? StartTime { get; }
 		public ImageSource? AppIcon { get; }


### PR DESCRIPTION
Show Window Title as well as exe name in the process selector to improve usability for people who run multiple clients.