### PR TITLE
Freeze GPose Camera Position

### DIFF
--- a/Anamnesis/Core/Memory/AddressService.cs
+++ b/Anamnesis/Core/Memory/AddressService.cs
@@ -42,6 +42,7 @@ public class AddressService : ServiceBase<AddressService>
 	public static IntPtr AnimationSpeedPatch { get; set; }
 	public static IntPtr CameraAngleXFreeze { get; set; }
 	public static IntPtr CameraAngleYFreeze { get; set; }
+	public static IntPtr GPoseCameraPositionFreeze { get; set; }
 
 	public static IntPtr Camera
 	{
@@ -147,6 +148,7 @@ public class AddressService : ServiceBase<AddressService>
 		tasks.Add(this.GetAddressFromSignature("PlayerTargetSystem", "48 8B 05 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 50 ?? 48 85 DB", 0, (p) => { PlayerTargetSystem = p; }));
 		tasks.Add(this.GetAddressFromTextSignature("CameraAngleXFreeze", "F3 0F 11 83 30 01 00 00 48 83 C4 20 5B C3", (p) => { CameraAngleXFreeze = p; }));
 		tasks.Add(this.GetAddressFromTextSignature("CameraAngleYFreeze", "89 83 34 01 00 00 F3 0F 10 83 40 01 00 00", (p) => { CameraAngleYFreeze = p; }));
+		tasks.Add(this.GetAddressFromTextSignature("GPoseCameraPositionFreeze", "F3 0F 10 5E 08 49 8B CF F3 0F 10 56 04 F3 0F 10 0E E8", (p) => { GPoseCameraPositionFreeze = p + 0x11; }));
 
 		tasks.Add(this.GetAddressFromTextSignature("TimeAsm", "48 89 87 ?? ?? ?? ?? 48 69 C0", (p) => TimeAsm = p));
 

--- a/Anamnesis/Services/GposeService.cs
+++ b/Anamnesis/Services/GposeService.cs
@@ -14,6 +14,8 @@ public delegate void GposeEvent(bool newState);
 [AddINotifyPropertyChangedInterface]
 public class GposeService : ServiceBase<GposeService>
 {
+	private NopHookViewModel? freezePosition;
+
 	private bool initialized = false;
 
 	public static event GposeEvent? GposeStateChanged;
@@ -40,6 +42,8 @@ public class GposeService : ServiceBase<GposeService>
 
 	public override Task Start()
 	{
+		this.freezePosition = new NopHookViewModel(AddressService.GPoseCameraPositionFreeze, 5);
+
 		Task.Run(this.CheckThread);
 		return base.Start();
 	}
@@ -54,12 +58,14 @@ public class GposeService : ServiceBase<GposeService>
 			{
 				this.initialized = true;
 				this.IsGpose = newGpose;
+				this.freezePosition?.SetEnabled(newGpose);
 				continue;
 			}
 
 			if (newGpose != this.IsGpose)
 			{
 				this.IsGpose = newGpose;
+				this.freezePosition?.SetEnabled(newGpose);
 				GposeStateChanged?.Invoke(newGpose);
 			}
 


### PR DESCRIPTION
Fixes #1195 

Adds a nop hook that freezes the GPose camera position.
This prevents the camera position snapping back to the starting position.

While the issue is already closed, I think this is a better solution than just disabling motion in-game.