### PR TITLE
Extended Vector2 converter to support the old Vector2D format

### DIFF
--- a/Anamnesis/Serialization/Converters/VectorConverter.cs
+++ b/Anamnesis/Serialization/Converters/VectorConverter.cs
@@ -13,8 +13,28 @@ public class Vector2Converter : JsonConverter<Vector2>
 {
 	public override Vector2 Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		string? str = reader.GetString() ?? throw new Exception("Cannot convert null to Vector2");
-		return VectorExtensions.FromString2D(str);
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			// New format: "X, Y"
+			string? str = reader.GetString() ?? throw new Exception("Cannot convert null to Vector2");
+			return VectorExtensions.FromString2D(str);
+		}
+		else if (reader.TokenType == JsonTokenType.StartObject)
+		{
+			// Fallback to old format: { "X": 0, "Y": 0 }
+			using JsonDocument document = JsonDocument.ParseValue(ref reader);
+			JsonElement root = document.RootElement;
+
+			if (root.TryGetProperty("X", out JsonElement propX) && propX.TryGetSingle(out float x) &&
+				root.TryGetProperty("Y", out JsonElement propY) && propY.TryGetSingle(out float y))
+				return new Vector2(x, y);
+			else
+				throw new JsonException("Invalid JSON format for Vector2. Expected properties 'X' and 'Y' with float values.");
+		}
+		else
+		{
+			throw new Exception("Unexpected token type encountered during string to Vector2 conversion");
+		}
 	}
 
 	public override void Write(Utf8JsonWriter writer, Vector2 value, JsonSerializerOptions options)


### PR DESCRIPTION
This pull request resolves the "Fail to open file: The JSON value could not be converted to System.Numerics.Vector2" error that was reported during the first round of testing. The context of the reported error is scene files, though old exported camera files were also affected.

In #1385 I replaced the custom Anamnesis vector objects with System.Numerics variants. It turns out that the way the old 2D and 3D vector structs were serialized differed, and my implementation did not account for that difference (refer to the format difference below). As part of that pull request, I opted for a single format that is used for both 2D and 3D vectors, without realizing that although their "ToString" methods followed the format, Json serialization did not. This is what caused the issue this pull request aims to fix.

**Old format:**
```
"Pan": 
{
      "X": 0.17714392,
      "Y": -0.2959028
},
```

**New format:**
```
"0.17714392, -0.2959028"
```