### PR TITLE
Resolved issue causing skeleton deformations on history undo

### DIFF
--- a/Anamnesis/Core/Memory/MemoryService.cs
+++ b/Anamnesis/Core/Memory/MemoryService.cs
@@ -418,7 +418,7 @@ public class MemoryService : ServiceBase<MemoryService>
 			}
 		}
 
-		Log.Verbose($"Writing: {buffer.Length} bytes to {address} for type {type.Name} for reason: {reason}");
+		// Log.Verbose($"Writing: {buffer.Length} bytes to {address} for type {type.Name} for reason: {reason}");
 		return Write(address, buffer, false);
 	}
 

--- a/Anamnesis/Files/PoseFile.cs
+++ b/Anamnesis/Files/PoseFile.cs
@@ -116,7 +116,7 @@ public class PoseFile : JsonFileBase
 			throw new Exception("Actor has no model");
 
 		if (actor.ModelObject.Skeleton == null)
-			throw new Exception("Actor model has no skeleton");
+			throw new Exception("Actor model has no skeleton. Are you trying to load a pose outside of GPose?");
 
 		if (this.Bones == null)
 			return;
@@ -129,28 +129,35 @@ public class PoseFile : JsonFileBase
 
 		if (bones == null)
 		{
-			if (mode.HasFlag(Mode.WorldScale) && this.Scale != null)
-				actor.ModelObject.Transform.Scale = (Vector3)this.Scale;
+			if (mode.HasFlag(Mode.WorldScale) && this.Scale.HasValue)
+				actor.ModelObject.Transform.Scale = this.Scale.Value;
 
-			if (mode.HasFlag(Mode.WorldRotation) && this.Rotation != null)
-				actor.ModelObject.Transform.Rotation = (Quaternion)this.Rotation;
+			if (mode.HasFlag(Mode.WorldRotation) && this.Rotation.HasValue)
+				actor.ModelObject.Transform.Rotation = this.Rotation.Value;
 		}
 
-		SkeletonMemory? skeletonMem = actor.ModelObject.Skeleton;
+		SkeletonMemory skeletonMem = actor.ModelObject.Skeleton;
 
 		PoseService.Instance.SetEnabled(true);
 		PoseService.Instance.CanEdit = false;
 		skeletonMem.PauseSynchronization = true;
-		await Task.Delay(100);
 
-		// Create a back up of the relative rotations of every bones
-		Dictionary<string, Quaternion> unPosedBoneRotations = new Dictionary<string, Quaternion>();
+		// Create a backup of all bone transforms
+		// Keep in mind that unposed bone transforms is a collection of character-relative transforms.
+		// Meanwhile, posed bone positions is a collection of parent-relative positions.
+		Dictionary<string, Transform> unposedBoneTransforms = new();
+		Dictionary<string, Vector3> posedBonePositions = new();
 		foreach ((string name, BoneVisual3d bone) in skeleton.Bones)
 		{
 			if (GetBoneMode(actor, skeleton, name) == BoneProcessingModes.Ignore)
 				continue;
 
-			unPosedBoneRotations.Add(name, bone.Rotation);
+			unposedBoneTransforms[bone.BoneName] = new Transform
+			{
+				Position = bone.Position,
+				Rotation = bone.Rotation,
+				Scale = bone.Scale,
+			};
 		}
 
 		// Facial expressions hack:
@@ -172,7 +179,79 @@ public class PoseFile : JsonFileBase
 			originalHeadPosition = headBone?.Position;
 		}
 
