### PR TITLE
Tweaks for Hrothgar Fur and Faces

### DIFF
--- a/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
+++ b/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
@@ -13,15 +13,22 @@ public class NpcFaceWarningConverter : IMultiValueConverter
 {
 	public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
 	{
-		if (values.Length != 2)
+		if (values.Length != 4)
 			throw new ArgumentException();
 
-		if (values[0] is ActorTypes type && values[1] is byte head)
+		if (values[0] is ActorTypes type && values[1] is byte head && values[2] is ActorCustomizeMemory.Races race && values[3] is ActorCustomizeMemory.Genders gender)
 		{
+			bool isHrothF = race == ActorCustomizeMemory.Races.Hrothgar && gender == ActorCustomizeMemory.Genders.Feminine;
+
 			if (type == ActorTypes.BattleNpc || type == ActorTypes.EventNpc)
 				return Visibility.Collapsed;
 
-			if (head > 5)
+			// For all except Fem Hrothgar, >4 is an NPC face.
+			if (head > 4 && !isHrothF)
+				return Visibility.Visible;
+
+			// For Fem Hrothgar only, between 5 and 8 are player faces.
+			if ((head < 5 || head > 8) && isHrothF)
 				return Visibility.Visible;
 
 			return Visibility.Collapsed;

--- a/Anamnesis/Actor/Pages/CharacterPage.xaml
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml
@@ -301,6 +301,8 @@
 					<MultiBinding Converter="{StaticResource NpcFaceWarningConverter}">
 						<Binding Path="Actor.ObjectKind" />
 						<Binding Path="Actor.Customize.Head" />
+						<Binding Path="Actor.Customize.Race" />
+						<Binding Path="Actor.Customize.Gender" />
 					</MultiBinding>
 				</Grid.Visibility>
 

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml
@@ -210,9 +210,15 @@
 					</Grid.ColumnDefinitions>
 
 					<XivToolsWpf:NumberBox Grid.Column="0" Value="{Binding Customize.Lips}" Minimum="0" Maximum="4" Buttons="True" Margin="0, 0, 12, 0"  ValueOffset="1"/>
-					<TextBlock Text="Color:" Grid.Column="1" Style="{StaticResource Label}"/>
-					<CheckBox Grid.Column="2" IsChecked="{Binding Customize.EnableLipColor}"/>
-					<controls:ColorControl Grid.Column="3" Value="{Binding Customize.LipsToneFurPattern}" IsEnabled="{Binding Customize.EnableLipColor}" Type="Lips" Gender="{Binding Customize.Gender}" Tribe="{Binding Customize.Tribe}"/>
+
+					<!-- Lip Color -->
+					<TextBlock Text="Color:" Grid.Column="1" Style="{StaticResource Label}" Visibility="{Binding HasntFur, Converter={StaticResource B2V}}"/>
+					<CheckBox Grid.Column="2" IsChecked="{Binding Customize.EnableLipColor}" Visibility="{Binding HasntFur, Converter={StaticResource B2V}}"/>
+					<controls:ColorControl Grid.Column="3" Value="{Binding Customize.LipsToneFurPattern}" Visibility="{Binding HasntFur, Converter={StaticResource B2V}}" IsEnabled="{Binding Customize.EnableLipColor}" Type="Lips" Gender="{Binding Customize.Gender}" Tribe="{Binding Customize.Tribe}"/>
+
+					<!-- Fur pattern -->
+					<XivToolsWpf:TextBlock Grid.Column="1" Key="Character_Appearance_Fur" Style="{StaticResource Label}" Visibility="{Binding HasFur, Converter={StaticResource B2V}}" TextAlignment="Center"/>
+					<XivToolsWpf:NumberBox Grid.Column="2" Value="{Binding Customize.LipsToneFurPattern}" Visibility="{Binding HasFur, Converter={StaticResource B2V}}" Minimum="0" Maximum="255" Buttons="True" HorizontalAlignment="Center"/>
 				</Grid>
 
 				<!-- Height -->
@@ -266,11 +272,6 @@
 					<XivToolsWpf:TextBlock Grid.Row="1" Grid.Column="2" Key="Character_Appearance_Ears" Style="{StaticResource Label}" Visibility="{Binding HasEars, Converter={StaticResource B2V}}"/>
 					<XivToolsWpf:TextBlock Grid.Row="1" Grid.Column="2" Key="Character_Appearance_Tail" Style="{StaticResource Label}" Visibility="{Binding HasTail, Converter={StaticResource B2V}}"/>
 					<XivToolsWpf:NumberBox Grid.Row="1" Value="{Binding Customize.TailEarsType}" Grid.Column="3" Visibility="{Binding HasEarsTail, Converter={StaticResource B2V}}" Minimum="0" Maximum="255" Buttons="True"/>
-
-					<!-- Fur pattern -->
-					<XivToolsWpf:TextBlock Grid.Row="2" Grid.Column="0" Key="Character_Appearance_Fur" Style="{StaticResource Label}" Visibility="{Binding HasFur, Converter={StaticResource B2V}}"/>
-					<XivToolsWpf:NumberBox Grid.Row="2" Value="{Binding Customize.LipsToneFurPattern}" Grid.Column="1" Visibility="{Binding HasFur, Converter={StaticResource B2V}}" Minimum="0" Maximum="255" Buttons="True"/>
-
 				</Grid>
 				
 			

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -47,6 +47,7 @@ public partial class CustomizeEditor : UserControl
 
 	public bool HasGender { get; set; }
 	public bool HasFur { get; set; }
+	public bool HasntFur { get; set; }
 	public bool HasTail { get; set; }
 	public bool HasEars { get; set; }
 	public bool HasEarsTail { get; set; }
@@ -170,6 +171,7 @@ public partial class CustomizeEditor : UserControl
 		this.TribeComboBox.SelectedItem = this.Tribe;
 
 		this.HasFur = this.Customize.Race == AnAppearance.Races.Hrothgar;
+		this.HasntFur = !this.HasFur;
 		this.HasTail = this.Customize.Race == AnAppearance.Races.Hrothgar || this.Customize.Race == AnAppearance.Races.Miqote || this.Customize.Race == AnAppearance.Races.AuRa;
 		this.HasEars = this.Customize.Race == AnAppearance.Races.Viera || this.Customize.Race == AnAppearance.Races.Lalafel || this.Customize.Race == AnAppearance.Races.Elezen;
 		this.HasEarsTail = this.HasTail | this.HasEars;

--- a/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
+++ b/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
@@ -122,9 +122,18 @@ public partial class FacialFeaturesControl : UserControl
 			return;
 
 		this.features.Clear();
+
+		// Add an offset for Fem Hrothgar to show the facial features icons properly.
+		// Fem Hrothgar is defined as being either Helions or TheLost tribe AND Feminine gender.
+		int hrothFOffset = 0;
+		if((this.Tribe == ActorCustomizeMemory.Tribes.Helions || this.Tribe == ActorCustomizeMemory.Tribes.TheLost) && this.Gender == ActorCustomizeMemory.Genders.Feminine)
+		{
+			hrothFOffset = 4;
+		}
+
 		for (byte i = 0; i < 7; i++)
 		{
-			int id = (this.Head - 1) + (8 * i);
+			int id = (this.Head - (1 + hrothFOffset)) + (8 * i);
 
 			if (id < 0 || id >= facialFeatures.Length)
 				continue;


### PR DESCRIPTION
This pull request introduces some tweaks for Hrothgar to make the character view more user friendly for them.  Here are the tweaks I've done:

1) For the fur color pattern, it's tied to the same value as lip color for other races. There was a box for it that was being cut off at the bottom of the page. This tweak switches lip color for fur pattern for Hrothgar specifically. This should fix the issue a user mentioned on Discord.

2) For Hrothgals, their face IDs are actually 5 -> 8, instead of 1 -> 4. This tweak makes it so the NPC face warning doesn't show up for values in that range, as well as make the facial features icons show up for those faces as well. This should fix #1362. 