### PR TITLE
Simplified import process; Resolved issue causing facial expression to reset due to bone mismatch

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -412,7 +412,7 @@ public partial class PosePage : UserControl
 			PoseService.Instance.SetEnabled(true);
 			PoseService.Instance.FreezeScale |= mode.HasFlag(PoseFile.Mode.Scale);
 			PoseService.Instance.FreezeRotation |= mode.HasFlag(PoseFile.Mode.Rotation);
-			PoseService.Instance.FreezePositions = mode.HasFlag(PoseFile.Mode.Position);
+			PoseService.Instance.FreezePositions |= mode.HasFlag(PoseFile.Mode.Position);
 
 			if (importOption == PoseImportOptions.SelectedBones)
 			{

--- a/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
@@ -290,33 +290,25 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 				newTransform.Rotation = CmQuaternion.Normalize(CmQuaternion.Multiply(parentRot, newTransform.Rotation));
 			}
 
-			// Check if there are actual changes before updating
-			bool positionChanged = !this.Position.IsApproximately(newTransform.Position);
-			bool rotationChanged = !this.Rotation.IsApproximately(newTransform.Rotation);
-			bool scaleChanged = !this.Scale.IsApproximately(newTransform.Scale);
+			// Apply the updates in a single step
+			this.Position = newTransform.Position;
+			this.Rotation = newTransform.Rotation;
+			this.Scale = newTransform.Scale;
 
-			if (positionChanged || rotationChanged || scaleChanged)
+			// Set the Media3D hierarchy transforms
+			this.rotation.Quaternion = newTransform.Rotation.ToMedia3DQuaternion();
+			this.position.OffsetX = newTransform.Position.X;
+			this.position.OffsetY = newTransform.Position.Y;
+			this.position.OffsetZ = newTransform.Position.Z;
+
+			// Draw a line for visualization
+			if (this.Parent != null && this.lineToParent != null)
 			{
-				// Apply the updates in a single step
-				this.Position = newTransform.Position;
-				this.Rotation = newTransform.Rotation;
-				this.Scale = newTransform.Scale;
-
-				// Set the Media3D hierarchy transforms
-				this.rotation.Quaternion = newTransform.Rotation.ToMedia3DQuaternion();
-				this.position.OffsetX = newTransform.Position.X;
-				this.position.OffsetY = newTransform.Position.Y;
-				this.position.OffsetZ = newTransform.Position.Z;
-
-				// Draw a line for visualization
-				if (this.Parent != null && this.lineToParent != null)
-				{
-					var endPoint = this.lineToParent.Points[1];
-					endPoint.X = newTransform.Position.X;
-					endPoint.Y = newTransform.Position.Y;
-					endPoint.Z = newTransform.Position.Z;
-					this.lineToParent.Points[1] = endPoint;
-				}
+				var endPoint = this.lineToParent.Points[1];
+				endPoint.X = newTransform.Position.X;
+				endPoint.Y = newTransform.Position.Y;
+				endPoint.Z = newTransform.Position.Z;
+				this.lineToParent.Points[1] = endPoint;
 			}
 
 			if (readChildren)

--- a/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
@@ -3,11 +3,11 @@
 
 namespace Anamnesis.Actor.Refresh;
 
-using System.Threading.Tasks;
 using Anamnesis.Brio;
 using Anamnesis.Files;
 using Anamnesis.Memory;
 using Anamnesis.Services;
+using System.Threading.Tasks;
 using XivToolsWpf;
 
 public class BrioActorRefresher : IActorRefresher
@@ -28,7 +28,7 @@ public class BrioActorRefresher : IActorRefresher
 
 		RedrawType redrawType = RedrawType.AllowFull | RedrawType.PreservePosition | RedrawType.AllowOptimized | RedrawType.ForceAllowNPCAppearance;
 
-		if(actor.IsWeaponDirty)
+		if (actor.IsWeaponDirty)
 		{
 			redrawType |= RedrawType.ForceRedrawWeaponsOnOptimized;
 		}
@@ -48,7 +48,7 @@ public class BrioActorRefresher : IActorRefresher
 
 			// Redraw
 			var result = await Brio.Redraw(actor.ObjectIndex, redrawType);
-			if(result == "\"Full\"")
+			if (result == "\"Full\"")
 			{
 				// TODO: It's probably best to find some way to detect when it's safe
 				// this is a good first attempt though.
@@ -60,7 +60,7 @@ public class BrioActorRefresher : IActorRefresher
 					// Restore current pose
 					skeletonVisual3D = new SkeletonVisual3d();
 					await skeletonVisual3D.SetActor(actor);
-					await poseFile.Apply(actor, skeletonVisual3D, null, PoseFile.Mode.All, true);
+					poseFile.Apply(actor, skeletonVisual3D, null, PoseFile.Mode.All, true);
 				}).Start();
 			}
 		}

