### PR TITLE
Make Overworld Actors fully redraw with Brio

### DIFF
--- a/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
@@ -33,7 +33,7 @@ public class BrioActorRefresher : IActorRefresher
 			redrawType |= RedrawType.ForceRedrawWeaponsOnOptimized;
 		}
 
-		if (actor.IsWeaponDirty && isPosing)
+		if (actor.IsOverworldActor || (actor.IsWeaponDirty && isPosing))
 		{
 			redrawType &= ~RedrawType.AllowOptimized;
 		}


### PR DESCRIPTION
This forces a full redraw when changing an overworld actor (basically the same as a Penumbra redraw), it resolves the issue with weapon animations and helmets caused by an optimized redraw.