### PR TITLE
Fix Weapon Tint

### DIFF
--- a/Anamnesis/Memory/WeaponSubModelMemory.cs
+++ b/Anamnesis/Memory/WeaponSubModelMemory.cs
@@ -6,7 +6,7 @@ namespace Anamnesis.Memory;
 public class WeaponSubModelMemory : MemoryBase
 {
 	[Bind(0x070)] public Vector Scale { get; set; }
-	[Bind(0x258)] public Color Tint { get; set; }
+	[Bind(0x260)] public Color Tint { get; set; }
 
 	public bool IsHidden
 	{


### PR DESCRIPTION
Changing the weapon tint currently causes a CTD.
Looks like the offset moved in 6.2 and we just didn't notice.