--- a/Anamnesis/Files/PoseFile.cs
+++ b/Anamnesis/Files/PoseFile.cs
@@ -46,20 +46,7 @@ public class PoseFile : JsonFileBase
 
 	public static BoneProcessingModes GetBoneMode(ActorMemory? actor, SkeletonVisual3d? skeleton, string boneName)
 	{
-		if (boneName == "n_root")
-			return BoneProcessingModes.Ignore;
-
-		// Special case for elezen ears as they cannot use other races ear values.
-		if (actor?.Customize?.Race == ActorCustomizeMemory.Races.Elezen)
-		{
-			// append '_elezen' to both ear bones.
-			if (boneName == "j_mimi_l" || boneName == "j_mimi_r")
-			{
-				return BoneProcessingModes.KeepRelative;
-			}
-		}
-
-		return BoneProcessingModes.FullLoad;
+		return boneName != "n_root" ? BoneProcessingModes.FullLoad : BoneProcessingModes.Ignore;
 	}
 
 	public static async Task<DirectoryInfo?> Save(DirectoryInfo? dir, ActorMemory? actor, SkeletonVisual3d? skeleton, HashSet<string>? bones = null, bool editMeta = false)
@@ -107,7 +94,7 @@ public class PoseFile : JsonFileBase
 		}
 	}
 
-	public async Task Apply(ActorMemory actor, SkeletonVisual3d skeleton, HashSet<string>? bones, Mode mode, bool doFacialExpressionHack)
+	public void Apply(ActorMemory actor, SkeletonVisual3d skeleton, HashSet<string>? bones, Mode mode, bool doFacialExpressionHack)
 	{
 		if (actor == null)
 			throw new ArgumentNullException(nameof(actor));
@@ -298,8 +285,6 @@ public class PoseFile : JsonFileBase
 				bone.ReadTransform();
 				bone.WriteTransform(skeleton, false);
 			}
-
-			await Task.Delay(10);
 		}
 
 		// Restore the head bone rotation if we were only loading an expression
@@ -322,9 +307,6 @@ public class PoseFile : JsonFileBase
 			bone.Scale = transform.Scale;
 			bone.WriteTransform(skeleton, false);
 		}
-
-		// Give enough time for the game to process the bone transform updates.
-		await Task.Delay(100);
 
 		skeletonMem.PauseSynchronization = false;
 		skeletonMem.WriteDelayedBinds();

--- a/Anamnesis/Files/PoseFile.cs
+++ b/Anamnesis/Files/PoseFile.cs
@@ -331,13 +331,10 @@ public class PoseFile : JsonFileBase
 			}
 		}
 
-		if (!hasFaceBones)
-			return false;
-
 		// Looking for the tongue-A bone, a new bone common to all races and genders added in DT.
 		// If we dont have it, we are assumed to be a pre-DT pose file.
 		// This doesn't account for users manually editing the JSON.
-		if (!this.Bones.ContainsKey("j_f_bero_01"))
+		if (!hasFaceBones || !this.Bones.ContainsKey("j_f_bero_01"))
 			return true;
 
 		return false;

--- a/Anamnesis/Files/SceneFile.cs
+++ b/Anamnesis/Files/SceneFile.cs
@@ -155,7 +155,7 @@ public class SceneFile : JsonFileBase
 			if (mode.HasFlag(Mode.Pose))
 			{
 				// TODO: This should follow the same approach as the pose page imports
-				await entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation, true);
+				entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation, true);
 			}
 		}
 

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -212,7 +212,7 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 							fullActor.SetAddress(newActor.Address);
 							fullActor.Synchronize();
 							await skeletonVisual3D.SetActor(fullActor);
-							await poseFile.Apply(fullActor, skeletonVisual3D, null, PoseFile.Mode.Rotation, true);
+							poseFile.Apply(fullActor, skeletonVisual3D, null, PoseFile.Mode.Rotation, true);
 						}
 					}
 


### PR DESCRIPTION
This pull request makes the following changes:
- The import process was simplified. Toggling between "Freeze positions" mode on and off is no longer necessary. This is instead replaced by a simple approach that stores initial bone positions and resets to those values after applying the pose file.
- Added a step at the end of the import process to preserve facial expression state if bones are mismatched (facial expression import is skipped if bones are mismatched).
- Removed the changed position, rotation, scale checks in the `ReadTransform` to allow for lines to be redrawn even if no changes occur. This is necessary as there are circumstances under which the skeleton in the 3D view does not update its lines.