### PR TITLE
Hotfix/Patch 7.1 Misc fixes

### DIFF
--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -3,9 +3,9 @@
 
 namespace Anamnesis.Actor.Refresh;
 
-using System.Threading.Tasks;
 using Anamnesis.Memory;
 using Anamnesis.Services;
+using System.Threading.Tasks;
 using static Anamnesis.Memory.ActorBasicMemory;
 
 public class AnamnesisActorRefresher : IActorRefresher
@@ -28,7 +28,6 @@ public class AnamnesisActorRefresher : IActorRefresher
 
 	public async Task RefreshActor(ActorMemory actor)
 	{
-		await Task.Delay(16);
 		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
 		{
 			actor.ObjectKind = ActorTypes.BattleNpc;
@@ -45,7 +44,5 @@ public class AnamnesisActorRefresher : IActorRefresher
 			await Task.Delay(75);
 			actor.RenderMode = RenderModes.Draw;
 		}
-
-		await Task.Delay(150);
 	}
 }

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -31,7 +31,10 @@ public partial class CustomizeEditor : UserControl
 		this.ContentArea.DataContext = this;
 
 		this.GenderComboBox.ItemsSource = Enum.GetValues(typeof(ActorCustomizeMemory.Genders));
-		this.AgeComboBox.ItemsSource = Enum.GetValues(typeof(ActorCustomizeMemory.Ages));
+		this.AgeComboBox.ItemsSource =
+			Enum.GetValues(typeof(ActorCustomizeMemory.Ages))
+				.Cast<ActorCustomizeMemory.Ages>()
+				.Where(age => age != ActorCustomizeMemory.Ages.None);
 
 		List<Race> races = new();
 		foreach (Race race in GameDataService.Races)

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -249,6 +249,10 @@ public class ActorMemory : ActorBasicMemory
 		// Refresh the actor
 		if (this.AutomaticRefreshEnabled && change.OriginBind.Flags.HasFlag(BindFlags.ActorRefresh))
 		{
+			// Don't refresh because of a refresh
+			if (this.IsRefreshing && (change.OriginBind.Name == nameof(this.ObjectKind) || change.OriginBind.Name == nameof(this.RenderMode)))
+				return;
+
 			if (change.OriginBind.Flags.HasFlag(BindFlags.WeaponRefresh))
 				this.IsWeaponDirty = true;
 


### PR DESCRIPTION
**Changes:**
- Removed the "None" as a selectable option from the age customize editor menu. 
  - Note: It is used internally to determine if the model is a non-humanoid NPC but it should not be selectable by the user.
- Fixed infinite actor refresh loop causing flickering and game crashes.
- Added thread locks to resolve an issue where the history class might occasionally try to record multiple elements at once from differen't threads, causing Anamnesis throw a critical exception and close itself.