### PR TITLE
Use DPI scale for ScreenUtils.IsOnScreen

### DIFF
--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using Anamnesis;
 using Anamnesis.GUI.Dialogs;
 using Anamnesis.GUI.Views;
@@ -118,6 +119,11 @@ public partial class MainWindow : ChromedWindow
 	{
 		get => this.Tab == Tabs.Developer;
 		set => this.Tab = Tabs.Developer;
+	}
+
+	public static DpiScale GetDpi()
+	{
+		return VisualTreeHelper.GetDpi(instance);
 	}
 
 	protected override void OnActivated(EventArgs e)

--- a/Anamnesis/Utils/ScreenUtils.cs
+++ b/Anamnesis/Utils/ScreenUtils.cs
@@ -4,16 +4,19 @@
 namespace Anamnesis.Utils;
 
 using System.Windows.Forms;
+using System.Windows;
 
 public static class ScreenUtils
 {
-	public static bool IsOnScreen(System.Windows.Point val)
+	public static bool IsOnScreen(Point val)
 	{
+		var dpi = GUI.MainWindow.GetDpi();
+
 		bool found = false;
 
 		foreach (Screen screen in Screen.AllScreens)
 		{
-			found |= screen.Bounds.Contains(new System.Drawing.Point((int)val.X, (int)val.Y));
+			found |= screen.Bounds.Contains(new System.Drawing.Point((int)(val.X * dpi.DpiScaleX), (int)(val.Y * dpi.DpiScaleY)));
 		}
 
 		return found;


### PR DESCRIPTION
This fixes a bug where the Anamnesis window can appear outside of the screen bounds when using a higher DPI, requiring the user to reset their settings.