### PR TITLE
Do not crash when Brio call fails

### DIFF
--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -25,6 +25,7 @@ using PropertyChanged;
 using XivToolsWpf;
 using XivToolsWpf.Windows;
 using XivToolsWpf.Extensions;
+using Serilog;
 
 /// <summary>
 /// Interaction logic for MainWindow.xaml.
@@ -326,9 +327,16 @@ public partial class MainWindow : ChromedWindow
 			if (!actor.IsValid || actor.Memory == null)
 				return;
 
-			if(await Brio.Brio.Despawn(actor.Memory.ObjectIndex))
+			try
 			{
-				TargetService.UnpinActor(actor);
+				if (await Brio.Brio.Despawn(actor.Memory.ObjectIndex))
+				{
+					TargetService.UnpinActor(actor);
+				}
+			}
+			catch(Exception ex)
+			{
+				Log.Error("Failed to despawn actor", ex);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1291 

The root cause here is that if anything at all went wrong, Ana would crash and leave freeze positions and posing mode patches active.

There are any number of reasons Brio could fail to spawn or despawn an actor, so Ana should not crash but just display an error.