### PR TITLE
Resolved issue with Json serialization, causing Vector2 objects not to (de)serialize

### DIFF
--- a/Anamnesis/Serialization/Converters/VectorConverter.cs
+++ b/Anamnesis/Serialization/Converters/VectorConverter.cs
@@ -9,15 +9,25 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using XivToolsWpf.Math3D.Extensions;
 
-public class VectorConverter : JsonConverter<Vector3>
+public class Vector2Converter : JsonConverter<Vector2>
+{
+	public override Vector2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		string? str = reader.GetString() ?? throw new Exception("Cannot convert null to Vector2");
+		return VectorExtensions.FromString2D(str);
+	}
+
+	public override void Write(Utf8JsonWriter writer, Vector2 value, JsonSerializerOptions options)
+	{
+		writer.WriteStringValue(value.ToInvariantString());
+	}
+}
+
+public class Vector3Converter : JsonConverter<Vector3>
 {
 	public override Vector3 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		string? str = reader.GetString();
-
-		if (str == null)
-			throw new Exception("Cannot convert null to Vector");
-
+		string? str = reader.GetString() ?? throw new Exception("Cannot convert null to Vector3");
 		return VectorExtensions.FromString3D(str);
 	}
 

--- a/Anamnesis/Serialization/SerializerService.cs
+++ b/Anamnesis/Serialization/SerializerService.cs
@@ -3,11 +3,11 @@
 
 namespace Anamnesis.Serialization;
 
+using Anamnesis.Serialization.Converters;
 using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Anamnesis.Serialization.Converters;
 
 public class SerializerService : ServiceBase<SerializerService>
 {
@@ -26,7 +26,8 @@ public class SerializerService : ServiceBase<SerializerService>
 		Options.Converters.Add(new Color4Converter());
 		Options.Converters.Add(new ColorConverter());
 		Options.Converters.Add(new QuaternionConverter());
-		Options.Converters.Add(new VectorConverter());
+		Options.Converters.Add(new Vector2Converter());
+		Options.Converters.Add(new Vector3Converter());
 		Options.Converters.Add(new IItemConverter());
 		Options.Converters.Add(new IDyeConverter());
 		Options.Converters.Add(new ItemCategoriesConverter());


### PR DESCRIPTION
_Note: https://github.com/Aether-Tools/AetherToolsWpf/pull/3 needs to be merged first._

---

Fixed an issue causing Vector2 objects not to serialize. The Json serializer was missing a converter for Vector2 objects.