### PR TITLE
Use index for penumbra refresh

### DIFF
--- a/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
@@ -20,10 +20,6 @@ public class PenumbraActorRefresher : IActorRefresher
 		if (GposeService.Instance.IsGpose && actor.IsOverworldActor)
 			return false;
 
-		// Only if the actor has a name
-		if (string.IsNullOrEmpty(actor.Name))
-			return false;
-
 		return true;
 	}
 
@@ -32,13 +28,13 @@ public class PenumbraActorRefresher : IActorRefresher
 		if (actor.ObjectKind == ActorTypes.Player)
 		{
 			actor.ObjectKind = ActorTypes.BattleNpc;
-			await Penumbra.Penumbra.Redraw(actor.Name);
+			await Penumbra.Penumbra.Redraw(actor.ObjectIndex);
 			await Task.Delay(200);
 			actor.ObjectKind = ActorTypes.Player;
 		}
 		else
 		{
-			await Penumbra.Penumbra.Redraw(actor.Name);
+			await Penumbra.Penumbra.Redraw(actor.ObjectIndex);
 		}
 	}
 }

--- a/Anamnesis/Penumbra/Penumbra.cs
+++ b/Anamnesis/Penumbra/Penumbra.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 
 public static class Penumbra
 {
-	public static async Task Redraw(string targetName)
+	public static async Task Redraw(int targetIndex)
 	{
 		RedrawData data = new();
-		data.Name = targetName;
-		data.Type = RedrawData.RedrawType.WithSettings;
+		data.ObjectTableIndex = targetIndex;
+		data.Type = RedrawData.RedrawType.Redraw;
 
 		await PenumbraApi.Post("/redraw", data);
 
@@ -22,17 +22,12 @@ public static class Penumbra
 	{
 		public enum RedrawType
 		{
-			WithoutSettings,
-			WithSettings,
-			OnlyWithSettings,
-			Unload,
-			RedrawWithoutSettings,
-			RedrawWithSettings,
-			AfterGPoseWithSettings,
-			AfterGPoseWithoutSettings,
+			Redraw,
+			AfterGPose,
 		}
 
 		public string Name { get; set; } = string.Empty;
-		public RedrawType Type { get; set; } = RedrawType.WithSettings;
+		public int ObjectTableIndex { get; set; } = -1;
+		public RedrawType Type { get; set; } = RedrawType.Redraw;
 	}
 }


### PR DESCRIPTION
Switches to using the actor index for Penumbra refresh. 

Still can't reload overworld objects within GPose as penum will attempt to remap. That would be another useful change to make on the penum side at some point.