### PR TITLE
Hotfix/Patch 7.1 Follow-up fixes

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -272,9 +272,6 @@ public partial class PosePage : UserControl
 	{
 		Application.Current?.Dispatcher.Invoke(() =>
 		{
-			////if (this.Skeleton != null && !this.PoseService.CanEdit)
-			////	this.Skeleton.CurrentBone = null;
-
 			this.Skeleton?.Reselect();
 			this.Skeleton?.ReadTransforms();
 		});

--- a/Anamnesis/Actor/Posing/Views/Pose3DView.xaml.cs
+++ b/Anamnesis/Actor/Posing/Views/Pose3DView.xaml.cs
@@ -193,9 +193,8 @@ public partial class Pose3DView : UserControl
 				if (this.Skeleton == null || this.Skeleton.Actor == null || CameraService.Instance.Camera == null)
 					continue;
 
-				// Update the skeleton's transforms until either the motion is disabled
-				// or the world position is frozen
-				if (this.Skeleton.Actor.IsMotionEnabled && PoseService.Instance.WorldPositionNotFrozen)
+				// Update skeleton transforms until pose service is enabled
+				if (!PoseService.Instance.IsEnabled)
 				{
 					this.Skeleton.ReadTransforms();
 				}

--- a/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
@@ -24,6 +24,7 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 {
 	public readonly List<TransformMemory> TransformMemories = new();
 
+	private const float EqualityTolerance = 0.00001f;
 	private static bool scaleLinked = true;
 
 	private readonly object transformLock = new();
@@ -364,13 +365,13 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 			bool changed = false;
 			foreach (TransformMemory transformMemory in this.TransformMemories)
 			{
-				if (this.CanTranslate)
+				if (this.CanTranslate && !transformMemory.Position.IsApproximately(position, EqualityTolerance))
 				{
 					transformMemory.Position = position;
 					changed = true;
 				}
 
-				if (this.CanScale)
+				if (this.CanScale && !transformMemory.Scale.IsApproximately(this.Scale, EqualityTolerance))
 				{
 					transformMemory.Scale = this.Scale;
 					changed = true;
@@ -379,8 +380,11 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 				if (this.CanRotate)
 				{
 					CmQuaternion newRot = rotation.FromMedia3DQuaternion();
-					transformMemory.Rotation = newRot;
-					changed = true;
+					if (!transformMemory.Rotation.IsApproximately(newRot, EqualityTolerance))
+					{
+						transformMemory.Rotation = newRot;
+						changed = true;
+					}
 				}
 			}
 

--- a/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/BoneVisual3d.cs
@@ -354,25 +354,23 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 				throw new Exception($"Failed to transform bone: {this.BoneName} to root", ex);
 			}
 
-			Quaternion rotation = transform.Matrix.ToQuaternion();
+			var matrix = transform.Matrix;
+			Quaternion rotation = matrix.ToQuaternion();
 			rotation.Invert();
 
-			CmVector position = default;
-			position.X = (float)transform.Matrix.OffsetX;
-			position.Y = (float)transform.Matrix.OffsetY;
-			position.Z = (float)transform.Matrix.OffsetZ;
+			var position = new CmVector((float)matrix.OffsetX, (float)matrix.OffsetY, (float)matrix.OffsetZ);
 
 			// and push those values to the game memory
 			bool changed = false;
 			foreach (TransformMemory transformMemory in this.TransformMemories)
 			{
-				if (this.CanTranslate && !transformMemory.Position.IsApproximately(position))
+				if (this.CanTranslate)
 				{
 					transformMemory.Position = position;
 					changed = true;
 				}
 
-				if (this.CanScale && !transformMemory.Scale.IsApproximately(this.Scale))
+				if (this.CanScale)
 				{
 					transformMemory.Scale = this.Scale;
 					changed = true;
@@ -381,11 +379,8 @@ public class BoneVisual3d : ModelVisual3D, ITransform, IBone, IDisposable
 				if (this.CanRotate)
 				{
 					CmQuaternion newRot = rotation.FromMedia3DQuaternion();
-					if (!transformMemory.Rotation.IsApproximately(newRot))
-					{
-						transformMemory.Rotation = newRot;
-						changed = true;
-					}
+					transformMemory.Rotation = newRot;
+					changed = true;
 				}
 			}
 

--- a/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
@@ -497,13 +497,17 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 		if (!GposeService.GetIsGPose())
 			return;
 
-		// Take a snapshot of the current transforms
-		var snapshot = this.TakeSnapshot();
-
-		// Read skeleton transforms, starting from the root bones
-		foreach (var rootBone in this.rootBones)
+		// If history is restoring, wait until it's done.
+		lock (HistoryService.Instance.LockObject)
 		{
-			rootBone.ReadTransform(true, snapshot);
+			// Take a snapshot of the current transforms
+			var snapshot = this.TakeSnapshot();
+
+			// Read skeleton transforms, starting from the root bones
+			foreach (var rootBone in this.rootBones)
+			{
+				rootBone.ReadTransform(true, snapshot);
+			}
 		}
 	}
 

--- a/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
@@ -497,10 +497,6 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 		if (!GposeService.GetIsGPose())
 			return;
 
-		// Clear bone selection.
-		// This method should only be called while the user cannot interact with the bones.
-		this.ClearSelection();
-
 		// Take a snapshot of the current transforms
 		var snapshot = this.TakeSnapshot();
 

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -69,7 +69,7 @@ public class ActorMemory : ActorBasicMemory
 	[Bind(0x08F8)] public ushort OrnamentId { get; set; }
 	[Bind(0x09C0)] public AnimationMemory? Animation { get; set; }
 	[Bind(0x1AB8, BindFlags.ActorRefresh)] public int ModelType { get; set; }
-	[Bind(0x1AC4)] public bool IsMotionDisabled { get; set; }
+	[Bind(0x1B24)] public bool IsMotionDisabled { get; set; }
 	[Bind(0x19D8)] public byte Voice { get; set; }
 	[Bind(0x226C)] public float Transparency { get; set; }
 	[Bind(0x22DC)] public byte CharacterModeRaw { get; set; }

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -227,7 +227,7 @@ public class ActorMemory : ActorBasicMemory
 			return;
 
 		// Only record changes that originate from the user
-		if (!change.OriginBind.Flags.HasFlag(BindFlags.DontRecordHistory))
+		if (!change.OriginBind.Flags.HasFlag(BindFlags.DontRecordHistory) && !HistoryService.Instance.IsRestoring)
 		{
 			if (change.Origin == PropertyChange.Origins.User)
 			{

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -3,21 +3,20 @@
 
 namespace Anamnesis;
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-using Anamnesis.Actor;
 using Anamnesis.Actor.Refresh;
 using Anamnesis.Core.Memory;
 using Anamnesis.Memory;
 using PropertyChanged;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 
 [AddINotifyPropertyChangedInterface]
 public class ActorService : ServiceBase<ActorService>
 {
 	private const int TickDelay = 10;
-	private const int ActorTableSize = 424;
+	private const int ActorTableSize = 819;
 	private const int GPoseIndexStart = 200;
 	private const int GPoseIndexEnd = 244;
 	private const int OverworldPlayerIndex = 0;
@@ -50,7 +49,7 @@ public class ActorService : ServiceBase<ActorService>
 
 	public async Task<bool> RefreshActor(ActorMemory actor)
 	{
-		if(this.CanRefreshActor(actor))
+		if (this.CanRefreshActor(actor))
 		{
 			foreach (IActorRefresher actorRefresher in this.actorRefreshers)
 			{


### PR DESCRIPTION
**Changes:**
- Fixed an issue that prevented NPCs from being targetable in Anamnesis.
  - Caused by an outdated actor table size.
- Fixed broken actor motion detection.
  - Caused by a wrong memory offset.
- Resolved issue causing minor character deformations during posing.
  - Caused by approximate equality thresholds in the `BoneVisual3d.WriteTransform()` preventing some bones from updating their respective transforms' position and rotation. I resolved it by increasing the vector equality tolerance.
- Fixed issue that prevented users from selecting bones in the 3D pose view.
  - Caused by a clear bone selection call in `SkeletonVisual3d.ReadTransforms()`, which was getting called frequently by `Pose3DView.UpdateCamera()`.
- Anamnesis now preserves bone selection on history undo action, and parenting/position/rotation/scale toggle.