### PR TITLE
Tweaks for Importing Poses and Expressions

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -250,22 +250,22 @@ public partial class PosePage : UserControl
 
 	private async void OnImportClicked(object sender, RoutedEventArgs e)
 	{
-		await this.ImportPose(false, PoseFile.Mode.Rotation);
+		await this.ImportPose(false, PoseFile.Mode.Rotation, true);
 	}
 
 	private async void OnImportScaleClicked(object sender, RoutedEventArgs e)
 	{
-		await this.ImportPose(false, PoseFile.Mode.Scale);
+		await this.ImportPose(false, PoseFile.Mode.Scale, true);
 	}
 
 	private async void OnImportSelectedClicked(object sender, RoutedEventArgs e)
 	{
-		await this.ImportPose(true, PoseFile.Mode.Rotation);
+		await this.ImportPose(true, PoseFile.Mode.Rotation, false);
 	}
 
 	private async void OnImportAllClicked(object sender, RoutedEventArgs e)
 	{
-		await this.ImportPose(false, PoseFile.Mode.All);
+		await this.ImportPose(false, PoseFile.Mode.All, true);
 	}
 
 	private async void OnImportBodyClicked(object sender, RoutedEventArgs e)
@@ -273,10 +273,9 @@ public partial class PosePage : UserControl
 		if (this.Skeleton == null)
 			return;
 
-		this.Skeleton.SelectHead();
-		this.Skeleton.InvertSelection();
+		this.Skeleton.SelectBody();
 
-		await this.ImportPose(true, PoseFile.Mode.Rotation);
+		await this.ImportPose(true, PoseFile.Mode.Rotation, false);
 		this.Skeleton.ClearSelection();
 	}
 
@@ -296,11 +295,14 @@ public partial class PosePage : UserControl
 		}
 
 		this.Skeleton.SelectHead();
-		await this.ImportPose(true, PoseFile.Mode.Rotation | PoseFile.Mode.Scale);
+		await this.ImportPose(true, PoseFile.Mode.Rotation | PoseFile.Mode.Scale | PoseFile.Mode.Position, true);
 		this.Skeleton.ClearSelection();
 	}
 
-	private async Task ImportPose(bool selectionOnly, PoseFile.Mode mode)
+	// We want to skip doing the "Facial Expression Hack" if we're posing by selected bones or by body.
+	// Otherwise, the head won't pose as intended and will return to its original position.
+	// Not quite !selectedOnly, due to posing by expression actually needing the hack.
+	private async Task ImportPose(bool selectionOnly, PoseFile.Mode mode, bool doFacialExpressionHack)
 	{
 		try
 		{
@@ -351,7 +353,7 @@ public partial class PosePage : UserControl
 					}
 				}
 
-				await poseFile.Apply(this.Actor, this.Skeleton, bones, mode);
+				await poseFile.Apply(this.Actor, this.Skeleton, bones, mode, doFacialExpressionHack);
 			}
 		}
 		catch (Exception ex)

--- a/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
@@ -354,6 +354,18 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 		return bone;
 	}
 
+	public void SelectBody()
+	{
+		this.SelectHead();
+		this.InvertSelection();
+
+		List<BoneVisual3d> additionalBones = new List<BoneVisual3d>();
+		BoneVisual3d? headBone = this.GetBone("j_kao");
+		if (headBone != null)
+			additionalBones.Add(headBone);
+		this.Select(additionalBones, SkeletonVisual3d.SelectMode.Add);
+	}
+
 	public void SelectHead()
 	{
 		this.ClearSelection();

--- a/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
@@ -60,7 +60,7 @@ public class BrioActorRefresher : IActorRefresher
 					// Restore current pose
 					skeletonVisual3D = new SkeletonVisual3d();
 					await skeletonVisual3D.SetActor(actor);
-					await poseFile.Apply(actor, skeletonVisual3D, null, PoseFile.Mode.All);
+					await poseFile.Apply(actor, skeletonVisual3D, null, PoseFile.Mode.All, true);
 				}).Start();
 			}
 		}

--- a/Anamnesis/Files/SceneFile.cs
+++ b/Anamnesis/Files/SceneFile.cs
@@ -156,7 +156,7 @@ public class SceneFile : JsonFileBase
 
 			if (mode.HasFlag(Mode.Pose))
 			{
-				await entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation);
+				await entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation, true);
 			}
 		}
 

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -213,7 +213,7 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 							fullActor.SetAddress(newActor.Address);
 							fullActor.Tick();
 							await skeletonVisual3D.SetActor(fullActor);
-							await poseFile.Apply(fullActor, skeletonVisual3D, null, PoseFile.Mode.Rotation);
+							await poseFile.Apply(fullActor, skeletonVisual3D, null, PoseFile.Mode.Rotation, true);
 						}
 					}
 


### PR DESCRIPTION
This pull request introduces some tweaks for importing poses to hopefully making posing easier with outdated body pose files and modern DT expression pose files. Here are the tweaks I've done:

1) I noticed that when importing by Body Pose or by Selected Bones, the head bone (j_kao) wasn't getting posed, as its rotation was being reset by the facial expression hack. This could cause the head to not be posed as intended, and even do nothing when just importing that one bone. This tweak resolves that by conditionally applying the facial expression hack. Child bones like visor, hair, and Viera ears seem to be okay as they are parented.

2) Facial expressions in DT now use bone positions, in addition to rotation and scale. This tweak adds bone positions to importing by Expression as well as restoring the head position in the facial expression hack. This allows users to import expressions completely, without having to do import by Full Transforms.

This has made posing easier for me. Pose first, then apply an expression, and finally a scale if desired. I've also been able to apply new expressions after posing, positioning, and scaling with these tweaks.