### PR TITLE
Reworked signature scanner and memory service to reduce memory usage

### DIFF
--- a/Anamnesis/Core/Memory/MemoryService.cs
+++ b/Anamnesis/Core/Memory/MemoryService.cs
@@ -3,6 +3,12 @@
 
 namespace Anamnesis.Memory;
 
+using Anamnesis.Core.Memory;
+using Anamnesis.GUI.Dialogs;
+using Anamnesis.GUI.Windows;
+using Anamnesis.Keyboard;
+using Anamnesis.Services;
+using PropertyChanged;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -12,27 +18,85 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Anamnesis.Core.Memory;
-using Anamnesis.GUI.Dialogs;
-using Anamnesis.GUI.Windows;
-using Anamnesis.Keyboard;
-using Anamnesis.Services;
-using PropertyChanged;
 using XivToolsWpf;
 
 [AddINotifyPropertyChangedInterface]
 public class MemoryService : ServiceBase<MemoryService>
 {
+	/// <summary>
+	/// The memory protection constant for read, write, and execute permissions.
+	/// </summary>
 	private const uint VirtualProtectReadWriteExecute = 0x40;
 
-	private readonly Dictionary<string, IntPtr> modules = new Dictionary<string, IntPtr>();
+	/// <summary>
+	/// The maximum number of attempts to read from memory before failing.
+	/// </summary>
+	private const int MaxReadAttempts = 10;
 
+	/// <summary>
+	/// The number of milliseconds to wait between read attempts.
+	/// </summary>
+	private const int TimeBetweenReadAttempts = 20;
+
+	/// <summary>
+	/// The interval in milliseconds to wait for process refresh checks.
+	/// </summary>
+	private const int ProcessRefreshTimerInterval = 100;
+
+	/// <summary>
+	/// The interval in milliseconds to wait for before doing a process recovery attempt.
+	/// </summary>
+	private const int ProcessWatchdogInterval = 10000;
+
+	/// <summary>
+	/// A dictionary to store the base addresses of loaded modules by their names.
+	/// </summary>
+	private readonly Dictionary<string, IntPtr> modules = new();
+
+	/// <summary>Gets the handle to the opened process.</summary>
 	public static IntPtr Handle { get; private set; }
-	public static SignatureScanner? Scanner { get; private set; }
-	public static Process? Process { get; private set; }
-	public static bool IsProcessAlive { get; private set; }
-	public static bool DoesProcessHaveFocus { get; private set; }
 
+	/// <summary>Gets the signature scanner for the process.</summary>
+	public static SignatureScanner? Scanner { get; private set; }
+
+	/// <summary>Gets the process being managed.</summary>
+	public static Process? Process { get; private set; }
+
+	/// <summary>Gets a value indicating whether the process is alive.</summary>
+	public static bool IsProcessAlive
+	{
+		get
+		{
+			if (!Instance.IsAlive)
+				return false;
+
+			if (Process == null || Process.HasExited)
+				return false;
+
+			if (!Process.Responding)
+				return false;
+
+			return true;
+		}
+	}
+
+	/// <summary>Gets a value indicating whether the process has window focus.</summary>
+	public static bool DoesProcessHaveFocus
+	{
+		get
+		{
+			if (Process == null)
+				return false;
+
+			IntPtr wnd = GetForegroundWindow();
+			return wnd == Process.MainWindowHandle;
+		}
+	}
+
+	/// <summary>
+	/// Gets the path to the game directory.
+	/// </summary>
+	/// <exception cref="Exception">Thrown if the game process or its main module are not available.</exception>
 	public static string GamePath
 	{
 		get
@@ -50,31 +114,11 @@ public class MemoryService : ServiceBase<MemoryService>
 		}
 	}
 
-	public int LastTickCount { get; set; }
-
-	public static bool GetDoesProcessHaveFocus()
-	{
-		if (Process == null)
-			return false;
-
-		IntPtr wnd = GetForegroundWindow();
-		return wnd == Process.MainWindowHandle;
-	}
-
-	public static bool GetIsProcessAlive()
-	{
-		if (!Instance.IsAlive)
-			return false;
-
-		if (Process == null || Process.HasExited)
-			return false;
-
-		if (!Process.Responding)
-			return false;
-
-		return true;
-	}
-
+	/// <summary>
+	/// Reads a pointer from the specified memory address.
+	/// </summary>
+	/// <param name="address">The memory address to read the pointer from.</param>
+	/// <returns>The pointer read from the specified memory address.</returns>
 	public static IntPtr ReadPtr(IntPtr address)
 	{
 		byte[] d = new byte[8];
@@ -84,6 +128,13 @@ public class MemoryService : ServiceBase<MemoryService>
 		return ptr;
 	}
 
+	/// <summary>
+	/// Reads a value of type <typeparamref name="T"/> from the specified memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of value to read. Must be a struct.</typeparam>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <returns>The value read from the specified memory address, or null if the read fails.</returns>
+	/// <exception cref="Exception">Thrown if the specified memory address is invalid.</exception>
 	public static T? Read<T>(UIntPtr address)
 		where T : struct
 	{
@@ -94,6 +145,13 @@ public class MemoryService : ServiceBase<MemoryService>
 		}
 	}
 
