### PR TITLE
Corrected outdated motion detection property

### DIFF
--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -3,10 +3,10 @@
 
 namespace Anamnesis.Memory;
 
-using System;
-using System.Threading.Tasks;
 using Anamnesis.Utils;
 using PropertyChanged;
+using System;
+using System.Threading.Tasks;
 
 public class ActorMemory : ActorBasicMemory
 {
@@ -57,7 +57,7 @@ public class ActorMemory : ActorBasicMemory
 	[Bind(0x08F8, BindFlags.Pointer)] public ActorMemory? Ornament { get; set; }
 	[Bind(0x0900)] public ushort OrnamentId { get; set; }
 	[Bind(0x09C0)] public AnimationMemory? Animation { get; set; }
-	[Bind(0x12D4)] public bool IsMotionEnabled { get; set; }
+	[Bind(0x1ABC)] public bool IsMotionDisabled { get; set; }
 	[Bind(0x19D0)] public byte Voice { get; set; }
 	[Bind(0x21C8)] public float Transparency { get; set; }
 	[Bind(0x226C)] public byte CharacterModeRaw { get; set; }
@@ -120,6 +120,13 @@ public class ActorMemory : ActorBasicMemory
 		}
 	}
 
+	[DependsOn(nameof(IsMotionDisabled))]
+	public bool IsMotionEnabled
+	{
+		get => !this.IsMotionDisabled;
+		set => this.IsMotionDisabled = !value;
+	}
+
 	[DependsOn(nameof(ObjectIndex), nameof(CharacterMode))]
 	public bool CanAnimate => (this.CharacterMode == CharacterModes.Normal || this.CharacterMode == CharacterModes.AnimLock) || !ActorService.Instance.IsLocalOverworldPlayer(this.ObjectIndex);
 
@@ -166,7 +173,7 @@ public class ActorMemory : ActorBasicMemory
 
 			this.IsRefreshing = true;
 
-			if(await ActorService.Instance.RefreshActor(this))
+			if (await ActorService.Instance.RefreshActor(this))
 			{
 				Log.Information($"Completed actor refresh for actor address: {this.Address}");
 			}


### PR DESCRIPTION
Resolved an issue that was reported on the XIV Tools Discord server concerning Anamnesis' inability to detect whenever actors are frozen while in GPose.

This property is part of Client::Game::Character::BlacklistProxyContainer, which starts at offset 0x1A98h from the Character object. I believe it corresponds to the motion state as the class has the functions "FreezeMotion" and "ResumeMotion". Testing it in-game also seems to corroborate that. Unfortunately, its not yet mapped by the guys and gals over at aers/FFXIVClientStructs so I can't say for certain this is the right variable.
