### PR TITLE
Change memory flags when writing game code

### DIFF
--- a/Anamnesis/Core/Memory/NopHookViewModel.cs
+++ b/Anamnesis/Core/Memory/NopHookViewModel.cs
@@ -50,12 +50,12 @@ public class NopHookViewModel
 		if (enabled)
 		{
 			// Write Nop
-			MemoryService.Write(this.address, this.nopValue);
+			MemoryService.Write(this.address, this.nopValue, true);
 		}
 		else
 		{
 			// Write the original value
-			MemoryService.Write(this.address, this.originalValue);
+			MemoryService.Write(this.address, this.originalValue, true);
 		}
 	}
 }

--- a/Anamnesis/Memory/TimeMemory.cs
+++ b/Anamnesis/Memory/TimeMemory.cs
@@ -53,6 +53,6 @@ public class TimeMemory
 	public void SetTime(long newTime)
 	{
 		// As long as Eorzea Time updating is disabled we can just set it directly
-		MemoryService.Write(AddressService.TimeReal, BitConverter.GetBytes(newTime));
+		MemoryService.Write(AddressService.TimeReal, BitConverter.GetBytes(newTime), false);
 	}
 }


### PR DESCRIPTION
(Fix for Apple Silicon not working correctly)

* This correctly flags memory as RWX when we overwrite FFXIV code.
* Windows x64 mostly lets you get away with not doing this, but stricter archs such as Apple Silicon need it.

Resolves #1171