+	/// <summary>
+	/// Reads a value of type <typeparamref name="T"/> from the specified memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of value to read. The type must be a struct.</typeparam>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <returns>The value read from the specified memory address.</returns>
+	/// <exception cref="Exception">Thrown if the address is invalid or the read operation fails after multiple attempts.</exception>
 	public static T Read<T>(IntPtr address)
 		where T : struct
 	{
@@ -101,9 +159,9 @@ public class MemoryService : ServiceBase<MemoryService>
 			throw new Exception("Invalid address");
 
 		int attempt = 0;
-		while (attempt < 10)
+		while (attempt < MaxReadAttempts)
 		{
-			int size = Marshal.SizeOf(typeof(T));
+			int size = Marshal.SizeOf<T>();
 			IntPtr mem = Marshal.AllocHGlobal(size);
 			ReadProcessMemory(Handle, address, mem, size, out _);
 			T? val = Marshal.PtrToStructure<T>(mem);
@@ -113,12 +171,19 @@ public class MemoryService : ServiceBase<MemoryService>
 			if (val != null)
 				return (T)val;
 
-			Thread.Sleep(100);
+			Thread.Sleep(TimeBetweenReadAttempts);
 		}
 
 		throw new Exception($"Failed to read memory {typeof(T)} from address {address}");
 	}
 
+	/// <summary>
+	/// Reads a value of the specified type from the given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <param name="type">The type of value to read.</param>
+	/// <returns>The value read from the specified memory address.</returns>
+	/// <exception cref="Exception">Thrown if the address is invalid or the read operation fails after multiple attempts.</exception>
 	public static object Read(IntPtr address, Type type)
 	{
 		if (address == IntPtr.Zero)
@@ -132,7 +197,7 @@ public class MemoryService : ServiceBase<MemoryService>
 		if (type == typeof(bool))
 			readType = typeof(OneByteBool);
 
-		for (int attempt = 0; attempt < 10; attempt++)
+		for (int attempt = 0; attempt < MaxReadAttempts; attempt++)
 		{
 			int size = Marshal.SizeOf(readType);
 			IntPtr mem = Marshal.AllocHGlobal(size);
@@ -154,27 +219,158 @@ public class MemoryService : ServiceBase<MemoryService>
 				return val;
 			}
 
-			Thread.Sleep(16);
+			Thread.Sleep(TimeBetweenReadAttempts);
 		}
 
 		throw new Exception($"Failed to read memory {type} from address {address}");
 	}
 
-	public static void Write<T>(IntPtr address, T value, string purpose)
+	/// <summary>
+	/// Reads memory from the specified address into the provided buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The buffer to store the read data.</param>
+	/// <param name="size">The size of the data to read.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	public static bool Read(UIntPtr address, byte[] buffer, UIntPtr size)
+	{
+		return ReadProcessMemory(Handle, address, buffer, size, IntPtr.Zero);
+	}
+
+	/// <summary>
+	/// Reads memory from the specified address into the provided buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The buffer to store the read data.</param>
+	/// <param name="size">The size of the data to read. If less than or equal to 0, the buffer length is used.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	public static bool Read(IntPtr address, byte[] buffer, int size = -1)
+	{
+		if (size <= 0)
+			size = buffer.Length;
+
+		return ReadProcessMemory(Handle, address, buffer, size, out _);
+	}
+
+	/// <summary>
+	/// Reads memory from the specified address into the provided span buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The span buffer to store the read data.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	public static unsafe bool Read(IntPtr address, Span<byte> buffer)
+	{
+		fixed (byte* ptr = buffer)
+		{
+			return ReadProcessMemory(Handle, address, (IntPtr)ptr, buffer.Length, out _);
+		}
+	}
+
+	/// <summary>
+	/// Reads a byte from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The byte value read from the specified address.</returns>
+	public static byte ReadByte(IntPtr baseAddress, int offset = 0)
+	{
+		byte[] buffer = new byte[1];
+		ReadProcessMemory(Handle, baseAddress + offset, buffer, 1, out _);
+		return buffer[0];
+	}
+
+	/// <summary>
+	/// Reads a 16-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 16-bit integer value read from the specified address.</returns>
+	public static short ReadInt16(IntPtr baseAddress, int offset = 0)
+	{
+		byte[] buffer = new byte[2];
+		ReadProcessMemory(Handle, baseAddress + offset, buffer, 2, out _);
+		return BitConverter.ToInt16(buffer);
+	}
+
+	/// <summary>
+	/// Reads a 32-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 32-bit integer value read from the specified address.</returns>
+	public static int ReadInt32(IntPtr baseAddress, int offset = 0)
+	{
+		byte[] buffer = new byte[4];
+		ReadProcessMemory(Handle, baseAddress + offset, buffer, 4, out _);
+		return BitConverter.ToInt32(buffer);
+	}
+
+	/// <summary>
+	/// Reads a 64-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 64-bit integer value read from the specified address.</returns>
+	public static long ReadInt64(IntPtr baseAddress, int offset = 0)
+	{
+		byte[] buffer = new byte[8];
+		ReadProcessMemory(Handle, baseAddress + offset, buffer, 8, out _);
+		return BitConverter.ToInt64(buffer);
+	}
+
+	/// <summary>
+	/// Writes a byte array to a specified memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="buffer">The byte array to write.</param>
+	/// <param name="writingCode">Indicates whether the write operation involves writing executable code.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	public static bool Write(IntPtr address, byte[] buffer, bool writingCode)
+	{
+		if (writingCode)
+			VirtualProtectEx(Handle, address, buffer.Length, VirtualProtectReadWriteExecute, out _);
+
+		return WriteProcessMemory(Handle, address, buffer, buffer.Length, out _);
+	}
+
+	/// <summary>
+	/// Writes a value of a specified type to a given memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of the value to write. Must be a struct.</typeparam>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The value to write.</param>
+	/// <param name="reason">The reason for writing the value.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	public static bool Write<T>(IntPtr address, T value, string reason)
 		where T : struct
 	{
-		Write(address, value, typeof(T), purpose);
+		return Write(address, value, typeof(T), reason);
 	}
 
