### PR TITLE
Fixes to clearing the second dye channel via middle mouse and with the "Remove All Equpment" and "Equip NPC Smallclothes" buttons

### DIFF
--- a/Anamnesis/Actor/Views/ItemView.xaml
+++ b/Anamnesis/Actor/Views/ItemView.xaml
@@ -158,7 +158,7 @@
 						</Grid>
 					</Grid>
 				</Button>
-				<Button MouseUp="OnDyeMouseUp2"
+				<Button MouseUp="OnDye2MouseUp"
 				        Margin="2, 4, 0, 0"
 				        Grid.Column="0"
 				        Grid.RowSpan="2"

--- a/Anamnesis/Actor/Views/ItemView.xaml
+++ b/Anamnesis/Actor/Views/ItemView.xaml
@@ -158,7 +158,7 @@
 						</Grid>
 					</Grid>
 				</Button>
-				<Button MouseUp="OnDyeMouseUp"
+				<Button MouseUp="OnDyeMouseUp2"
 				        Margin="2, 4, 0, 0"
 				        Grid.Column="0"
 				        Grid.RowSpan="2"

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -166,7 +166,7 @@ public partial class ItemView : UserControl
 		}
 	}
 
-	private void OnDyeMouseUp2(object sender, MouseButtonEventArgs e)
+	private void OnDye2MouseUp(object sender, MouseButtonEventArgs e)
 	{
 		if (this.Actor?.CanRefresh != true || this.ItemModel == null)
 			return;

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -166,6 +166,17 @@ public partial class ItemView : UserControl
 		}
 	}
 
+	private void OnDyeMouseUp2(object sender, MouseButtonEventArgs e)
+	{
+		if (this.Actor?.CanRefresh != true || this.ItemModel == null)
+			return;
+
+		if (e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Released)
+		{
+			this.ItemModel.Dye2 = 0;
+		}
+	}
+
 	private void SetItem(IItem? item, bool autoOffhand = false, bool forceMain = false, bool forceOff = false)
 	{
 		this.lockViewModel = true;

--- a/Anamnesis/Memory/IEquipmentItemMemory.cs
+++ b/Anamnesis/Memory/IEquipmentItemMemory.cs
@@ -9,6 +9,7 @@ public interface IEquipmentItemMemory : INotifyPropertyChanged
 {
 	ushort Base { get; set; }
 	byte Dye { get; set; }
+	byte Dye2 { get; set; }
 	ushort Set { get; set; }
 
 	public void Clear(bool isPlayer);

--- a/Anamnesis/Memory/ItemMemory.cs
+++ b/Anamnesis/Memory/ItemMemory.cs
@@ -21,6 +21,7 @@ public class ItemMemory : MemoryBase, IEquipmentItemMemory
 		this.Base = (ushort)(isPlayer ? 0 : 1);
 		this.Variant = 0;
 		this.Dye = 0;
+		this.Dye2 = 0;
 	}
 
 	public void Equip(IItem item)

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -85,5 +85,6 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 		this.Base = useEmperorsFists ? ItemUtility.EmperorsNewFists.ModelBase : (ushort)0;
 		this.Variant = useEmperorsFists ? ItemUtility.EmperorsNewFists.ModelVariant : (ushort)0;
 		this.Dye = 0;
+		this.Dye2 = 0;
 	}
 }


### PR DESCRIPTION
This pull request fixes some issues with clearing the second dye channel on the Character screen when modifying an actor. More specifically, the first commit of this pull request now allows users to clear the second dye channel on an item via middle mouse just like you can with the first dye channel. The second commit clears the second dye channel when the user clicks on the "Remove All Equipment" and "Equip NPC Smallclothes" buttons. For the "Equip NPC Smallclothes" button, only items that are normally cleared when clicking it will have the second dye channel removed.