-		// Apply all transforms a few times to ensure parent-inherited values are caluclated correctly, and to ensure
+		// Collect the parent-relative positions of all posed bones
+		foreach ((string name, Bone? savedBone) in this.Bones)
+		{
+			if (savedBone == null)
+				continue;
+
+			string boneName = LegacyBoneNameConverter.GetModernName(name) ?? name;
+
+			// Don't apply bones that cant be serialized.
+			if (GetBoneMode(actor, skeleton, boneName) != BoneProcessingModes.FullLoad)
+				continue;
+
+			BoneVisual3d? bone = skeleton.GetBone(boneName);
+
+			if (bone == null)
+			{
+				Log.Warning($"Bone: \"{boneName}\" not found");
+				continue;
+			}
+
+			if (bones != null && !bones.Contains(boneName))
+				continue;
+
+			unposedBoneTransforms.Remove(boneName);
+
+			foreach (TransformMemory transformMemory in bone.TransformMemories)
+			{
+				if (savedBone.Position != null && !mode.HasFlag(Mode.Position))
+				{
+					posedBonePositions.TryAdd(boneName, transformMemory.Position);
+				}
+			}
+		}
+
+		// Add unposed bone transform positions to posedBonePositions
+		// This is necessary to recover the positions of bones that are not explicitly
+		// written to while "Freeze Position" is enabled.
+		if (!mode.HasFlag(Mode.Position))
+		{
+			foreach (var unposedBone in unposedBoneTransforms)
+			{
+				if (!posedBonePositions.ContainsKey(unposedBone.Key))
+				{
+					BoneVisual3d? bone = skeleton.GetBone(unposedBone.Key);
+					if (bone == null)
+						continue;
+
+					// Position is retrieved from the memory, not the bone itself
+					posedBonePositions.Add(unposedBone.Key, bone.TransformMemory.Position);
+				}
+			}
+		}
+
+		// Record position changes if bones are posed without position to preserve positions.
+		foreach ((string name, Vector3 pos) in posedBonePositions)
+		{
+			BoneVisual3d? bone = skeleton.GetBone(name);
+
+			if (bone == null)
+				continue;
+
+			if (!bone.TransformMemory.Binds.TryGetValue("Position", out PropertyBindInfo? bindInfo))
+			{
+				Log.Error($"Failed to find position bind for bone: {name}");
+				continue;
+			}
+
+			PropertyChange change = new(bindInfo, pos, pos, PropertyChange.Origins.User);
+			change.ConfigureBindPath();
+			actor.History.Record(change);
+		}
+
+		// Apply all transforms a few times to ensure parent-inherited values are calculated correctly, and to ensure
 		// we dont end up with some values read during a ffxiv frame update.
 		for (int i = 0; i < 3; i++)
 		{
@@ -181,10 +260,7 @@ public class PoseFile : JsonFileBase
 				if (savedBone == null)
 					continue;
 
-				string boneName = name;
-				string? modernName = LegacyBoneNameConverter.GetModernName(name);
-				if (modernName != null)
-					boneName = modernName;
+				string boneName = LegacyBoneNameConverter.GetModernName(name) ?? name;
 
 				// Don't apply bones that cant be serialized.
 				if (GetBoneMode(actor, skeleton, boneName) != BoneProcessingModes.FullLoad)
@@ -200,9 +276,6 @@ public class PoseFile : JsonFileBase
 
 				if (bones != null && !bones.Contains(boneName))
 					continue;
-
-				// Remove this bone from the relative rotations backup
-				unPosedBoneRotations.Remove(boneName);
 
 				foreach (TransformMemory transformMemory in bone.TransformMemories)
 				{
@@ -226,7 +299,7 @@ public class PoseFile : JsonFileBase
 				bone.WriteTransform(skeleton, false);
 			}
 
-			await Task.Delay(1);
+			await Task.Delay(10);
 		}
 
 		// Restore the head bone rotation if we were only loading an expression
@@ -238,21 +311,23 @@ public class PoseFile : JsonFileBase
 		}
 
 		// Restore the relative rotations of any bones that we did not explicitly write to.
-		foreach ((string name, Quaternion rotation) in unPosedBoneRotations)
+		foreach ((string name, Transform transform) in unposedBoneTransforms)
 		{
 			BoneVisual3d? bone = skeleton.GetBone(name);
-
 			if (bone == null)
 				continue;
 
-			bone.Rotation = rotation;
+			bone.Rotation = transform.Rotation;
+			bone.Position = transform.Position;
+			bone.Scale = transform.Scale;
 			bone.WriteTransform(skeleton, false);
 		}
 
+		// Give enough time for the game to process the bone transform updates.
 		await Task.Delay(100);
 
 		skeletonMem.PauseSynchronization = false;
