### PR TITLE
Resolved identified XAML binding errors

### DIFF
--- a/Anamnesis/Actor/Converters/ExtendedWeaponToSubModelConverter.cs
+++ b/Anamnesis/Actor/Converters/ExtendedWeaponToSubModelConverter.cs
@@ -1,0 +1,29 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Actor.Converters;
+
+using Anamnesis.Memory;
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+[ValueConversion(typeof(ExtendedWeaponMemory), typeof(WeaponSubModelMemory))]
+public class ExtendedWeaponToSubModelConverter : IValueConverter
+{
+	public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		if (value is ExtendedWeaponMemory extendedWeaponMemory)
+		{
+			return extendedWeaponMemory.SubModel;
+		}
+
+		return DependencyProperty.UnsetValue;
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/Anamnesis/Actor/Pages/ActionPage.xaml
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml
@@ -169,7 +169,7 @@
                         </Grid>
 
 
-                        <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Click="OnBlendAnimation" IsEnabled="{Binding AnimationService.BlendLocked, Converter={StaticResource NotConverter}}" Style="{StaticResource TransparentButton}">
+						<Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Click="OnBlendAnimation" IsEnabled="{Binding Actor.Animation.BlendLocked, Converter={StaticResource NotConverter}}" Style="{StaticResource TransparentButton}">
                             <XivToolsWpf:TextBlock Key="Character_Action_AnimationBlend"/>
                         </Button>
 
@@ -409,8 +409,7 @@
 											   Grid.Column="0"
 											   Style="{StaticResource Label}" />
 
-                    <ToggleButton Grid.Row="0" Grid.Column="1" Height="20" Style="{StaticResource TransparentIconToggleButton}" IsEnabled="{Binding GposeService.IsGpose}" IsChecked="{Binding PoseService.FreezeWorldPosition}" BorderThickness="1" Padding="0" Margin="0"
-							  Visibility="{Binding IsValidWeapon, Converter={StaticResource B2V}}">
+                    <ToggleButton Grid.Row="0" Grid.Column="1" Height="20" Style="{StaticResource TransparentIconToggleButton}" IsEnabled="{Binding GposeService.IsGpose}" IsChecked="{Binding PoseService.FreezeWorldPosition}" BorderThickness="1" Padding="0" Margin="0">
 
                         <ToggleButton.ToolTip>
                             <XivToolsWpf:TextBlock Key="Character_Action_GlobalFreezeWorldPositionsTooltip"/>
@@ -424,8 +423,7 @@
 											   Grid.Column="0"
 											   Style="{StaticResource Label}" />
 
-                    <ToggleButton Grid.Row="1" Grid.Column="1" Height="20" Style="{StaticResource TransparentIconToggleButton}" IsEnabled="{Binding GposeService.IsGpose}" IsChecked="{Binding AnimationService.SpeedControlEnabled}" BorderThickness="1" Padding="0" Margin="0"
-							  Visibility="{Binding IsValidWeapon, Converter={StaticResource B2V}}">
+                    <ToggleButton Grid.Row="1" Grid.Column="1" Height="20" Style="{StaticResource TransparentIconToggleButton}" IsEnabled="{Binding GposeService.IsGpose}" IsChecked="{Binding AnimationService.SpeedControlEnabled}" BorderThickness="1" Padding="0" Margin="0">
                         <fa:IconBlock Icon="Stopwatch" FontSize="10"/>
                     </ToggleButton>
 

--- a/Anamnesis/Actor/Pages/PosePage.xaml
+++ b/Anamnesis/Actor/Pages/PosePage.xaml
@@ -298,8 +298,7 @@
 
 							<CheckBox Margin="3,0,6,0"
 									  IsEnabled="{Binding GposeService.IsGpose}"
-									  IsChecked="{Binding PoseService.FreezeWorldPosition}"
-									  Visibility="{Binding IsValidWeapon, Converter={StaticResource B2V}}">
+									  IsChecked="{Binding PoseService.FreezeWorldPosition}">
 
 								<ToggleButton.ToolTip>
 									<XivToolsWpf:TextBlock Key="Character_Action_GlobalFreezeWorldPositionsTooltip"/>

--- a/Anamnesis/Actor/Posing/Views/PoseMatrixView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseMatrixView.xaml
@@ -351,10 +351,7 @@
 									  ItemsSource="{Binding HairBones}">
 							<ItemsControl.ItemsPanel>
 								<ItemsPanelTemplate>
-									<WrapPanel Width="{Binding (FrameworkElement.ActualWidth), RelativeSource={RelativeSource AncestorType=ScrollContentPresenter}}"
-											   ItemWidth="{Binding (ListView.View).ItemWidth, RelativeSource={RelativeSource AncestorType=ListView}}"
-											   MinWidth="{Binding ItemWidth, RelativeSource={RelativeSource Self}}"
-											   ItemHeight="{Binding (ListView.View).ItemHeight, RelativeSource={RelativeSource AncestorType=ListView}}" />
+									<WrapPanel/>
 								</ItemsPanelTemplate>
 							</ItemsControl.ItemsPanel>
 
@@ -943,10 +940,7 @@
 										  ItemsSource="{Binding MetBones}">
 								<ItemsControl.ItemsPanel>
 									<ItemsPanelTemplate>
-										<WrapPanel Width="{Binding (FrameworkElement.ActualWidth), RelativeSource={RelativeSource AncestorType=ScrollContentPresenter}}"
-												   ItemWidth="{Binding (ListView.View).ItemWidth, RelativeSource={RelativeSource AncestorType=ListView}}"
-												   MinWidth="{Binding ItemWidth, RelativeSource={RelativeSource Self}}"
-												   ItemHeight="{Binding (ListView.View).ItemHeight, RelativeSource={RelativeSource AncestorType=ListView}}" />
+										<WrapPanel/>
 									</ItemsPanelTemplate>
 								</ItemsControl.ItemsPanel>
 
@@ -968,10 +962,7 @@
 							<ItemsControl Grid.Column="1" ItemsSource="{Binding TopBones}">
 								<ItemsControl.ItemsPanel>
 									<ItemsPanelTemplate>
-										<WrapPanel Width="{Binding (FrameworkElement.ActualWidth), RelativeSource={RelativeSource AncestorType=ScrollContentPresenter}}"
-												   ItemWidth="{Binding (ListView.View).ItemWidth, RelativeSource={RelativeSource AncestorType=ListView}}"
-												   MinWidth="{Binding ItemWidth, RelativeSource={RelativeSource Self}}"
-												   ItemHeight="{Binding (ListView.View).ItemHeight, RelativeSource={RelativeSource AncestorType=ListView}}" />
+										<WrapPanel/>
 									</ItemsPanelTemplate>
 								</ItemsControl.ItemsPanel>
 
@@ -1014,10 +1005,7 @@
 										  ItemsSource="{Binding MainHandBones}">
 								<ItemsControl.ItemsPanel>
 									<ItemsPanelTemplate>
-										<WrapPanel Width="{Binding (FrameworkElement.ActualWidth), RelativeSource={RelativeSource AncestorType=ScrollContentPresenter}}"
-												   ItemWidth="{Binding (ListView.View).ItemWidth, RelativeSource={RelativeSource AncestorType=ListView}}"
-												   MinWidth="{Binding ItemWidth, RelativeSource={RelativeSource Self}}"
-												   ItemHeight="{Binding (ListView.View).ItemHeight, RelativeSource={RelativeSource AncestorType=ListView}}" />
+										<WrapPanel/>
 									</ItemsPanelTemplate>
 								</ItemsControl.ItemsPanel>
 
@@ -1039,10 +1027,7 @@
 							<ItemsControl Grid.Column="1" ItemsSource="{Binding OffHandBones}">
 								<ItemsControl.ItemsPanel>
 									<ItemsPanelTemplate>
-										<WrapPanel Width="{Binding (FrameworkElement.ActualWidth), RelativeSource={RelativeSource AncestorType=ScrollContentPresenter}}"
-												   ItemWidth="{Binding (ListView.View).ItemWidth, RelativeSource={RelativeSource AncestorType=ListView}}"
-												   MinWidth="{Binding ItemWidth, RelativeSource={RelativeSource Self}}"
-												   ItemHeight="{Binding (ListView.View).ItemHeight, RelativeSource={RelativeSource AncestorType=ListView}}" />
+										<WrapPanel/>
 									</ItemsPanelTemplate>
 								</ItemsControl.ItemsPanel>
 

--- a/Anamnesis/Actor/Views/EquipmentEditor.xaml
+++ b/Anamnesis/Actor/Views/EquipmentEditor.xaml
@@ -4,8 +4,13 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
 			 xmlns:local="clr-namespace:Anamnesis.Actor.Views"
+			 xmlns:converters="clr-namespace:Anamnesis.Actor.Converters"
 			 mc:Ignorable="d"
 			 d:DesignHeight="600">
+
+	<UserControl.Resources>
+		<converters:ExtendedWeaponToSubModelConverter x:Key="ExtendedWeaponToSubModelConverter"/>
+	</UserControl.Resources>
 
 	<Grid x:Name="ContentArea">
 		<Grid.ColumnDefinitions>
@@ -22,7 +27,7 @@
 			<RowDefinition/>
 		</Grid.RowDefinitions>
 
-		<local:ItemView Grid.Row="0" Grid.Column="0" ItemModel="{Binding MainHand}" ExtendedViewModel="{Binding ModelObject.Weapons}"  Slot="MainHand" IsEnabled="{Binding IsChocobo, Converter={StaticResource !B}}"/>
+		<local:ItemView Grid.Row="0" Grid.Column="0" ItemModel="{Binding MainHand}" ExtendedViewModel="{Binding ModelObject.Weapons, Converter={StaticResource ExtendedWeaponToSubModelConverter}}" Slot="MainHand" IsEnabled="{Binding IsChocobo, Converter={StaticResource !B}}"/>
 		<local:ItemView Grid.Row="0" Grid.Column="1" ItemModel="{Binding OffHand}" ExtendedViewModel="{Binding ModelObject.Weapons.SubModel}" Slot="OffHand" IsEnabled="{Binding IsChocobo, Converter={StaticResource !B}}"/>
 		<local:ItemView Grid.Row="1" Grid.Column="0" ItemModel="{Binding Equipment.Head}" Slot="Head"/>
 		<local:ItemView Grid.Row="2" Grid.Column="0" ItemModel="{Binding Equipment.Chest}" Slot="Body" />

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml
@@ -12,6 +12,13 @@
 			 mc:Ignorable="d" 
 			 d:DesignHeight="450">
 
+	<UserControl.Resources>
+		<Style x:Key="SelectorItemStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource MaterialDesignListBoxItem}">
+			<Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+			<Setter Property="VerticalContentAlignment" Value="Top"/>
+		</Style>
+	</UserControl.Resources>
+
 	<Grid x:Name="ContentArea">
 
 		<Grid.ColumnDefinitions>
@@ -178,11 +185,12 @@
 		<xivToolsWpfSelectors:Selector
 			Grid.Column="1"
 			Grid.Row="2"
-			Width="300">
+			Width="300"
+			ListBoxItemStyle="{StaticResource SelectorItemStyle}">
 
 			<xivToolsWpfSelectors:Selector.ItemTemplate>
 				<DataTemplate>
-					<Grid Height="32" Margin="0, -2">
+					<Grid Height="32">
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="Auto"/>
 							<ColumnDefinition/>

--- a/Anamnesis/Actor/Views/FacialFeaturesControl.xaml
+++ b/Anamnesis/Actor/Views/FacialFeaturesControl.xaml
@@ -16,6 +16,8 @@
 			<Setter Property="IsSelected" Value="{Binding Selected}" />
 			<Setter Property="BorderThickness" Value="0" />
 			<Setter Property="Background" Value="Transparent" />
+			<Setter Property="HorizontalContentAlignment" Value="Left" />
+			<Setter Property="VerticalContentAlignment" Value="Top" />
 			<Setter Property="Template">
 				<Setter.Value>
 					<ControlTemplate TargetType="ListBoxItem">

--- a/Anamnesis/MainWindow.xaml
+++ b/Anamnesis/MainWindow.xaml
@@ -46,11 +46,11 @@
 											  Click="OnTargetActorClicked"
 											  Header="Target" />
 
-                                <MenuItem Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Path=SettingsService.Settings.UseExternalRefreshBrio, Converter={StaticResource B2V}}" 
+								<MenuItem Visibility="{Binding DataContext.SettingsService.Settings.UseExternalRefreshBrio, Source={x:Reference PinnedActorList}, Converter={StaticResource B2V}}" 
 											  IsEnabled="{Binding IsGPoseActor}"
 											  Click="OnDespawnActorClicked"
 											  Header="Despawn" />