-	public static void Write(IntPtr address, object value, string purpose)
+	/// <summary>
+	/// Writes an object value to a given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The object value to write.</param>
+	/// <param name="reason">The reason for writing the value.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	public static bool Write(IntPtr address, object value, string reason)
 	{
-		Write(address, value, value.GetType(), purpose);
+		return Write(address, value, value.GetType(), reason);
 	}
 
-	public static void Write(IntPtr address, object value, Type type, string purpose)
+	/// <summary>
+	/// Writes an object value of a specified type to a given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The object value to write.</param>
+	/// <param name="type">The type of the value to write.</param>
+	/// <param name="reason">The reason for writing the value.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	public static bool Write(IntPtr address, object value, Type type, string reason)
 	{
 		if (address == IntPtr.Zero)
-			return;
+			return false;
 
 		if (type.IsEnum)
 			type = type.GetEnumUnderlyingType();
@@ -222,31 +418,19 @@ public class MemoryService : ServiceBase<MemoryService>
 			}
 		}
 
-		Log.Verbose($"Writing: {buffer.Length} bytes to {address} for type {type.Name} for reason: {purpose}");
-		Write(address, buffer, false);
+		Log.Verbose($"Writing: {buffer.Length} bytes to {address} for type {type.Name} for reason: {reason}");
+		return Write(address, buffer, false);
 	}
 
-	public static bool Read(UIntPtr address, byte[] buffer, UIntPtr size)
-	{
-		return ReadProcessMemory(Handle, address, buffer, size, IntPtr.Zero);
-	}
-
-	public static bool Read(IntPtr address, byte[] buffer, int size = -1)
-	{
-		if (size <= 0)
-			size = buffer.Length;
-
-		return ReadProcessMemory(Handle, address, buffer, size, out _);
-	}
-
-	public static bool Write(IntPtr address, byte[] buffer, bool writingCode)
-	{
-		if(writingCode)
-			VirtualProtectEx(Handle, address, buffer.Length, VirtualProtectReadWriteExecute, out _);
-
-		return WriteProcessMemory(Handle, address, buffer, buffer.Length, out _);
-	}
-
+	/// <summary>
+	/// Sends a key press or release event to the main window of the attached process.
+	/// </summary>
+	/// <param name="key">The key to be sent.</param>
+	/// <param name="state">The state of the key (pressed or released).</param>
+	/// <remarks>
+	/// This method handles special cases for the Shift, Ctrl, and Alt keys to ensure the
+	/// correct virtual key code is used.
+	/// </remarks>
 	public static void SendKey(Key key, KeyboardKeyStates state)
 	{
 		if (Process == null)
@@ -273,6 +457,7 @@ public class MemoryService : ServiceBase<MemoryService>
 		}
 	}
 
+	/// <inheritdoc/>
 	public override async Task Initialize()
 	{
 		await base.Initialize();
@@ -281,16 +466,22 @@ public class MemoryService : ServiceBase<MemoryService>
 		_ = Task.Run(this.ProcessWatcherTask);
 	}
 
+	/// <inheritdoc/>
 	public override async Task Start()
 	{
 		await base.Start();
 	}
 
 	/// <summary>
-	/// Open the PC game process with all security and access rights.
+	/// Opens the specified game process with all necessary security and access rights.
 	/// </summary>
+	/// <param name="process">The process to be opened.</param>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	/// <exception cref="Exception">Thrown if the target process is not responding or has no main module.</exception>
 	public async Task OpenProcess(Process process)
 	{
+		Debug.Assert(process != null, "Process is null");
+
 		Process = process;
 
 		Log.Information($"Opening game process: {process.MainModule?.FileName}");
@@ -380,6 +571,10 @@ public class MemoryService : ServiceBase<MemoryService>
 	[DllImport("user32.dll")]
 	private static extern IntPtr PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
+	/// <summary>
+	/// Attempts to find and open the game process, setting it as the current process.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	private async Task GetProcess()
 	{
 		Process? proc = null;
@@ -409,25 +604,24 @@ public class MemoryService : ServiceBase<MemoryService>
 
 		if (proc != null)
 			await this.OpenProcess(proc);
-
-		IsProcessAlive = true;
 	}
 
+	/// <summary>
+	/// Monitors the game process to ensure it is still running, and attempts to reopen it if it terminates.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	private async Task ProcessWatcherTask()
 	{
 		while (this.IsAlive && Process != null)
 		{
-			await Task.Delay(100);
-
-			DoesProcessHaveFocus = GetDoesProcessHaveFocus();
-			IsProcessAlive = GetIsProcessAlive();
+			await Task.Delay(ProcessRefreshTimerInterval);
 
 			if (!IsProcessAlive)
 			{
 				try
 				{
 					Log.Information("FFXIV Process has terminated");
-					await Task.Delay(10000);
+					await Task.Delay(ProcessWatchdogInterval);
 					TargetService.Instance.ClearSelection();
 					await this.GetProcess();
 				}
@@ -441,21 +635,24 @@ public class MemoryService : ServiceBase<MemoryService>
 					if (ex.InnerException is Win32Exception)
 						continue;
 
-					Log.Error(ex, "Unable to get ffxiv process");
+					Log.Error(ex, "Unable to get FFXIV process");
 				}
 				catch (Exception ex)
 				{
-					Log.Error(ex, "Unable to get ffxiv process");
+					Log.Error(ex, "Unable to get FFXIV process");
 				}
 			}
 		}
 	}
 
