### PR TITLE
Fixed a missing default case for loading a dt pose on a dt face.

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -367,16 +367,24 @@ public partial class PosePage : UserControl
 
 					if (poseFile.IsPreDTPoseFile() && !this.Skeleton.HasPreDTFace)
 					{
+						// Old pose, and new face. Warn, load as EW expression if OK.
 						doPreDtExpressionPoseModeOnOK = true;
 					}
 					else if (!poseFile.IsPreDTPoseFile() && this.Skeleton.HasPreDTFace)
 					{
+						// New pose and old face. Warn, load as DT expression if OK.
 						dialogMsgKey = "Pose_WarningExpresionNewOnOld";
 					}
 					else if (poseFile.IsPreDTPoseFile() && this.Skeleton.HasPreDTFace)
 					{
+						// Old pose and old face. Don't warn, load as EW expression.
 						showDialog = false;
 						doPreDtExpressionPoseModeOnOK = true;
+					}
+					else
+					{
+						// New pose and new face. Don't warn. Everything is OK.
+						showDialog = false;
 					}
 
 					if(showDialog)


### PR DESCRIPTION
This pull request adds a missing else condition when importing poses, for the case when we are loading a DT pose on to a DT face. The issue was users would have been warned for this particular use case, when they should not be. They should only be prompted when importing an old pose on a new face OR a new pose on an old face.

I tested with a new face (my character) and an old face (Aymeric). I loaded an old expression and a new expression on both characters and got the desired results.