-                            </ContextMenu>
+								</ContextMenu>
 							</ToggleButton.ContextMenu>
 
 						<Grid Margin="6,0">
@@ -147,7 +147,7 @@
 				<ScaleTransform x:Name="WindowScale" ScaleX="0.5" ScaleY="0.5" />
 			</Grid.LayoutTransform>
 
-			<Grid IsEnabled="{Binding GposeService.IsNotChangingState}" Margin="3,0,3,3">
+			<Grid IsEnabled="{Binding GposeService.Initialized}" Margin="3,0,3,3">
 
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>

--- a/Anamnesis/Services/GposeService.cs
+++ b/Anamnesis/Services/GposeService.cs
@@ -3,25 +3,21 @@
 
 namespace Anamnesis.Services;
 
-using System;
-using System.Threading.Tasks;
 using Anamnesis.Core.Memory;
 using Anamnesis.Memory;
 using PropertyChanged;
+using System;
+using System.Threading.Tasks;
 
 public delegate void GposeEvent(bool newState);
 
 [AddINotifyPropertyChangedInterface]
 public class GposeService : ServiceBase<GposeService>
 {
-	private bool initialized = false;
-
 	public static event GposeEvent? GposeStateChanged;
 
+	public bool Initialized { get; private set; } = false;
 	public bool IsGpose { get; private set; }
-
-	[DependsOn(nameof(IsGpose))]
-	public bool IsOverworld => !this.IsGpose;
 
 	public static bool GetIsGPose()
 	{
@@ -50,9 +46,9 @@ public class GposeService : ServiceBase<GposeService>
 		{
 			bool newGpose = GetIsGPose();
 
-			if (!this.initialized)
+			if (!this.Initialized)
 			{
-				this.initialized = true;
+				this.Initialized = true;
 				this.IsGpose = newGpose;
 				continue;
 			}

--- a/Anamnesis/Services/PinnedActor.cs
+++ b/Anamnesis/Services/PinnedActor.cs
@@ -3,10 +3,6 @@
 
 namespace Anamnesis;
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Threading.Tasks;
 using Anamnesis.Actor;
 using Anamnesis.Files;
 using Anamnesis.Memory;
@@ -15,6 +11,10 @@ using Anamnesis.Styles;
 using FontAwesome.Sharp;
 using PropertyChanged;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
 using XivToolsWpf.Extensions;
 
 [AddINotifyPropertyChangedInterface]
@@ -146,7 +146,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 				return;
 			}
 
-			if (this.IsGPoseActor && GposeService.Instance.IsOverworld)
+			if (this.IsGPoseActor && !GposeService.Instance.IsGpose)
 			{
 				Log.Information($"Actor: {this} was a gpose actor and we are now in the overworld");
 				this.Retarget();

--- a/Anamnesis/Views/Gallery.xaml
+++ b/Anamnesis/Views/Gallery.xaml
@@ -48,7 +48,7 @@
 				<Grid>
 					<Rectangle Fill="White" Margin="-3"/>
 					<TextBlock Text="Oops! No Image!" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Black" Margin="0, 0, 0, 20"/>
-					<Image Source="{Binding Image1Path}" x:Name="Image1" Margin="0, 0, 0, 20"/>
+					<Image Source="{Binding Image1Path, TargetNullValue={x:Null}}" x:Name="Image1" Margin="0, 0, 0, 20"/>
 					<TextBlock Text="{Binding Image1Author}" HorizontalAlignment="Right" VerticalAlignment="Bottom" Foreground="Black" Margin="2, 4, 2, 0"/>
 				</Grid>
 			</Border>
@@ -65,7 +65,7 @@
 				<Grid>
 					<Rectangle Fill="White" Margin="-3"/>
 					<TextBlock Text="Oops! No Image!" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Black" Margin="0, 0, 0, 20"/>
-					<Image Source="{Binding Image2Path}" x:Name="Image2" Margin="0, 0, 0, 20"/>
+					<Image Source="{Binding Image2Path, TargetNullValue={x:Null}}" x:Name="Image2" Margin="0, 0, 0, 20"/>
 					<TextBlock Text="{Binding Image2Author}" HorizontalAlignment="Right" VerticalAlignment="Bottom" Foreground="Black" Margin="2, 4, 2, 0"/>
 				</Grid>
 			</Border>


### PR DESCRIPTION
_**Note:** This pull request will be marked as a draft until this XivToolsWpf PR is handled: https://github.com/Aether-Tools/AetherToolsWpf/pull/1._

This pull request handles a handful of XAML binding errors that are currently present in Anamnesis:

> System.Windows.Data Error: 40 : BindingExpression path error: 'IsNotChangingState' property not found on 'object' ''GposeService' (HashCode=10987981)'. BindingExpression:Path=GposeService.IsNotChangingState; DataItem='MainWindow' (Name=''); target element is 'Grid' (Name=''); target property is 'IsEnabled' (type 'Boolean')
- **Cause:** IsNotChangingState is no longer part of the GposeService. It was removed in a previous commit.
- **Behavioural/visual changes:** Previously, the main window was enabled at all times because "Enabled" property's default value is `true`. Now, the main window will be enabled only if the GPose service is initialized.
---
> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Window', AncestorLevel='1''. BindingExpression:Path=SettingsService.Settings.UseExternalRefreshBrio; DataItem=null; target element is 'MenuItem' (Name=''); target property is 'Visibility' (type 'Visibility')
- **Cause:** UseExternalRefreshBrio was inaccessible due to incorrect binding.
- **Behavioural/visual changes:** Previously, the "Despawn" option in the pinned actor's context menu was visible regardless if Brio integration was enabled or not. Now, the menu item will only be visible if Brio integration is enabled.
---
> System.Windows.Data Error: 23 : Cannot convert '<null>' from type '<null>' to type 'System.Windows.Media.ImageSource' for 'en-US' culture with default conversions; consider using Converter property of Binding. NotSupportedException:'System.NotSupportedException: ImageSourceConverter cannot convert from (null).
   at System.ComponentModel.TypeConverter.GetConvertFromException(Object value)
   at System.Windows.Media.ImageSourceConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at MS.Internal.Data.DefaultValueConverter.ConvertHelper(Object o, Type destinationType, DependencyObject targetElement, CultureInfo culture, Boolean isForward)'
- **Cause:** Caused by the Gallery
- **Behavioural/visual changes:** None. The Gallery will no longer freak out whenever the image paths stay null (which is the case for Curated and None gallery modes.
---
> System.Windows.Data Error: 1 : Cannot create default converter to perform 'two-way' conversions between types 'Anamnesis.Memory.ExtendedWeaponMemory' and 'Anamnesis.Memory.WeaponSubModelMemory'. Consider using Converter property of Binding.
- **Cause:** EquipmentEditor.
- **Behavioural/visual changes:** Not sure on this one.
---
> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=HorizontalContentAlignment; DataItem=null; target element is 'ListBoxItem' (Name=''); target property is 'HorizontalContentAlignment' (type 'HorizontalAlignment')

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=VerticalContentAlignment; DataItem=null; target element is 'ListBoxItem' (Name=''); target property is 'VerticalContentAlignment' (type 'VerticalAlignment')
- **Cause:** EquipmentSelector and FacialFeaturesControl were missing the HorizontalContentAlignment and VerticalContentAlignment properties, which are expected by the MaterialDesignListBoxItem style.
- **Behavioural/visual changes:** No visual changes for FacialFeaturesControl. EquipmentSelector's items will now take up the entire horizontal space. Otherwise, some of the items end up smaller than others, leading to alignment issues (see image below).

![image](https://github.com/user-attachments/assets/e2ace65d-7d8d-4c45-9c2e-a51e10cb1a9e)
---
> System.Windows.Data Error: 40 : BindingExpression path error: 'IsValidWeapon' property not found on 'object' ''PosePage' (Name='')'. BindingExpression:Path=IsValidWeapon; DataItem='PosePage' (Name=''); target element is 'CheckBox' (Name=''); target property is 'Visibility' (type 'Visibility')

> System.Windows.Data Error: 40 : BindingExpression path error: 'IsValidWeapon' property not found on 'object' ''ActionPage' (Name='')'. BindingExpression:Path=IsValidWeapon; DataItem='ActionPage' (Name=''); target element is 'ToggleButton' (Name=''); target property is 'Visibility' (type 'Visibility')

> System.Windows.Data Error: 40 : BindingExpression path error: 'IsValidWeapon' property not found on 'object' ''ActionPage' (Name='')'. BindingExpression:Path=IsValidWeapon; DataItem='ActionPage' (Name=''); target element is 'ToggleButton' (Name=''); target property is 'Visibility' (type 'Visibility')
- **Cause:** IsValidWeapon is not part of the data context and seemingly hasn't been for a long time. Perhaps it was part of ActorMemory at some point but now the only IsValidWeapon definition is in the ItemView view model.
- **Behavioural/visual changes:** None
---
> System.Windows.Data Error: 40 : BindingExpression path error: 'File' property not found on 'object' ''SkeletonVisual3d' (HashCode=66961361)'. BindingExpression:Path=Skeleton.File.AllowPoseGui; DataItem='PosePage' (Name=''); target element is 'ListBoxItem' (Name=''); target property is 'Visibility' (type 'Visibility')

> System.Windows.Data Error: 40 : BindingExpression path error: 'File' property not found on 'object' ''SkeletonVisual3d' (HashCode=66961361)'. BindingExpression:Path=Skeleton.File.AllowPoseMatrix; DataItem='PosePage' (Name=''); target element is 'ListBoxItem' (Name=''); target property is 'Visibility' (type 'Visibility')
- **Cause:** SkeletonTemplateFile no longer exists and was removed from SkeletonVisual3d with this commit https://github.com/imchillin/Anamnesis/commit/07f157f7d8f24499049f6455433e4de2bea0247d#diff-986bef8299c3ae05f0f2cb5d9ba9621fe7fe4f78bebbd6c194ac985bab83e387
- **Behavioural/visual changes:** None
---
> System.Windows.Data Error: 5 : Value produced by BindingExpression is not valid for target property. Double:'NaN' BindingExpression:Path=ItemWidth; DataItem='WrapPanel' (Name=''); target element is 'WrapPanel' (Name=''); target property is 'MinWidth' (type 'Double')

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ListView', AncestorLevel='1''. BindingExpression:Path=(ListView.View).ItemWidth; DataItem=null; target element is 'WrapPanel' (Name=''); target property is 'ItemWidth' (type 'Double')

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ListView', AncestorLevel='1''. BindingExpression:Path=(ListView.View).ItemHeight; DataItem=null; target element is 'WrapPanel' (Name=''); target property is 'ItemHeight' (type 'Double')
- **Cause:** Outdated WrapPanel bindings in MatrixPoseView.
- **Behavioural/visual changes:** None
---
> System.Windows.Data Error: 40 : BindingExpression path error: 'BlendLocked' property not found on 'object' ''AnimationService' (HashCode=54572879)'. BindingExpression:Path=AnimationService.BlendLocked; DataItem='ActionPage' (Name=''); target element is 'Button' (Name=''); target property is 'IsEnabled' (type 'Boolean')
- **Cause:** Outdated binding to BlendLocked.
- **Behavioural/visual changes:** The button should now be disabled whenever BlendLocked is true.
---

There are 2 XAML binding errors that I did not attempt to fix as their scope is beyond this pull request:
> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.DataGridCell', AncestorLevel='1''. BindingExpression:(no path); DataItem=null; target element is 'Popup' (Name='PART_Popup'); target property is 'PlacementTarget' (type 'UIElement')

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.DataGridCell', AncestorLevel='1''. BindingExpression:Path=ActualWidth; DataItem=null; target element is 'Border' (Name='dropDownBorder'); target property is 'MinWidth' (type 'Double')
- **Cause:** The ComboBox (the one for item sorting options) in EquipmentSelector uses the MaterialDesignDataGridComboBox style, which expects the component to be inside a DataGridCell. However, this is not the case.
- **Possible solution:** Creating a custom ComboBox style.