### PR TITLE
Fixed the facial features and NPC warning message for Hrothgar.

### DIFF
--- a/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
+++ b/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
@@ -18,17 +18,18 @@ public class NpcFaceWarningConverter : IMultiValueConverter
 
 		if (values[0] is ActorTypes type && values[1] is byte head && values[2] is ActorCustomizeMemory.Races race && values[3] is ActorCustomizeMemory.Genders gender)
 		{
-			bool isHrothF = race == ActorCustomizeMemory.Races.Hrothgar && gender == ActorCustomizeMemory.Genders.Feminine;
+			bool isHroth = race == ActorCustomizeMemory.Races.Hrothgar;
 
 			if (type == ActorTypes.BattleNpc || type == ActorTypes.EventNpc)
 				return Visibility.Collapsed;
 
-			// For all except Fem Hrothgar, >4 is an NPC face.
-			if (head > 4 && !isHrothF)
+			// For all except Hrothgar, >4 is an NPC face.
+			if (head > 4 && !isHroth)
 				return Visibility.Visible;
 
-			// For Fem Hrothgar only, between 5 and 8 are player faces.
-			if ((head < 5 || head > 8) && isHrothF)
+			// For Hrothgar only, between 5 and 8 are player faces.
+			// For Male Hrothgar specifically, faces 1-4 additionally are customizable.
+			if (isHroth && (head > 8 || (gender == ActorCustomizeMemory.Genders.Feminine && head < 5)))
 				return Visibility.Visible;
 
 			return Visibility.Collapsed;

--- a/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
+++ b/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
@@ -123,17 +123,19 @@ public partial class FacialFeaturesControl : UserControl
 
 		this.features.Clear();
 
-		// Add an offset for Fem Hrothgar to show the facial features icons properly.
-		// Fem Hrothgar is defined as being either Helions or TheLost tribe AND Feminine gender.
-		int hrothFOffset = 0;
-		if((this.Tribe == ActorCustomizeMemory.Tribes.Helions || this.Tribe == ActorCustomizeMemory.Tribes.TheLost) && this.Gender == ActorCustomizeMemory.Genders.Feminine)
+		// Add an offset Fem Hrothgar to show the facial features icons properly.
+		// Fem Hrothgar use faces 5-8, always offset.
+		// Masc Hrothgar use faces 1-4 and 5-8, offset only if we're between 5 and 8.
+		int hrothOffset = 0;
+		bool isHroth = this.Tribe == ActorCustomizeMemory.Tribes.Helions || this.Tribe == ActorCustomizeMemory.Tribes.TheLost;
+		if (isHroth && (this.Gender == ActorCustomizeMemory.Genders.Feminine || (this.Head >= 5 && this.Head <= 8)))
 		{
-			hrothFOffset = 4;
+			hrothOffset = 4;
 		}
 
 		for (byte i = 0; i < 7; i++)
 		{
-			int id = (this.Head - (1 + hrothFOffset)) + (8 * i);
+			int id = (this.Head - (1 + hrothOffset)) + (8 * i);
 
 			if (id < 0 || id >= facialFeatures.Length)
 				continue;


### PR DESCRIPTION
### Overview
This pull request is to fix the facial features and NPC face warning for Hrothgar. All Hrothgar use faces 5-8. However, male Hrothgar faces 1-4 are also customizable in the same way faces 5-8 are. This issue was reported in #1391 .

This facial features will display according to the above pattern based on an offset. Fem Hrothgar will always use the offset. Male Hrothgar will only use the offset if their face is between 5 and 8, accounting for faces 1-4.

For the NPC warning, it will display for non-Hrothgar players for faces above 4. No change there. For Hrothgar, the warning will only display for faces above 8 for males, and additionally for faces below 5 for females.

### Testing
I tested this with both a male and female player chara. I also loaded up Runar, to test an NPC face (101). 

For the fem player chara, I made sure for faces 5-8, facial features were displaying and matching the in-game model, and the NPC face warning was not visible. For faces otherwise, I made sure that the NPC warning was visible.

For the masc player chara, I made sure for faces 1-4 and 5-8 facial features were displaying, matching the in-game model, and matching their counterparts. Additionally, for the aforementioned faces, no NPC face warning was visible. For faces otherwise, I made sure the NPC face warning was visible.