-	// Special struct for handling 1 byte bool marshaling
+	/// <summary>
+	/// Special struct for handling 1-byte bool marshaling.
+	/// </summary>
 	private struct OneByteBool
 	{
 #pragma warning disable CS0649
 		[MarshalAs(UnmanagedType.I1)]
 		public bool Value;
+#pragma warning restore CS0649
 	}
 }

--- a/Anamnesis/Core/Memory/SignatureScanner.cs
+++ b/Anamnesis/Core/Memory/SignatureScanner.cs
@@ -2,30 +2,39 @@
 // Licensed under the MIT license.
 
 namespace Anamnesis.Core.Memory;
-
+using Anamnesis.Memory;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using Anamnesis.Memory;
-using Serilog;
-
-#pragma warning disable SA1011
 
 /// <summary>
-/// based on Dalamud's signature scanner: https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/SigScanner.cs.
+/// Provides functionality to scan for specific byte signature patterns within the memory of a process module.
 /// </summary>
-public sealed class SignatureScanner
+/// <remarks>
+/// It is designed to search through the .text and .data sections of a process module to locate specific byte
+/// patterns. Unlike Dalamud's implementation, this class uses the Win32 API to read memory. This is because
+/// Anamnesis does not have access to protected memory regions.
+/// <para>
+/// This class is largely based on Dalamud's SigScanner class, which can be found at:
+/// https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/SigScanner.cs.
+/// </para>
+/// </remarks>
+public unsafe sealed class SignatureScanner
 {
+	/// <summary>The size of each chunk of memory to scan at a time.</summary>
+	private const int ScanChunkSize = 1024; // 1kB
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SignatureScanner"/> class.
 	/// </summary>
-	/// <param name="module">The ProcessModule to be used for scanning.</param>
+	/// <param name="module">The process to be used for scanning.</param>
 	public SignatureScanner(ProcessModule module)
 	{
+		Debug.Assert(module != null, "Process module cannot be null.");
 		this.Module = module;
-		this.Is32BitProcess = !Environment.Is64BitProcess;
 
 		// Limit the search space to .text section.
 		this.SetupSearchSpace(module);
@@ -38,47 +47,139 @@ public sealed class SignatureScanner
 
 		if (this.TextSectionSize <= 0 || this.DataSectionSize <= 0)
 		{
-			throw new Exception("Process module is invalid");
+			throw new ArgumentException("Process module is invalid");
 		}
 	}
 
-	public bool IsCopy { get; private set; }
-	public bool Is32BitProcess { get; }
+	/// <summary>Gets the base address of the module the scanner is attached to.</summary>
 	public IntPtr SearchBase => this.Module.BaseAddress;
-	public IntPtr TextSectionBase => new IntPtr(this.SearchBase.ToInt64() + this.TextSectionOffset);
+
+	/// <summary>Gets the base address of the .text section within the module.</summary>
+	public IntPtr TextSectionBase => new(this.SearchBase.ToInt64() + this.TextSectionOffset);
+
+	/// <summary>Gets the offset of the .text section within the module.</summary>
 	public long TextSectionOffset { get; private set; }
+
+	/// <summary>Gets the size of the .text section within the module.</summary>
 	public int TextSectionSize { get; private set; }
-	public IntPtr DataSectionBase => new IntPtr(this.SearchBase.ToInt64() + this.DataSectionOffset);
+
+	/// <summary>Gets the base address of the .data section within the module.</summary>
+	public IntPtr DataSectionBase => new(this.SearchBase.ToInt64() + this.DataSectionOffset);
+
+	/// <summary>Gets the offset of the .data section within the module.</summary>
 	public long DataSectionOffset { get; private set; }
+
+	/// <summary>Gets the size of the .data section within the module.</summary>
 	public int DataSectionSize { get; private set; }
+
+	/// <summary>Gets the process module the scanner is attached to.</summary>
 	public ProcessModule Module { get; }
 
-	private IntPtr TextSectionTop => this.TextSectionBase + this.TextSectionSize;
+	/// <summary>
+	/// Scans a specified memory region for a given byte signature.
+	/// </summary>
+	/// <param name="baseAddress">The base address of the memory region to scan.</param>
+	/// <param name="size">The size of the memory region to scan.</param>
+	/// <param name="signature">The byte signature to search for. The signature needs to follow the IDA format. </param>
+	/// <returns>The address where the signature is found, or <see cref="IntPtr.Zero"/> if the process is not alive.</returns>
+	/// <exception cref="KeyNotFoundException">Thrown if the signature is not found in the specified memory region.</exception>
+	/// <note>
+	/// - The signature must be in the format of a string of hexadecimal bytes separated by spaces.
+	/// - The signature can contain wildcard characters represented by "??".
+	/// - This algorithm uses the Boyer-Moore algorithm for fast searching by employing a bad character shift table.
+	/// It also searches in chunks to prevent reading large amounts of memory at once, which can cause a significant
+	/// spike in memory usage, leaving the Large Object Heap (LOH) largely fragmented.
+	/// </note>
+	public static IntPtr Scan(IntPtr baseAddress, int size, string signature)
+	{
+		if (!MemoryService.IsProcessAlive)
+			return IntPtr.Zero;
+
+		var (needle, mask, badCharShift) = ParseSignature(signature);
+
+		Debug.Assert(needle != null && needle.Length > 0, "Parsed needle must not be null or empty.");
+		Debug.Assert(mask != null && mask.Length == needle.Length, "Parsed mask must not be null and must match the length of the needle.");
+		Debug.Assert(badCharShift != null && badCharShift.Length == 256, "Bad character shift table must have 256 entries.");
+
+		unsafe
+		{
+			int overlap = needle.Length - 1;
+
+			// Iterate over the memory in chunks
+			for (long offset = 0; offset < size;)
+			{
+				// Calculate the number of bytes to read in the current chunk
+				int bytesToRead = Math.Min(ScanChunkSize, size - (int)offset);
+				Span<byte> chunkBuffer = new byte[bytesToRead + overlap];
+
+				// Read memory into the chunk buffer, including the overlap
+				IntPtr currentAddress = IntPtr.Add(baseAddress, (int)offset);
+				MemoryService.Read(currentAddress, chunkBuffer);
+
+				// Scan the chunk buffer for the signature
+				for (int chunkOffset = 0; chunkOffset < bytesToRead;)
+				{
+					// Check if the current slice of the chunk buffer matches the needle
+					if (IsMatch(needle, mask, chunkBuffer.Slice(chunkOffset, needle.Length)))
+						return IntPtr.Add(currentAddress, chunkOffset);
+
+					// Use the bad character shift table to determine the next offset
+					chunkOffset += badCharShift[chunkBuffer[chunkOffset + needle.Length - 1]];
+				}
+
+				// Move to the next chunk, excluding the overlap to ensure no matches are missed
+				offset += bytesToRead;
+			}
+		}
+
+		// Throw an exception if the signature is not found
+		throw new KeyNotFoundException($"Signature \"{signature}\" not found.");
+	}
 
 	/// <summary>
 	/// Scan for a byte signature in the .text section.
 	/// </summary>
 	/// <param name="signature">The signature.</param>
 	/// <returns>The real offset of the found signature.</returns>
+	/// <exception cref="ArgumentNullException">Thrown if the signature is null.</exception>
+	/// <exception cref="KeyNotFoundException">
+	/// Thrown if the signature is not found in the .text section or a conflict is encountered.
+	/// </exception>
+	/// <remarks>
+	/// The signature needs to follow the IDA format.
+	/// </remarks>
 	public IntPtr ScanText(string signature)
 	{
-		IntPtr mBase = this.TextSectionBase;
-		IntPtr scanRet = this.Scan(mBase, this.TextSectionSize, signature);
+		if (signature == null)
+			throw new ArgumentNullException(nameof(signature));
 
-		if (ReadByte(scanRet) == 0xE8)
-			return this.ReadCallSig(scanRet);
+		IntPtr scanRet = Scan(this.TextSectionBase, this.TextSectionSize, signature);
+
+		var startByte = MemoryService.ReadByte(scanRet);
+		if (startByte == 0xE8 || startByte == 0xE9)
+		{
+			scanRet = ReadJmpCallSig(scanRet);
+			var rel = scanRet.ToInt64() - this.Module.BaseAddress.ToInt64();
+			if (rel < 0 || rel >= this.TextSectionSize)
+			{
+				throw new KeyNotFoundException(
+					$"Signature \"{signature}\" resolved to 0x{rel:X} which is outside the .text section. Possible signature conflicts?");
+			}
+		}
 
 		return scanRet;
 	}
 
 	/// <summary>
-	/// Scan for a .data address using a .text function.
-	/// This is intended to be used with IDA sigs.
-	/// Place your cursor on the line calling a static address, and create and IDA sig.
+	/// Get a .data address by scanning for the signature in the .text memory region.
 	/// </summary>
-	/// <param name="signature">The signature of the function using the data.</param>
-	/// <param name="offset">The offset from function start of the instruction using the data.</param>
-	/// <returns>An IntPtr to the static memory location.</returns>
+	/// <param name="signature">The signature of the function using the data. </param>
+	/// <param name="offset">The offset from function start of the instruction using the data. </param>
+	/// <returns> A pointer to the static address. </returns>
+	/// <remarks>
+	/// To create a signature, use IDA to find the function calling the static address.
+	/// Then place your cursor on the line calling the address and create the signature.
+	/// </remarks>
 	public IntPtr GetStaticAddressFromSig(string signature, int offset = 0)
 	{
 		IntPtr instrAddr = this.ScanText(signature);
@@ -89,11 +190,11 @@ public sealed class SignatureScanner
 		do
 		{
 			instrAddr = IntPtr.Add(instrAddr, 1);
-			num = ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
+			num = MemoryService.ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
 			steps--;
 		}
 		while (steps > 0 && !(num >= this.DataSectionOffset && num <= this.DataSectionOffset + this.DataSectionSize));
-		return IntPtr.Add(instrAddr, ReadInt32(instrAddr) + 4);
+		return IntPtr.Add(instrAddr, MemoryService.ReadInt32(instrAddr) + 4);
 	}
 
 	/// <summary>
@@ -101,182 +202,171 @@ public sealed class SignatureScanner
 	/// </summary>
 	/// <param name="signature">The signature.</param>
 	/// <returns>The real offset of the found signature.</returns>
-	public IntPtr ScanData(string signature)
-	{
-		IntPtr scanRet = this.Scan(this.DataSectionBase, this.DataSectionSize, signature);
-		return scanRet;
-	}
+	public IntPtr ScanData(string signature) => Scan(this.DataSectionBase, this.DataSectionSize, signature);
 
 	/// <summary>
 	/// Scan for a byte signature in the whole module search area.
 	/// </summary>
 	/// <param name="signature">The signature.</param>
 	/// <returns>The real offset of the found signature.</returns>
-	public IntPtr ScanModule(string signature)
-	{
-		IntPtr scanRet = this.Scan(this.SearchBase, this.Module.ModuleMemorySize, signature);
-		return scanRet;
-	}
+	public IntPtr ScanModule(string signature) => Scan(this.SearchBase, this.Module.ModuleMemorySize, signature);
 
-	public IntPtr Scan(IntPtr baseAddress, int size, string signature)
-	{
-		if (!MemoryService.GetIsProcessAlive())
-			return IntPtr.Zero;
-
-		byte?[]? needle = this.SigToNeedle(signature);
-
-		// Fast
-		byte[] bigBuffer = new byte[size];
-		MemoryService.Read(baseAddress, bigBuffer, size);
-
-		unsafe
-		{
-			for (long offset = 0; offset < size - needle.Length; offset++)
-			{
-				if (this.IsMatch(needle, bigBuffer, offset))
-				{
-					UIntPtr ptr = new UIntPtr(Convert.ToUInt64(baseAddress.ToInt64() + offset));
-					return (IntPtr)ptr.ToPointer();
-				}
-			}
-		}
-
-		throw new KeyNotFoundException($"Can't find a signature of {signature}");
-	}
-
+	/// <summary>
+	/// Resolve a RVA address.
+	/// </summary>
+	/// <param name="nextInstAddr">The address of the next instruction.</param>
+	/// <param name="relOffset">The relative offset.</param>
+	/// <returns>The calculated offset.</returns>
 	public IntPtr ResolveRelativeAddress(IntPtr nextInstAddr, int relOffset)
 	{
-		if (this.Is32BitProcess)
-			throw new NotSupportedException("32 bit is not supported.");
+		if (!Environment.Is64BitProcess)
+			throw new NotSupportedException("32-bit processes are not supported.");
 
 		return nextInstAddr + relOffset;
 	}
 
-	private static byte ReadByte(IntPtr baseAddress, int offset = 0)
+	/// <summary>
+	/// Build a bad character shift table for the Boyer-Moore algorithm, taking into account the bitmask.
+	/// </summary>
+	/// <param name="needle">The byte signature to search for.</param>
+	/// <param name="mask">The mask to indicate wildcard bytes.</param>
+	/// <returns>The bad character shift table.</returns>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static int[] BuildBadCharTable(byte[] needle, bool[] mask)
 	{
-		byte[] buffer = new byte[1];
-		MemoryService.Read(baseAddress + offset, buffer, 1);
-		return buffer[0];
-	}
-
-	private static int ReadInt32(IntPtr baseAddress, int offset = 0)
-	{
-		byte[] buffer = new byte[4];
-		MemoryService.Read(baseAddress + offset, buffer, 4);
-		return BitConverter.ToInt32(buffer);
-	}
-
-	private static short ReadInt16(IntPtr baseAddress, int offset = 0)
-	{
-		byte[] buffer = new byte[2];
-		MemoryService.Read(baseAddress + offset, buffer, 2);
-		return BitConverter.ToInt16(buffer);
-	}
-
-	private static long ReadInt64(IntPtr baseAddress, int offset = 0)
-	{
-		byte[] buffer = new byte[8];
-		MemoryService.Read(baseAddress + offset, buffer, 8);
-		return BitConverter.ToInt64(buffer);
-	}
-
-	private void SetupSearchSpace(ProcessModule module)
-	{
-		IntPtr baseAddress = module.BaseAddress;
-
-		// We don't want to read all of IMAGE_DOS_HEADER or IMAGE_NT_HEADER stuff so we cheat here.
-		int ntNewOffset = ReadInt32(baseAddress, 0x3C);
-		IntPtr ntHeader = baseAddress + ntNewOffset;
-
-		// IMAGE_NT_HEADER
-		IntPtr fileHeader = ntHeader + 4;
-		short numSections = ReadInt16(ntHeader, 6);
-
-		// IMAGE_OPTIONAL_HEADER
-		IntPtr optionalHeader = fileHeader + 20;
-
-		IntPtr sectionHeader;
-		if (this.Is32BitProcess) // IMAGE_OPTIONAL_HEADER32
-			sectionHeader = optionalHeader + 224;
-		else // IMAGE_OPTIONAL_HEADER64
-			sectionHeader = optionalHeader + 240;
-
-		// IMAGE_SECTION_HEADER
-		IntPtr sectionCursor = sectionHeader;
-		for (int i = 0; i < numSections; i++)
+		int idx;
+		var last = needle.Length - 1;
+		var badShift = new int[256];
+		for (idx = last; idx > 0 && mask[idx]; --idx)
 		{
-			long sectionName = ReadInt64(sectionCursor);
-
-			// .text
-			switch (sectionName)
-			{
-				case 0x747865742E: // .text
-					this.TextSectionOffset = ReadInt32(sectionCursor, 12);
-					this.TextSectionSize = ReadInt32(sectionCursor, 8);
-					break;
-				case 0x617461642E: // .data
-					this.DataSectionOffset = ReadInt32(sectionCursor, 12);
-					this.DataSectionSize = ReadInt32(sectionCursor, 8);
-					break;
-			}
-
-			sectionCursor += 40;
 		}
+
+		var diff = last - idx;
+		if (diff == 0)
+			diff = 1;
+
+		for (idx = 0; idx <= 255; ++idx)
+			badShift[idx] = diff;
+		for (idx = last - diff; idx < last; ++idx)
+			badShift[needle[idx]] = last - idx;
+		return badShift;
 	}
 
 	/// <summary>
-	/// Helper for ScanText to get the correct address for
-	/// IDA sigs that mark the first CALL location.
+	/// Parse the string-form byte signature into a byte array, mask, and bad character shift table.
 	/// </summary>
-	/// <param name="sigLocation">The address the CALL sig resolved to.</param>
-	/// <returns>The real offset of the signature.</returns>
-	private IntPtr ReadCallSig(IntPtr sigLocation)
+	/// <param name="signature">The byte signature to parse (IDA format).</param>
+	/// <returns>The parsed byte signature, mask, and bad character shift table.</returns>
+	/// <exception cref="ArgumentException">The signature is not even in length.</exception>
+	private static (byte[] needle, bool[] mask, int[] badCharShift) ParseSignature(string signature)
 	{
-		int jumpOffset = ReadInt32(IntPtr.Add(sigLocation, 1));
-		return IntPtr.Add(sigLocation, 5 + jumpOffset);
+		// Strip all whitespaces
+		signature = signature.Replace(" ", string.Empty);
+		if (signature.Length % 2 != 0)
+			throw new ArgumentException("Stripped signatures must be even in length", nameof(signature));
+
+		int needleLength = signature.Length / 2;
+		byte[] needle = new byte[needleLength];
+		bool[] mask = new bool[needleLength];
+
+		ReadOnlySpan<char> sigSpan = signature.AsSpan();
+		for (int i = 0; i < needleLength; i++)
+		{
+			ReadOnlySpan<char> hexString = sigSpan.Slice(i * 2, 2);
+			if (hexString.SequenceEqual("??") || hexString.SequenceEqual("**"))
+			{
+				needle[i] = 0;
+				mask[i] = false;
+				continue;
+			}
+
+			needle[i] = byte.Parse(hexString, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+			mask[i] = true;
+		}
+
+		return (needle, mask, BuildBadCharTable(needle, mask));
 	}
 
+	/// <summary>
+	/// Check if the buffer matches the needle.
+	/// </summary>
+	/// <param name="needle">The byte signature to search for.</param>
+	/// <param name="mask">The mask to indicate wildcard bytes.</param>
+	/// <param name="buffer">The buffer to search in.</param>
+	/// <returns>True if the buffer matches the needle, false otherwise.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private unsafe bool IsMatch(byte?[] needle, byte[] buffer, long offset)
+	private static unsafe bool IsMatch(byte[] needle, bool[] mask, Span<byte> buffer)
 	{
 		for (int i = 0; i < needle.Length; i++)
 		{
-			byte? expected = needle[i];
-			if (expected == null)
-				continue;
-
-			byte actual = buffer[offset + i];
-			if (expected != actual)
+			if (mask[i] && needle[i] != buffer[i])
 				return false;
 		}
 
 		return true;
 	}
 
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private byte?[] SigToNeedle(string signature)
+	/// <summary>
+	/// A helper method to ScanText to get the correct address for
+	/// IDA signatures that mark the first CALL location.
+	/// </summary>
+	/// <param name="sigLocation">The address the CALL sig resolved to.</param>
+	/// <returns>The real offset of the signature.</returns>
+	private static IntPtr ReadJmpCallSig(IntPtr sigLocation)
 	{
-		// Strip all whitespaces
-		signature = signature.Replace(" ", string.Empty);
+		int jumpOffset = MemoryService.ReadInt32(IntPtr.Add(sigLocation, 1));
+		return IntPtr.Add(sigLocation, 5 + jumpOffset);
+	}
 
-		if (signature.Length % 2 != 0)
-			throw new ArgumentException("Signature without whitespaces must be divisible by two.", nameof(signature));
+	/// <summary>
+	/// Sets up the search space by identifying the offsets and sizes of the .text and .data sections
+	/// within the specified process module.
+	/// </summary>
+	/// <param name="module">The process module to analyze.</param>
+	private void SetupSearchSpace(ProcessModule module)
+	{
+		IntPtr baseAddress = module.BaseAddress;
 
-		int needleLength = signature.Length / 2;
-		byte?[]? needle = new byte?[needleLength];
+		// We don't want to read all of IMAGE_DOS_HEADER or IMAGE_NT_HEADER stuff so we cheat here.
+		int ntNewOffset = MemoryService.ReadInt32(baseAddress, 0x3C);
+		IntPtr ntHeader = baseAddress + ntNewOffset;
 
-		for (int i = 0; i < needleLength; i++)
+		// IMAGE_NT_HEADER
+		IntPtr fileHeader = ntHeader + 4;
+		short numSections = MemoryService.ReadInt16(ntHeader, 6);
+
+		// IMAGE_OPTIONAL_HEADER
+		IntPtr optionalHeader = fileHeader + 20;
+
+		IntPtr sectionHeader;
+		if (Environment.Is64BitProcess) // IMAGE_OPTIONAL_HEADER64
+			sectionHeader = optionalHeader + 240;
+		else // IMAGE_OPTIONAL_HEADER32
+			sectionHeader = optionalHeader + 224;
+
+		// IMAGE_SECTION_HEADER
+		IntPtr sectionCursor = sectionHeader;
+		for (int i = 0; i < numSections; i++)
 		{
-			string? hexString = signature.Substring(i * 2, 2);
-			if (hexString == "??" || hexString == "**")
+			long sectionName = MemoryService.ReadInt64(sectionCursor);
+
+			// .text
+			switch (sectionName)
 			{
-				needle[i] = null;
-				continue;
+				case 0x747865742E: // .text
+					this.TextSectionOffset = MemoryService.ReadInt32(sectionCursor, 12);
+					this.TextSectionSize = MemoryService.ReadInt32(sectionCursor, 8);
+					break;
+				case 0x617461642E: // .data
+					this.DataSectionOffset = MemoryService.ReadInt32(sectionCursor, 12);
+					this.DataSectionSize = MemoryService.ReadInt32(sectionCursor, 8);
+					break;
 			}
 
-			needle[i] = byte.Parse(hexString, NumberStyles.AllowHexSpecifier);
+			sectionCursor += 40;
 		}
 
-		return needle;
+		Debug.Assert(this.TextSectionSize > 0, "Text section size must be greater than 0.");
+		Debug.Assert(this.DataSectionSize > 0, "Data section size must be greater than 0.");
 	}
 }


### PR DESCRIPTION
_Note: This is the first of a series of optimization changes that I would like to propose to be introduced to Anamnesis. This one in particular tackles an issue I identified while running the application through a memory profiler._

---

### The issue

During application initialization, the signature scanner runs through the `.text` memory region of the game process, getting all of its data. During this scanning process, a temporary byte buffer is created, equal to the size of the entire `.text` memory region. Several of those signature scans run in parallel to load in actor, weather, terrain, action timeline, etc. During this time, different threads are loading in the game data from Lumina.

https://github.com/imchillin/Anamnesis/blob/dd42f7225d1dd8c06ab8bf25d34d1e0c09e0f918/Anamnesis/Core/Memory/SignatureScanner.cs#L129

The temporary buffers for the scan eventually get deallocated by the garbage collector (GC), shortly after the application startup. Whereas, the information retrieved from Lumina will persist, fragmented in sections within the Large Object Heap (LOH).

As visualized by JetBrains dotMemory, the LOH skyrockets to ~860 MB:
> Debug Build
![image](https://github.com/user-attachments/assets/f86d0bf3-2c83-4d99-918a-f9fa5c7d6286)

Upon digging deeper, the profiler reveals that the LOH is not only fragmented but also left mostly unused:
> Debug Build
![image](https://github.com/user-attachments/assets/8a43b3cb-a85f-4d49-b8a2-5019b5d62f92)

As a result, the Anamnesis application ends up taking 1.0+ GB of memory out of the user's PC:
> Release Build*
![image](https://github.com/user-attachments/assets/b5505abf-18b8-4c57-be97-50010dc2893c)

---

### The solution

By default, the GC never compacts LOH. Running such a process introduces a significant performance penalty, hence why its usage is generally frowned upon. Furthermore, manually using the GC does not resolve the issue of the initial LOH spike, which would cause Anamnesis to run out of space on a PC with limited RAM. ([Microsoft Docs](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.gcsettings.largeobjectheapcompactionmode?view=net-6.0))

This is why I decided to rework the signature scanner, alongside some modifications to the memory service, to better handle memory read and write operations.

I tried two approaches for scanner:
1) Implementing the [Knuth–Morris–Pratt algorithm](https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm).
2) Implementing the [Boyer–Moore string-search algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm).

It seems that out of the two, the BM algorithm performed better for this use case, so I decided to use that one. Dalamud also seems to use this approach so opted to use their utility function to build the bad character shift table. The tricky part to creating the shift table is accounting for the needle bitmask and their solution is an optimal one.

However, this alone significantly reduces performance, increasing init times, compared to the old Anamnesis solution. This is because the `MemoryService.Read` (which uses ReadProcessMemory under the hood) function call is a relatively slow process (2000-3000ns per call). As a result, I combined the BM algorithm with a memory chunking process to reduce the number of memory read calls. The new algorithm also uses an overlap to account for signatures that might end up between two memory chunks.

After some testing, I opted for a **1kB** buffer chunk size. Increasing the size after this point seems to have a diminishing performance return, increasing memory usage.

---

### Results

The LOH size dropped from ~860 MB to just ~125 MB:
> Debug Build
![image](https://github.com/user-attachments/assets/941b7754-6b0a-4ece-a92d-bd097caf353a)

The LOH now sits between 85-90% utilization with a similar fragmentation percentage:
> Debug Build
![image](https://github.com/user-attachments/assets/7c69bff0-c422-467d-80a0-2a01c8f9d3b7)

After booting up the applicaiton, Anamnesis' memory usage is now:
> Release Build*
![image](https://github.com/user-attachments/assets/bafc26b2-bfbe-461f-b680-40fb30c85688)

---

### Memory vs Performance

Typically, reducing memory comes with a performance penalty. However, due to the use of the Boyer-Moore algorithm, the proposed solution not only tremendously decreases memory use but also improves the signature scanner's performance, thus decreasing initialization times.

On a **Release** build, the logs reveal the following initialization times:
**Before:**
> Initialized service: MemoryService in 1293ms
> Initialized service: AddressService in 139ms
> Services intialized in 3755ms

**After:**
> Initialized service: MemoryService in 678ms
> Initialized service: AddressService in 126ms
> Services intialized in 2383ms

\* The memory usage screenshots were taken directly after opening the application and switching to the Actor Tab (which defaults to the equipment editor view).