-		skeletonMem.Synchronize();
+		skeletonMem.WriteDelayedBinds();
 
 		PoseService.Instance.CanEdit = true;
 	}

--- a/Anamnesis/Files/SceneFile.cs
+++ b/Anamnesis/Files/SceneFile.cs
@@ -154,6 +154,7 @@ public class SceneFile : JsonFileBase
 
 			if (mode.HasFlag(Mode.Pose))
 			{
+				// TODO: This should follow the same approach as the pose page imports
 				await entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation, true);
 			}
 		}

--- a/Anamnesis/Memory/MemoryBase.cs
+++ b/Anamnesis/Memory/MemoryBase.cs
@@ -43,6 +43,9 @@ public class MemObjPropertyChangedEventArgs : PropertyChangedEventArgs
 [AddINotifyPropertyChangedInterface]
 public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 {
+	/// <summary>Dictionary of the object's property bindings.</summary>
+	public readonly Dictionary<string, PropertyBindInfo> Binds = new();
+
 	/// <summary>
 	/// A thread-local variable that determines whether property notifications should be suppressed.
 	/// </summary>
@@ -54,9 +57,6 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 
 	/// <summary>List of child memory objects.</summary>
 	protected readonly List<MemoryBase> Children = new();
-
-	/// <summary>Dictionary of the object's property bindings.</summary>
-	protected readonly Dictionary<string, PropertyBindInfo> Binds = new();
 
 	/// <summary>Set of delayed binds to be written later.</summary>
 	/// <remarks>

--- a/Anamnesis/Memory/PropertyChange.cs
+++ b/Anamnesis/Memory/PropertyChange.cs
@@ -121,6 +121,29 @@ public struct PropertyChange
 	}
 
 	/// <summary>
+	/// Adds all ancestor binds of the parent bind to the property change.
+	/// </summary>
+	/// <remarks>
+	/// Use this method only if the change's bind path is not already configured.
+	/// </remarks>
+	public void ConfigureBindPath()
+	{
+		var parentBind = this.BindPath[0].Memory.ParentBind;
+		if (parentBind == null)
+			return;
+
+		this.AddPath(parentBind);
+		var memParent = parentBind.Memory.Parent;
+		while (memParent != null)
+		{
+			if (memParent.ParentBind != null)
+				this.AddPath(memParent.ParentBind);
+
+			memParent = memParent.Parent;
+		}
+	}
+
+	/// <summary>
 	/// Returns a string that represents the current object.
 	/// </summary>
 	/// <returns>A string that represents the current object.</returns>


### PR DESCRIPTION
This pull request aims to fix the skeleton deformations that occur when you attempt to undo a pose import with frozen positions.
The issue was two-fold:
1. Due to the task delays placed within the pose import methods, history was being commited mid-import. This caused Anamnesis to create two entries in history instead of one.
2. Since the body section of a pose is imported without positions by the default import process, this means that posed bone positions are not stored in the history entry (since no positions change). However, when you undo that pose while positions are frozen, position values will try to stay in the same character-relative space prior to the undo step, while rotations change. This causes the skeleton to deform.

My proposed solution resolves the issue by:
1. Adding a property to stop the history's auto-commit. This allows me to manually commit when I'm done with the pose import.
2. Explicitly adding parent-relative positions in the history entry. This allows the undo step to reapply positions. Here I account for both posed bones (with import mode without positions) and for unposed bones (e.g. faces on body-only import).

---
#### Changelog:
- Added a TODO note in scene file. Fixing scene pose import will be handled in a separate pull request.
- Commented out verbose logs on memory and history changes. This was causing slowdowns during posing as the output was flooded with log messages. If we need to debug those sections of code in the future, the log writes can be readded.
- Added `ConfigureBindPath` method in PropertyChange to construct full bind paths for a changed property. This allows us to differentiate between property changes within the scope of the History module. Otherwise, the explicit position change written to the history entry will have path ".Position".
- Added auto-commit property to History class. This can be used to temporarily disable the auto-commit, allowing us to commit manually.
- Cleaned up pose import code. This includes some removed delays that are not necessary.
- Created explicit position entries in history entry to make the application reapply positions on history undo step.