### PR TITLE
Disable and uncheck NPC Face when Penumbra API is turned on.

### DIFF
--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -38,6 +38,7 @@ public class AnamnesisActorRefresher : IActorRefresher
 			await Task.Delay(75);
 			actor.RenderMode = RenderModes.Draw;
 		}
+
 		await Task.Delay(150);
 	}
 }

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -24,13 +24,13 @@ public class AnamnesisActorRefresher : IActorRefresher
 		await Task.Delay(16);
 		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
 		{
-				actor.ObjectKind = ActorTypes.BattleNpc;
-				actor.RenderMode = RenderModes.Unload;
-				await Task.Delay(75);
-				actor.RenderMode = RenderModes.Draw;
-				await Task.Delay(75);
-				actor.ObjectKind = ActorTypes.Player;
-				actor.RenderMode = RenderModes.Draw;
+			actor.ObjectKind = ActorTypes.BattleNpc;
+			actor.RenderMode = RenderModes.Unload;
+			await Task.Delay(75);
+			actor.RenderMode = RenderModes.Draw;
+			await Task.Delay(75);
+			actor.ObjectKind = ActorTypes.Player;
+			actor.RenderMode = RenderModes.Draw;
 		}
 		else
 		{

--- a/Anamnesis/Languages/de.json
+++ b/Anamnesis/Languages/de.json
@@ -613,7 +613,7 @@
 	"Settings_UseExternalRefresh": "Penumbra Redraw benutzen",
 	"Settings_UseExternalRefreshWarning": "Benötigt aktivierte Penumbra HTTP API.",
 	"Settings_EnableNpcHack": "Aktiviere NPC Gesichter auf PCs",
-	"Settings_EnableNpcHackWarning": "Mit dieser Option kannst du NPC Gesichter ausserhalb von GPose auf deinem Character nutzen, jedoch werden Penumbra Kollektionen nicht in GPose übertragen. Beachte das NPC Gesichter innerhalb GPose auch hiermit nicht möglich sind.",
+	"Settings_EnableNpcHackWarning": "NPC Gesichter werden nur ausserhalb von GPose funktionieren. Penumbra Kollektionen funktionieren hiermit nicht mehr. Funktioniert nur ohne Penumbra API",
 	"Settings_GameHotkeysTooltip": "Hotkeys verwenden wenn FFXIV im Fokus ist und man in GPose ist.\nDies verhindert, das FFXIV folgende Hotkeys registriert.",
 	"Settings_EnableHotkeys": "Hotkeys aktivieren",
 	"Settings_EnableHotkeys_Tooltip": "Auf Tastendrücke reagieren und Hotkeys ausführen",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -612,7 +612,7 @@
 	"Settings_UseExternalRefresh": "Use Penumbra Redraw",
 	"Settings_UseExternalRefreshWarning": "Requires the Penumbra HTTP API to be enabled in Penumbra. This option is found under the Advanced section of the Settings tab of the plugin. .",
 	"Settings_EnableNpcHack": "Enable NPC Faces on PC",
-	"Settings_EnableNpcHackWarning": "This option enables NPC Option on your Character outside of GPose, but it will break Penumbra Collections when entering GPose. Note that even with this, NPC options will not persist on PCs in GPose.",
+	"Settings_EnableNpcHackWarning": "NPC Faces will only work outside of GPose. This will break Penumbra Collections. Currently only works with the API turned off.",
 	"Settings_GameHotkeysTooltip": "Enable the use of hotkeys even when FFXIV has focus while in GPose.\nThis will prevent FFXIV from recieving the used keys.",
 	"Settings_EnableHotkeys": "Enable Hotkeys",
 	"Settings_EnableHotkeys_Tooltip": "Enable listening for keys and performing actions",

--- a/Anamnesis/Tabs/SettingsTab.xaml
+++ b/Anamnesis/Tabs/SettingsTab.xaml
@@ -265,13 +265,28 @@
 					</Grid.RowDefinitions>
 
 					<XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="0" Key="Settings_UseExternalRefresh" Style="{StaticResource Label}"/>
-					<CheckBox IsChecked="{Binding SettingsService.Settings.UseExternalRefresh}" Grid.Column="1" Grid.Row="0" Margin="6"/>
+                    <CheckBox IsChecked="{Binding SettingsService.Settings.UseExternalRefresh}" Grid.Column="1" Grid.Row="0" Margin="6" x:Name="Settings_UseExternalRefresh"/>
 
 					<XivToolsWPF:InfoControl Grid.Row="1" Key="Settings_UseExternalRefreshWarning" Width="237" Grid.ColumnSpan="2"/>
 
                     <XivToolsWPF:TextBlock Grid.Column="0" Grid.Row="2" Key="Settings_EnableNpcHack" Style="{StaticResource Label}"/>
-                    <CheckBox IsChecked="{Binding SettingsService.Settings.EnableNpcHack}" Grid.Column="1" Grid.Row="2" Margin="6"/>
-
+                    <CheckBox Grid.Column="1" Grid.Row="2" Margin="6">
+                        <CheckBox.Style>
+                            <Style TargetType="CheckBox" BasedOn="{StaticResource MaterialDesignCheckBox}">
+                                <Setter Property="IsChecked" Value="{Binding SettingsService.Settings.EnableNpcHack}"></Setter>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=Settings_UseExternalRefresh,Path=IsChecked}" Value="True">
+                                        <Setter Property="IsChecked" Value="False"/>
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ElementName=Settings_UseExternalRefresh,Path=IsChecked}" Value="False">
+                                        <Setter Property="IsEnabled" Value="True"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </CheckBox.Style>
+                    </CheckBox>
+                    
                     <XivToolsWPF:InfoControl Grid.Row="3" Key="Settings_EnableNpcHackWarning" Width="237" Grid.ColumnSpan="2"/>
                 </Grid>
 			</GroupBox>


### PR DESCRIPTION
Seeing how the NPC face doesnt survive a redraw with penumbra anyway, disabling the checkbox and locking it sounded appropriate. If people are using the API they can load the NPC inside Gpose directly anyway. 