### PR TITLE
Fix Camera Angle Freeze

### DIFF
--- a/Anamnesis/Core/Memory/AddressService.cs
+++ b/Anamnesis/Core/Memory/AddressService.cs
@@ -40,6 +40,8 @@ public class AddressService : ServiceBase<AddressService>
 	public static IntPtr Framework { get; set; }
 	public static IntPtr PlayerTargetSystem { get; set; }
 	public static IntPtr AnimationSpeedPatch { get; set; }
+	public static IntPtr CameraAngleXFreeze { get; set; }
+	public static IntPtr CameraAngleYFreeze { get; set; }
 
 	public static IntPtr Camera
 	{
@@ -143,6 +145,8 @@ public class AddressService : ServiceBase<AddressService>
 		tasks.Add(this.GetAddressFromSignature("GPose", "48 39 0D ?? ?? ?? ?? 75 28", 0, (p) => { GPose = p + 0x20; }));
 		tasks.Add(this.GetAddressFromSignature("Camera", "48 8D 35 ?? ?? ?? ?? 48 8B 09", 0, (p) => { cameraManager = p; })); // CameraAddress
 		tasks.Add(this.GetAddressFromSignature("PlayerTargetSystem", "48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 50 ?? 48 85 DB", 0, (p) => { PlayerTargetSystem = p; }));
+		tasks.Add(this.GetAddressFromTextSignature("CameraAngleXFreeze", "F3 0F 11 83 30 01 00 00 48 83 C4 20 5B C3", (p) => { CameraAngleXFreeze = p; }));
+		tasks.Add(this.GetAddressFromTextSignature("CameraAngleYFreeze", "89 83 34 01 00 00 F3 0F 10 83 40 01 00 00", (p) => { CameraAngleYFreeze = p; }));
 
 		tasks.Add(this.GetAddressFromTextSignature("TimeAsm", "48 89 87 ?? ?? ?? ?? 48 69 C0", (p) => TimeAsm = p));
 

--- a/Anamnesis/Services/CameraService.cs
+++ b/Anamnesis/Services/CameraService.cs
@@ -11,6 +11,9 @@ using Anamnesis.Services;
 
 public class CameraService : ServiceBase<CameraService>
 {
+	private NopHookViewModel? freezeCameraAngleX;
+	private NopHookViewModel? freezeCameraAngleY;
+
 	private bool delimitCamera;
 
 	public CameraMemory Camera { get; set; } = new CameraMemory();
@@ -36,9 +39,27 @@ public class CameraService : ServiceBase<CameraService>
 		}
 	}
 
+	public bool FreezeAngle
+	{
+		get
+		{
+			return this.Camera.FreezeAngle;
+		}
+		set
+		{
+			this.Camera.FreezeAngle = value;
+
+			this.freezeCameraAngleX?.SetEnabled(value);
+			this.freezeCameraAngleY?.SetEnabled(value);
+		}
+	}
+
 	public override async Task Start()
 	{
 		await base.Start();
+
+		this.freezeCameraAngleX = new NopHookViewModel(AddressService.CameraAngleXFreeze, 8);
+		this.freezeCameraAngleY = new NopHookViewModel(AddressService.CameraAngleYFreeze, 6);
 
 		_ = Task.Run(this.Tick);
 	}
@@ -72,7 +93,7 @@ public class CameraService : ServiceBase<CameraService>
 				if (!GposeService.Instance.IsGpose)
 				{
 					this.DelimitCamera = false;
-					this.Camera.FreezeAngle = false;
+					this.FreezeAngle = false;
 				}
 				else
 				{

--- a/Anamnesis/Views/CameraEditor.xaml
+++ b/Anamnesis/Views/CameraEditor.xaml
@@ -80,7 +80,7 @@
 									Width="22"
 									Padding="0"
 									Margin="0"
-									IsChecked="{Binding CameraService.Camera.FreezeAngle}">
+									IsChecked="{Binding CameraService.FreezeAngle}">
 					
 					<ToggleButton.Content>
 						<fa:IconBlock Icon="LockOpen"


### PR DESCRIPTION
Partially fixes #1207 

Adds hooks that freeze the Camera Angle, like the Time freeze.
This prevents unwanted movement in the X axis when positioning the camera, and disables the angle positioning button (right click by default) to achieve this.

Why it "partially fixes" the mentioned issue? Well, because the first unexpected behavior is fixed with this, but I don't fully know whether the second one is intentional or not. The time controller also has a slider which ignores the lock icon, because otherwise you can't set the time, and in this case the camera angle. That's why I left that as is.