### PR TITLE
XivTools -> AetherTools; Updates Newtonsoft.Json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Lib/XivToolsWpf"]
 	path = Lib/XivToolsWpf
-	url = https://github.com/XIV-Tools/XivToolsWpf
+	url = https://github.com/Aether-Tools/AetherToolsWpf
+	branch = Anamnesis


### PR DESCRIPTION
This will link the WPF Toolset from https://github.com/XIV-Tools/XivToolsWpf to https://github.com/Aether-Tools/AetherToolsWpf with branch = Anamnesis. At the same time said Branch has been updated to use a non-vulnerable version of Newtonsoft.Json. 
This is required in order to keep access to all build dependencies for the Maintainers. 