### PR TITLE
Added support for legacy actors (with old skeletons) to the pose panels

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -302,17 +302,25 @@ public partial class PosePage : UserControl
 
 		if (this.Actor?.ModelObject != null)
 		{
+			this.Actor.Refreshed -= this.OnActorRefreshed;
 			this.Actor.ModelObject.PropertyChanged -= this.OnModelObjectChanged;
 		}
 
 		if (newActor?.ModelObject != null)
 		{
+			newActor.Refreshed += this.OnActorRefreshed;
 			newActor.ModelObject.PropertyChanged += this.OnModelObjectChanged;
 		}
 
 		this.Actor = newActor;
 
 		await this.Refresh();
+	}
+
+	private void OnActorRefreshed(object? sender, EventArgs e)
+	{
+		this.refreshDebounceTimer.Stop();
+		this.refreshDebounceTimer.Start();
 	}
 
 	private void OnModelObjectChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/Anamnesis/Actor/Posing/Views/Pose3DView.xaml
+++ b/Anamnesis/Actor/Posing/Views/Pose3DView.xaml
@@ -30,7 +30,7 @@
 				<StackPanel
 					IsEnabled="True"
 					Orientation="Horizontal"
-					Margin="100, 0, 0, 0"
+					Margin="130, 0, 0, 0"
 					VerticalAlignment="Top">
 					
 					<Button Padding="6,2"

--- a/Anamnesis/Actor/Posing/Views/PoseBodyGUIView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseBodyGUIView.xaml
@@ -145,26 +145,22 @@
                     <local:BoneView Canvas.Left="170" Canvas.Top="195" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
 
                     <!-- Ears[M, 02] -->
-                    <local:BoneView Canvas.Left="108" Canvas.Top="70" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="172" Canvas.Top="70" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="90" Canvas.Top="25" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="185" Canvas.Top="25" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="108" Canvas.Top="70" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"/>
+						<local:BoneView Canvas.Left="172" Canvas.Top="70" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"/>
+						<local:BoneView Canvas.Left="90" Canvas.Top="25" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"/>
+						<local:BoneView Canvas.Left="185" Canvas.Top="25" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"/>
+					</Canvas>
 
-                    <!-- Ears[F, 03] -->
-                    <local:BoneView Canvas.Left="108" Canvas.Top="70" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="172" Canvas.Top="70" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="90" Canvas.Top="25" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="185" Canvas.Top="25" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
+					<!-- Ears[F, 03] -->
+					<Canvas Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="108" Canvas.Top="70" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"/>
+						<local:BoneView Canvas.Left="172" Canvas.Top="70" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"/>
+						<local:BoneView Canvas.Left="90" Canvas.Top="25" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"/>
+						<local:BoneView Canvas.Left="185" Canvas.Top="25" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"/>
+					</Canvas>
 
-                    <!-- Earrings -->
+					<!-- Earrings -->
                     <local:BoneView Canvas.Left="80" Canvas.Top="80" BoneName="n_ear_a_l" FlippedBoneName="n_ear_a_r"/>
                     <local:BoneView Canvas.Left="200" Canvas.Top="80" BoneName="n_ear_a_r" FlippedBoneName="n_ear_a_l"/>
                     <local:BoneView Canvas.Left="80" Canvas.Top="105" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>
@@ -196,46 +192,38 @@
                     <local:BoneView Canvas.Left="170" Canvas.Top="200" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
 
                     <!-- Ears[01] -->
-                    <local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zera_a_l" FlippedBoneName="j_zera_a_r"
-                                    Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zera_a_r" FlippedBoneName="j_zera_a_l"
-                                    Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zera_b_l" FlippedBoneName="j_zera_b_r"
-                                    Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zera_b_r" FlippedBoneName="j_zera_b_l"
-                                    Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars01, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zera_a_l" FlippedBoneName="j_zera_a_r"/>
+						<local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zera_a_r" FlippedBoneName="j_zera_a_l"/>
+						<local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zera_b_l" FlippedBoneName="j_zera_b_r"/>
+						<local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zera_b_r" FlippedBoneName="j_zera_b_l"/>
+					</Canvas>
 
-                    <!-- Ears[02] -->
-                    <local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"
-                                    Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
+					<!-- Ears[02] -->
+					<Canvas Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"/>
+						<local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"/>
+						<local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"/>
+						<local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"/>
+					</Canvas>
 
-                    <!-- Ears[03] -->
-                    <local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"
-                                    Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
+					<!-- Ears[03] -->
+					<Canvas Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"/>
+						<local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"/>
+						<local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"/>
+						<local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"/>
+					</Canvas>
 
-                    <!-- Ears[04] -->
-                    <local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerd_a_l" FlippedBoneName="j_zerd_a_r"
-                                    Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerd_a_r" FlippedBoneName="j_zerd_a_l"
-                                    Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerd_b_l" FlippedBoneName="j_zerd_b_r"
-                                    Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-                    <local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerd_b_r" FlippedBoneName="j_zerd_b_l"
-                                    Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
+					<!-- Ears[04] -->
+					<Canvas Visibility="{Binding IsEars04, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="100" Canvas.Top="70" BoneName="j_zerd_a_l" FlippedBoneName="j_zerd_a_r"/>
+						<local:BoneView Canvas.Left="175" Canvas.Top="70" BoneName="j_zerd_a_r" FlippedBoneName="j_zerd_a_l"/>
+						<local:BoneView Canvas.Left="85" Canvas.Top="20" BoneName="j_zerd_b_l" FlippedBoneName="j_zerd_b_r"/>
+						<local:BoneView Canvas.Left="190" Canvas.Top="20" BoneName="j_zerd_b_r" FlippedBoneName="j_zerd_b_l"/>
+					</Canvas>
 
-                    <!-- Earrings -->
+					<!-- Earrings -->
                     <local:BoneView Canvas.Left="75" Canvas.Top="90" BoneName="n_ear_a_l" FlippedBoneName="n_ear_a_r"/>
                     <local:BoneView Canvas.Left="200" Canvas.Top="90" BoneName="n_ear_a_r" FlippedBoneName="n_ear_a_l"/>
                     <local:BoneView Canvas.Left="75" Canvas.Top="115" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>

--- a/Anamnesis/Actor/Posing/Views/PoseBodyGUIView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseBodyGUIView.xaml
@@ -20,16 +20,9 @@
                     <Image Canvas.Left="0" Canvas.Top="0" Width="300" Height="300" Opacity="0.15" Stretch="Uniform"
 						   Source="pack://application:,,,/Assets/Pose/CharFHyurFaceBackground.png" IsHitTestVisible="False"/>
 
-                    <!-- Jaw -->
-                    <local:BoneView Canvas.Left="146" Canvas.Top="288" BoneName="j_f_ago"/>
-
                     <!-- Eyes -->
                     <local:BoneView Canvas.Left="105" Canvas.Top="170" BoneName="j_f_eye_l" FlippedBoneName="j_f_eye_r"/>
                     <local:BoneView Canvas.Left="185" Canvas.Top="170" BoneName="j_f_eye_r" FlippedBoneName="j_f_eye_l"/>
-
-                    <!-- Eyebrows -->
-                    <local:BoneView Canvas.Left="105" Canvas.Top="145" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
-                    <local:BoneView Canvas.Left="185" Canvas.Top="145" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
 
                     <!-- Cheeks -->
                     <local:BoneView Canvas.Left="105" Canvas.Top="210" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
@@ -44,7 +37,29 @@
                     <local:BoneView Canvas.Left="225" Canvas.Top="220" BoneName="n_ear_a_r" FlippedBoneName="n_ear_a_l"/>
                     <local:BoneView Canvas.Left="65" Canvas.Top="240" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>
                     <local:BoneView Canvas.Left="225" Canvas.Top="240" BoneName="n_ear_b_r" FlippedBoneName="n_ear_b_l"/>
-                </Canvas>
+
+					<!-- Legacy bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="85" Canvas.Top="145" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="205" Canvas.Top="145" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="130" Canvas.Top="150" BoneName="j_f_miken_l" FlippedBoneName="j_f_miken_r"/>
+						<local:BoneView Canvas.Left="160" Canvas.Top="150" BoneName="j_f_miken_r" FlippedBoneName="j_f_miken_l"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="146" Canvas.Top="288" BoneName="j_ago"/>
+					</Canvas>
+
+					<!-- Modern bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="105" Canvas.Top="145" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
+						<local:BoneView Canvas.Left="185" Canvas.Top="145" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="146" Canvas.Top="288" BoneName="j_f_ago"/>
+					</Canvas>
+				</Canvas>
             </Viewbox>
         </DataTemplate>
 
@@ -94,16 +109,9 @@
                     <Image Canvas.Left="0" Canvas.Top="0" Width="300" Height="300" Opacity="0.15" Stretch="Uniform"
                            Source="pack://application:,,,/Assets/Pose/CharFMiqoFaceBackground.png" IsHitTestVisible="False"/>
 
-                    <!-- Jaw -->
-                    <local:BoneView Canvas.Left="140" Canvas.Top="250" BoneName="j_f_ago"/>
-
                     <!-- Eyes -->
                     <local:BoneView Canvas.Left="104" Canvas.Top="156" BoneName="j_f_eye_l" FlippedBoneName="j_f_eye_r"/>
                     <local:BoneView Canvas.Left="176" Canvas.Top="156" BoneName="j_f_eye_r" FlippedBoneName="j_f_eye_l"/>
-
-                    <!-- Eyebrows -->
-                    <local:BoneView Canvas.Left="104" Canvas.Top="136" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
-                    <local:BoneView Canvas.Left="176" Canvas.Top="136" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
 
                     <!-- Cheeks -->
                     <local:BoneView Canvas.Left="104" Canvas.Top="196" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
@@ -118,7 +126,29 @@
                     <local:BoneView Canvas.Left="255" Canvas.Top="85" BoneName="n_ear_a_r" FlippedBoneName="n_ear_a_l"/>
                     <local:BoneView Canvas.Left="25" Canvas.Top="115" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>
                     <local:BoneView Canvas.Left="255" Canvas.Top="115" BoneName="n_ear_b_r" FlippedBoneName="n_ear_b_l"/>
-                </Canvas>
+
+					<!-- Legacy bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="86" Canvas.Top="130" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="194" Canvas.Top="130" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="125" Canvas.Top="135" BoneName="j_f_miken_l" FlippedBoneName="j_f_miken_r"/>
+						<local:BoneView Canvas.Left="155" Canvas.Top="135" BoneName="j_f_miken_r" FlippedBoneName="j_f_miken_l"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="140" Canvas.Top="250" BoneName="j_ago"/>
+					</Canvas>
+
+					<!-- Modern bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="104" Canvas.Top="136" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
+						<local:BoneView Canvas.Left="176" Canvas.Top="136" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="140" Canvas.Top="250" BoneName="j_f_ago"/>
+					</Canvas>
+				</Canvas>
             </Viewbox>
         </DataTemplate>
 

--- a/Anamnesis/Actor/Posing/Views/PoseFaceGUIView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseFaceGUIView.xaml
@@ -291,24 +291,20 @@
 						   Source="pack://application:,,,/Assets/Pose/CharFVieraFloppyFaceExBackground.png" IsHitTestVisible="False"/>
 
 					<!-- Ears[M, 02] -->
-					<local:BoneView Canvas.Left="210" Canvas.Top="150" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"
-										 Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="364" Canvas.Top="150" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"
-										 Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="176" Canvas.Top="30" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"
-										 Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="30" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"
-										 Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-
+					<Canvas Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="210" Canvas.Top="150" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"/>
+						<local:BoneView Canvas.Left="364" Canvas.Top="150" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"/>
+						<local:BoneView Canvas.Left="176" Canvas.Top="30" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="30" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"/>
+					</Canvas>
+							
 					<!-- Ears[F, 03] -->
-					<local:BoneView Canvas.Left="210" Canvas.Top="150" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"
-										 Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="364" Canvas.Top="150" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"
-										 Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="176" Canvas.Top="30" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"
-										 Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="30" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"
-										 Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="210" Canvas.Top="150" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"/>
+						<local:BoneView Canvas.Left="364" Canvas.Top="150" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"/>
+						<local:BoneView Canvas.Left="176" Canvas.Top="30" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="30" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"/>
+					</Canvas>
 
 					<!-- Earrings -->
 					<local:BoneView Canvas.Left="140" Canvas.Top="100" BoneName="n_ear_a_l" FlippedBoneName="n_ear_a_r"/>
@@ -395,44 +391,36 @@
 						   Source="pack://application:,,,/Assets/Pose/CharFVieraFaceExBackground.png" IsHitTestVisible="False"/>
 
 					<!-- Ears[01] -->
-					<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zera_a_l" FlippedBoneName="j_zera_a_r"
-							Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zera_a_r" FlippedBoneName="j_zera_a_l"
-							Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zera_b_l" FlippedBoneName="j_zera_b_r"
-							Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zera_b_r" FlippedBoneName="j_zera_b_l"
-							Visibility="{Binding IsEars01, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars01, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zera_a_l" FlippedBoneName="j_zera_a_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zera_a_r" FlippedBoneName="j_zera_a_l"/>
+						<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zera_b_l" FlippedBoneName="j_zera_b_r"/>
+						<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zera_b_r" FlippedBoneName="j_zera_b_l"/>
+					</Canvas>
 
 					<!-- Ears[02] -->
-					<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"
-							Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"
-							Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"
-							Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"
-							Visibility="{Binding IsEars02, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerb_a_l" FlippedBoneName="j_zerb_a_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerb_a_r" FlippedBoneName="j_zerb_a_l"/>
+						<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerb_b_l" FlippedBoneName="j_zerb_b_r"/>
+						<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerb_b_r" FlippedBoneName="j_zerb_b_l"/>
+					</Canvas>
 
 					<!-- Ears[03] -->
-					<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"
-							Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"
-							Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"
-							Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"
-							Visibility="{Binding IsEars03, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerc_a_l" FlippedBoneName="j_zerc_a_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerc_a_r" FlippedBoneName="j_zerc_a_l"/>
+						<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerc_b_l" FlippedBoneName="j_zerc_b_r"/>
+						<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerc_b_r" FlippedBoneName="j_zerc_b_l"/>
+					</Canvas>
 
 					<!-- Ears[04] -->
-					<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerd_a_l" FlippedBoneName="j_zerd_a_r"
-							Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerd_a_r" FlippedBoneName="j_zerd_a_l"
-							Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerd_b_l" FlippedBoneName="j_zerd_b_r"
-							Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
-					<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerd_b_r" FlippedBoneName="j_zerd_b_l"
-							Visibility="{Binding IsEars04, Converter={StaticResource B2V}}"/>
+					<Canvas Visibility="{Binding IsEars04, Converter={StaticResource B2V}}">
+						<local:BoneView Canvas.Left="180" Canvas.Top="140" BoneName="j_zerd_a_l" FlippedBoneName="j_zerd_a_r"/>
+						<local:BoneView Canvas.Left="400" Canvas.Top="140" BoneName="j_zerd_a_r" FlippedBoneName="j_zerd_a_l"/>
+						<local:BoneView Canvas.Left="160" Canvas.Top="40" BoneName="j_zerd_b_l" FlippedBoneName="j_zerd_b_r"/>
+						<local:BoneView Canvas.Left="420" Canvas.Top="40" BoneName="j_zerd_b_r" FlippedBoneName="j_zerd_b_l"/>
+					</Canvas>
 
 					<!-- Earrings -->
 					<local:BoneView Canvas.Left="130" Canvas.Top="100" BoneName="n_ear_a_l" FlippedBoneName="n_ear_a_r"/>

--- a/Anamnesis/Actor/Posing/Views/PoseFaceGUIView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseFaceGUIView.xaml
@@ -20,6 +20,10 @@
 					<Image Canvas.Left="0" Canvas.Top="0" Width="600" Height="600" Opacity="0.3" Stretch="Uniform"
 						   Source="pack://application:,,,/Assets/Pose/CharFHyurFaceExBackground.png" IsHitTestVisible="False"/>
 
+					<!-- Eyes -->
+					<local:BoneView Canvas.Left="224" Canvas.Top="295" BoneName="j_f_eye_l" FlippedBoneName="j_f_eye_r"/>
+					<local:BoneView Canvas.Left="382" Canvas.Top="295" BoneName="j_f_eye_r" FlippedBoneName="j_f_eye_l"/>
+
 					<!-- Ears -->
 					<local:BoneView Canvas.Left="130" Canvas.Top="360" BoneName="j_mimi_l" FlippedBoneName="j_mimi_r"/>
 					<local:BoneView Canvas.Left="470" Canvas.Top="360" BoneName="j_mimi_r" FlippedBoneName="j_mimi_l"/>
@@ -30,74 +34,100 @@
 					<local:BoneView Canvas.Left="130" Canvas.Top="430" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>
 					<local:BoneView Canvas.Left="470" Canvas.Top="430" BoneName="n_ear_b_r" FlippedBoneName="n_ear_b_l"/>
 
-					<!-- Eyebrows -->
-					<local:BoneView Canvas.Left="170" Canvas.Top="250" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
-					<local:BoneView Canvas.Left="435" Canvas.Top="250" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
-					<local:BoneView Canvas.Left="212" Canvas.Top="240" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
-					<local:BoneView Canvas.Left="394" Canvas.Top="240" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
-					<local:BoneView Canvas.Left="250" Canvas.Top="250" BoneName="j_f_miken_01_l" FlippedBoneName="j_f_miken_01_r"/>
-					<local:BoneView Canvas.Left="355" Canvas.Top="250" BoneName="j_f_miken_01_r" FlippedBoneName="j_f_miken_01_l"/>
-
-					<!-- Nose Bridge -->
-					<local:BoneView Canvas.Left="280" Canvas.Top="270" BoneName="j_f_miken_02_l" FlippedBoneName="j_f_miken_02_r"/>
-					<local:BoneView Canvas.Left="330" Canvas.Top="270" BoneName="j_f_miken_02_r" FlippedBoneName="j_f_miken_02_l"/>
-					<local:BoneView Canvas.Left="290" Canvas.Top="300" BoneName="j_f_dmiken_l" FlippedBoneName="j_f_dmiken_r"/>
-					<local:BoneView Canvas.Left="320" Canvas.Top="300" BoneName="j_f_dmiken_r" FlippedBoneName="j_f_dmiken_l"/>
-
-					<!-- Eyes -->
-					<local:BoneView Canvas.Left="224" Canvas.Top="295" BoneName="j_f_eye_l" FlippedBoneName="j_f_eye_r"/>
-					<local:BoneView Canvas.Left="382" Canvas.Top="295" BoneName="j_f_eye_r" FlippedBoneName="j_f_eye_l"/>
-
-					<!--- Upper Eyelids -->
-					<local:BoneView Canvas.Left="262" Canvas.Top="292" BoneName="j_f_mabup_03in_l" FlippedBoneName="j_f_mabup_03in_r"/>
-					<local:BoneView Canvas.Left="348" Canvas.Top="292" BoneName="j_f_mabup_03in_r" FlippedBoneName="j_f_mabup_03in_l"/>
-					<local:BoneView Canvas.Left="224" Canvas.Top="275" BoneName="j_f_mabup_01_l" FlippedBoneName="j_f_mabup_01_r"/>
-					<local:BoneView Canvas.Left="382" Canvas.Top="275" BoneName="j_f_mabup_01_r" FlippedBoneName="j_f_mabup_01_l"/>
-					<local:BoneView Canvas.Left="176" Canvas.Top="288" BoneName="j_f_mabup_02out_l" FlippedBoneName="j_f_mabup_02out_r"/>
-					<local:BoneView Canvas.Left="430" Canvas.Top="288" BoneName="j_f_mabup_02out_r" FlippedBoneName="j_f_mabup_02out_l"/>
-
-					<!--- Lower Eyelids -->
-					<local:BoneView Canvas.Left="262" Canvas.Top="310" BoneName="j_f_mabdn_03in_l" FlippedBoneName="j_f_mabdn_03in_r"/>
-					<local:BoneView Canvas.Left="348" Canvas.Top="310" BoneName="j_f_mabdn_03in_r" FlippedBoneName="j_f_mabdn_03in_l"/>
-					<local:BoneView Canvas.Left="224" Canvas.Top="320" BoneName="j_f_mabdn_01_l" FlippedBoneName="j_f_mabdn_01_r"/>
-					<local:BoneView Canvas.Left="382" Canvas.Top="320" BoneName="j_f_mabdn_01_r" FlippedBoneName="j_f_mabdn_01_l"/>
-					<local:BoneView Canvas.Left="176" Canvas.Top="306" BoneName="j_f_mabdn_02out_l" FlippedBoneName="j_f_mabdn_02out_r"/>
-					<local:BoneView Canvas.Left="430" Canvas.Top="306" BoneName="j_f_mabdn_02out_r" FlippedBoneName="j_f_mabdn_02out_l"/>
-
-					<!-- Nose -->
-					<local:BoneView Canvas.Left="305" Canvas.Top="340" BoneName="j_f_uhana"/>
-					<local:BoneView Canvas.Left="285" Canvas.Top="390" BoneName="j_f_hana_l" FlippedBoneName="j_f_hana_r"/>
-					<local:BoneView Canvas.Left="325" Canvas.Top="390" BoneName="j_f_hana_r" FlippedBoneName="j_f_hana_l"/>
-
-
-					<!-- Teeth -->
-					<local:BoneView Canvas.Left="305" Canvas.Top="430" BoneName="j_f_hagukiup"/>
-					<local:BoneView Canvas.Left="305" Canvas.Top="465" BoneName="j_f_hagukidn"/>
-
-					<!-- Jaw -->
-					<local:BoneView Canvas.Left="305" Canvas.Top="508" BoneName="j_f_ago"/>
-
-					<!-- Chin -->
-					<local:BoneView Canvas.Left="305" Canvas.Top="538" BoneName="j_f_dago"/>
-
-					<!-- Cheekbones -->
-					<local:BoneView Canvas.Left="260" Canvas.Top="350" BoneName="j_f_dmemoto_l" FlippedBoneName="j_f_dmemoto_r"/>
-					<local:BoneView Canvas.Left="350" Canvas.Top="350" BoneName="j_f_dmemoto_r" FlippedBoneName="j_f_dmemoto_l"/>
-
-					<!-- Inner cheeks -->
-					<local:BoneView Canvas.Left="220" Canvas.Top="380" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
-					<local:BoneView Canvas.Left="386" Canvas.Top="380" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
-					<local:BoneView Canvas.Left="220" Canvas.Top="430" BoneName="j_f_shoho_l" FlippedBoneName="j_f_shoho_r"/>
-					<local:BoneView Canvas.Left="386" Canvas.Top="430" BoneName="j_f_shoho_r" FlippedBoneName="j_f_shoho_l"/>
-
-					<!-- Outer cheeks -->
-					<local:BoneView Canvas.Left="170" Canvas.Top="420" BoneName="j_f_dhoho_l" FlippedBoneName="j_f_dhoho_r"/>
-					<local:BoneView Canvas.Left="438" Canvas.Top="420" BoneName="j_f_dhoho_r" FlippedBoneName="j_f_dhoho_l"/>
-
 					<!-- Hair -->
 					<local:BoneView Canvas.Left="305" Canvas.Top="120" BoneName="HairFront"/>
 					<local:BoneView Canvas.Left="60" Canvas.Top="350" BoneName="HairAutoFrontLeft" FlippedBoneName="HairAutoFrontRight"/>
 					<local:BoneView Canvas.Left="540" Canvas.Top="350" BoneName="HairAutoFrontRight" FlippedBoneName="HairAutoFrontLeft"/>
+
+					<!-- Inner cheeks -->
+					<local:BoneView Canvas.Left="220" Canvas.Top="380" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
+					<local:BoneView Canvas.Left="386" Canvas.Top="380" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
+
+					<!-- Legacy bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="180" Canvas.Top="250" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="425" Canvas.Top="250" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="265" Canvas.Top="265" BoneName="j_f_miken_l" FlippedBoneName="j_f_miken_r"/>
+						<local:BoneView Canvas.Left="340" Canvas.Top="265" BoneName="j_f_miken_r" FlippedBoneName="j_f_miken_l"/>
+
+						<!-- Upper Eyelids -->
+						<local:BoneView Canvas.Left="224" Canvas.Top="270" BoneName="j_f_umab_l" FlippedBoneName="j_f_umab_r"/>
+						<local:BoneView Canvas.Left="382" Canvas.Top="270" BoneName="j_f_umab_r" FlippedBoneName="j_f_umab_l"/>
+
+						<!-- Lower Eyelids -->
+						<local:BoneView Canvas.Left="224" Canvas.Top="320" BoneName="j_f_dmab_l" FlippedBoneName="j_f_dmab_r"/>
+						<local:BoneView Canvas.Left="382" Canvas.Top="320" BoneName="j_f_dmab_r" FlippedBoneName="j_f_dmab_l"/>
+
+						<!-- Nose Bridge -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="310" BoneName="j_f_memoto"/>
+
+						<!-- Nose -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="390" BoneName="j_f_hana"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="530" BoneName="j_ago"/>
+					</Canvas>
+
+					<!-- Modern bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="170" Canvas.Top="250" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="435" Canvas.Top="250" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="212" Canvas.Top="240" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
+						<local:BoneView Canvas.Left="394" Canvas.Top="240" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
+						<local:BoneView Canvas.Left="250" Canvas.Top="250" BoneName="j_f_miken_01_l" FlippedBoneName="j_f_miken_01_r"/>
+						<local:BoneView Canvas.Left="355" Canvas.Top="250" BoneName="j_f_miken_01_r" FlippedBoneName="j_f_miken_01_l"/>
+
+						<!--- Upper Eyelids -->
+						<local:BoneView Canvas.Left="262" Canvas.Top="292" BoneName="j_f_mabup_03in_l" FlippedBoneName="j_f_mabup_03in_r"/>
+						<local:BoneView Canvas.Left="348" Canvas.Top="292" BoneName="j_f_mabup_03in_r" FlippedBoneName="j_f_mabup_03in_l"/>
+						<local:BoneView Canvas.Left="224" Canvas.Top="275" BoneName="j_f_mabup_01_l" FlippedBoneName="j_f_mabup_01_r"/>
+						<local:BoneView Canvas.Left="382" Canvas.Top="275" BoneName="j_f_mabup_01_r" FlippedBoneName="j_f_mabup_01_l"/>
+						<local:BoneView Canvas.Left="176" Canvas.Top="288" BoneName="j_f_mabup_02out_l" FlippedBoneName="j_f_mabup_02out_r"/>
+						<local:BoneView Canvas.Left="430" Canvas.Top="288" BoneName="j_f_mabup_02out_r" FlippedBoneName="j_f_mabup_02out_l"/>
+
+						<!--- Lower Eyelids -->
+						<local:BoneView Canvas.Left="262" Canvas.Top="310" BoneName="j_f_mabdn_03in_l" FlippedBoneName="j_f_mabdn_03in_r"/>
+						<local:BoneView Canvas.Left="348" Canvas.Top="310" BoneName="j_f_mabdn_03in_r" FlippedBoneName="j_f_mabdn_03in_l"/>
+						<local:BoneView Canvas.Left="224" Canvas.Top="320" BoneName="j_f_mabdn_01_l" FlippedBoneName="j_f_mabdn_01_r"/>
+						<local:BoneView Canvas.Left="382" Canvas.Top="320" BoneName="j_f_mabdn_01_r" FlippedBoneName="j_f_mabdn_01_l"/>
+						<local:BoneView Canvas.Left="176" Canvas.Top="306" BoneName="j_f_mabdn_02out_l" FlippedBoneName="j_f_mabdn_02out_r"/>
+						<local:BoneView Canvas.Left="430" Canvas.Top="306" BoneName="j_f_mabdn_02out_r" FlippedBoneName="j_f_mabdn_02out_l"/>
+
+						<!-- Nose -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="340" BoneName="j_f_uhana"/>
+						<local:BoneView Canvas.Left="285" Canvas.Top="390" BoneName="j_f_hana_l" FlippedBoneName="j_f_hana_r"/>
+						<local:BoneView Canvas.Left="325" Canvas.Top="390" BoneName="j_f_hana_r" FlippedBoneName="j_f_hana_l"/>
+
+						<!-- Nose Bridge -->
+						<local:BoneView Canvas.Left="280" Canvas.Top="270" BoneName="j_f_miken_02_l" FlippedBoneName="j_f_miken_02_r"/>
+						<local:BoneView Canvas.Left="330" Canvas.Top="270" BoneName="j_f_miken_02_r" FlippedBoneName="j_f_miken_02_l"/>
+						<local:BoneView Canvas.Left="290" Canvas.Top="300" BoneName="j_f_dmiken_l" FlippedBoneName="j_f_dmiken_r"/>
+						<local:BoneView Canvas.Left="320" Canvas.Top="300" BoneName="j_f_dmiken_r" FlippedBoneName="j_f_dmiken_l"/>
+
+						<!-- Cheekbones -->
+						<local:BoneView Canvas.Left="260" Canvas.Top="350" BoneName="j_f_dmemoto_l" FlippedBoneName="j_f_dmemoto_r"/>
+						<local:BoneView Canvas.Left="350" Canvas.Top="350" BoneName="j_f_dmemoto_r" FlippedBoneName="j_f_dmemoto_l"/>
+
+						<!-- Inner cheeks -->
+						<local:BoneView Canvas.Left="220" Canvas.Top="430" BoneName="j_f_shoho_l" FlippedBoneName="j_f_shoho_r"/>
+						<local:BoneView Canvas.Left="386" Canvas.Top="430" BoneName="j_f_shoho_r" FlippedBoneName="j_f_shoho_l"/>
+
+						<!-- Outer cheeks -->
+						<local:BoneView Canvas.Left="170" Canvas.Top="420" BoneName="j_f_dhoho_l" FlippedBoneName="j_f_dhoho_r"/>
+						<local:BoneView Canvas.Left="438" Canvas.Top="420" BoneName="j_f_dhoho_r" FlippedBoneName="j_f_dhoho_l"/>
+
+						<!-- Teeth -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="430" BoneName="j_f_hagukiup"/>
+						<local:BoneView Canvas.Left="305" Canvas.Top="465" BoneName="j_f_hagukidn"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="508" BoneName="j_f_ago"/>
+
+						<!-- Chin -->
+						<local:BoneView Canvas.Left="305" Canvas.Top="538" BoneName="j_f_dago"/>
+					</Canvas>
 				</Canvas>
 			</Viewbox>
 		</DataTemplate>
@@ -211,74 +241,104 @@
 					<local:BoneView Canvas.Left="35" Canvas.Top="155" BoneName="n_ear_b_l" FlippedBoneName="n_ear_b_r"/>
 					<local:BoneView Canvas.Left="555" Canvas.Top="155" BoneName="n_ear_b_r" FlippedBoneName="n_ear_b_l"/>
 
-					<!-- Eyebrows -->
-					<local:BoneView Canvas.Left="180" Canvas.Top="280" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
-					<local:BoneView Canvas.Left="425" Canvas.Top="280" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
-					<local:BoneView Canvas.Left="210" Canvas.Top="270" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
-					<local:BoneView Canvas.Left="395" Canvas.Top="270" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
-					<local:BoneView Canvas.Left="250" Canvas.Top="280" BoneName="j_f_miken_01_l" FlippedBoneName="j_f_miken_01_r"/>
-					<local:BoneView Canvas.Left="355" Canvas.Top="280" BoneName="j_f_miken_01_r" FlippedBoneName="j_f_miken_01_l"/>
-
-					<!-- Nose Bridge -->
-					<local:BoneView Canvas.Left="280" Canvas.Top="294" BoneName="j_f_miken_02_l" FlippedBoneName="j_f_miken_02_r"/>
-					<local:BoneView Canvas.Left="320" Canvas.Top="294" BoneName="j_f_miken_02_r" FlippedBoneName="j_f_miken_02_l"/>
-					<local:BoneView Canvas.Left="290" Canvas.Top="320" BoneName="j_f_dmiken_l" FlippedBoneName="j_f_dmiken_r"/>
-					<local:BoneView Canvas.Left="310" Canvas.Top="320" BoneName="j_f_dmiken_r" FlippedBoneName="j_f_dmiken_l"/>
-
 					<!-- Eyes -->
 					<local:BoneView Canvas.Left="218" Canvas.Top="322" BoneName="j_f_eye_l" FlippedBoneName="j_f_eye_r"/>
 					<local:BoneView Canvas.Left="380" Canvas.Top="322" BoneName="j_f_eye_r" FlippedBoneName="j_f_eye_l"/>
-
-					<!--- Upper Eyelids -->
-					<local:BoneView Canvas.Left="250" Canvas.Top="320" BoneName="j_f_mabup_03in_l" FlippedBoneName="j_f_mabup_03in_r"/>
-					<local:BoneView Canvas.Left="348" Canvas.Top="320" BoneName="j_f_mabup_03in_r" FlippedBoneName="j_f_mabup_03in_l"/>
-					<local:BoneView Canvas.Left="220" Canvas.Top="302" BoneName="j_f_mabup_01_l" FlippedBoneName="j_f_mabup_01_r"/>
-					<local:BoneView Canvas.Left="378" Canvas.Top="302" BoneName="j_f_mabup_01_r" FlippedBoneName="j_f_mabup_01_l"/>
-					<local:BoneView Canvas.Left="174" Canvas.Top="314" BoneName="j_f_mabup_02out_l" FlippedBoneName="j_f_mabup_02out_r"/>
-					<local:BoneView Canvas.Left="422" Canvas.Top="314" BoneName="j_f_mabup_02out_r" FlippedBoneName="j_f_mabup_02out_l"/>
-
-					<!--- Lower Eyelids -->
-					<local:BoneView Canvas.Left="250" Canvas.Top="340" BoneName="j_f_mabdn_03in_l" FlippedBoneName="j_f_mabdn_03in_r"/>
-					<local:BoneView Canvas.Left="348" Canvas.Top="340" BoneName="j_f_mabdn_03in_r" FlippedBoneName="j_f_mabdn_03in_l"/>
-					<local:BoneView Canvas.Left="212" Canvas.Top="344" BoneName="j_f_mabdn_01_l" FlippedBoneName="j_f_mabdn_01_r"/>
-					<local:BoneView Canvas.Left="386" Canvas.Top="344" BoneName="j_f_mabdn_01_r" FlippedBoneName="j_f_mabdn_01_l"/>
-					<local:BoneView Canvas.Left="174" Canvas.Top="334" BoneName="j_f_mabdn_02out_l" FlippedBoneName="j_f_mabdn_02out_r"/>
-					<local:BoneView Canvas.Left="424" Canvas.Top="334" BoneName="j_f_mabdn_02out_r" FlippedBoneName="j_f_mabdn_02out_l"/>
-
-					<!-- Nose -->
-					<local:BoneView Canvas.Left="300" Canvas.Top="350" BoneName="j_f_uhana"/>
-					<local:BoneView Canvas.Left="284" Canvas.Top="404" BoneName="j_f_hana_l" FlippedBoneName="j_f_hana_r"/>
-					<local:BoneView Canvas.Left="316" Canvas.Top="404" BoneName="j_f_hana_r" FlippedBoneName="j_f_hana_l"/>
-
-
-					<!-- Teeth -->
-					<local:BoneView Canvas.Left="300" Canvas.Top="444" BoneName="j_f_hagukiup"/>
-					<local:BoneView Canvas.Left="300" Canvas.Top="474" BoneName="j_f_hagukidn"/>
-
-					<!-- Jaw -->
-					<local:BoneView Canvas.Left="300" Canvas.Top="502" BoneName="j_f_ago"/>
-
-					<!-- Chin -->
-					<local:BoneView Canvas.Left="300" Canvas.Top="538" BoneName="j_f_dago"/>
-
-					<!-- Cheekbones -->
-					<local:BoneView Canvas.Left="260" Canvas.Top="370" BoneName="j_f_dmemoto_l" FlippedBoneName="j_f_dmemoto_r"/>
-					<local:BoneView Canvas.Left="340" Canvas.Top="370" BoneName="j_f_dmemoto_r" FlippedBoneName="j_f_dmemoto_l"/>
-
-					<!-- Inner cheeks -->
-					<local:BoneView Canvas.Left="210" Canvas.Top="380" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
-					<local:BoneView Canvas.Left="390" Canvas.Top="380" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
-					<local:BoneView Canvas.Left="210" Canvas.Top="440" BoneName="j_f_shoho_l" FlippedBoneName="j_f_shoho_r"/>
-					<local:BoneView Canvas.Left="390" Canvas.Top="440" BoneName="j_f_shoho_r" FlippedBoneName="j_f_shoho_l"/>
-
-					<!-- Outer cheeks -->
-					<local:BoneView Canvas.Left="160" Canvas.Top="410" BoneName="j_f_dhoho_l" FlippedBoneName="j_f_dhoho_r"/>
-					<local:BoneView Canvas.Left="440" Canvas.Top="410" BoneName="j_f_dhoho_r" FlippedBoneName="j_f_dhoho_l"/>
 
 					<!-- Hair -->
 					<local:BoneView Canvas.Left="300" Canvas.Top="150" BoneName="HairFront"/>
 					<local:BoneView Canvas.Left="100" Canvas.Top="400" BoneName="HairAutoFrontLeft" FlippedBoneName="HairAutoFrontRight"/>
 					<local:BoneView Canvas.Left="500" Canvas.Top="400" BoneName="HairAutoFrontRight" FlippedBoneName="HairAutoFrontLeft"/>
+
+					<!-- Inner cheeks -->
+					<local:BoneView Canvas.Left="210" Canvas.Top="380" BoneName="j_f_hoho_l" FlippedBoneName="j_f_hoho_r"/>
+					<local:BoneView Canvas.Left="390" Canvas.Top="380" BoneName="j_f_hoho_r" FlippedBoneName="j_f_hoho_l"/>
+
+					<!-- Legacy bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="180" Canvas.Top="275" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="425" Canvas.Top="275" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="265" Canvas.Top="290" BoneName="j_f_miken_l" FlippedBoneName="j_f_miken_r"/>
+						<local:BoneView Canvas.Left="335" Canvas.Top="290" BoneName="j_f_miken_r" FlippedBoneName="j_f_miken_l"/>
+
+						<!-- Upper Eyelids -->
+						<local:BoneView Canvas.Left="218" Canvas.Top="297" BoneName="j_f_umab_l" FlippedBoneName="j_f_umab_r"/>
+						<local:BoneView Canvas.Left="380" Canvas.Top="297" BoneName="j_f_umab_r" FlippedBoneName="j_f_umab_l"/>
+
+						<!-- Lower Eyelids -->
+						<local:BoneView Canvas.Left="218" Canvas.Top="347" BoneName="j_f_dmab_l" FlippedBoneName="j_f_dmab_r"/>
+						<local:BoneView Canvas.Left="380" Canvas.Top="347" BoneName="j_f_dmab_r" FlippedBoneName="j_f_dmab_l"/>
+
+						<!-- Nose Bridge -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="335" BoneName="j_f_memoto"/>
+
+						<!-- Nose -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="405" BoneName="j_f_hana"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="530" BoneName="j_ago"/>
+					</Canvas>
+
+					<!-- Modern bones -->
+					<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+						<!-- Eyebrows -->
+						<local:BoneView Canvas.Left="180" Canvas.Top="280" BoneName="j_f_mayu_l" FlippedBoneName="j_f_mayu_r"/>
+						<local:BoneView Canvas.Left="425" Canvas.Top="280" BoneName="j_f_mayu_r" FlippedBoneName="j_f_mayu_l"/>
+						<local:BoneView Canvas.Left="210" Canvas.Top="270" BoneName="j_f_mmayu_l" FlippedBoneName="j_f_mmayu_r"/>
+						<local:BoneView Canvas.Left="395" Canvas.Top="270" BoneName="j_f_mmayu_r" FlippedBoneName="j_f_mmayu_l"/>
+						<local:BoneView Canvas.Left="250" Canvas.Top="280" BoneName="j_f_miken_01_l" FlippedBoneName="j_f_miken_01_r"/>
+						<local:BoneView Canvas.Left="355" Canvas.Top="280" BoneName="j_f_miken_01_r" FlippedBoneName="j_f_miken_01_l"/>
+
+						<!--- Upper Eyelids -->
+						<local:BoneView Canvas.Left="250" Canvas.Top="320" BoneName="j_f_mabup_03in_l" FlippedBoneName="j_f_mabup_03in_r"/>
+						<local:BoneView Canvas.Left="348" Canvas.Top="320" BoneName="j_f_mabup_03in_r" FlippedBoneName="j_f_mabup_03in_l"/>
+						<local:BoneView Canvas.Left="220" Canvas.Top="302" BoneName="j_f_mabup_01_l" FlippedBoneName="j_f_mabup_01_r"/>
+						<local:BoneView Canvas.Left="378" Canvas.Top="302" BoneName="j_f_mabup_01_r" FlippedBoneName="j_f_mabup_01_l"/>
+						<local:BoneView Canvas.Left="174" Canvas.Top="314" BoneName="j_f_mabup_02out_l" FlippedBoneName="j_f_mabup_02out_r"/>
+						<local:BoneView Canvas.Left="422" Canvas.Top="314" BoneName="j_f_mabup_02out_r" FlippedBoneName="j_f_mabup_02out_l"/>
+
+						<!--- Lower Eyelids -->
+						<local:BoneView Canvas.Left="250" Canvas.Top="340" BoneName="j_f_mabdn_03in_l" FlippedBoneName="j_f_mabdn_03in_r"/>
+						<local:BoneView Canvas.Left="348" Canvas.Top="340" BoneName="j_f_mabdn_03in_r" FlippedBoneName="j_f_mabdn_03in_l"/>
+						<local:BoneView Canvas.Left="212" Canvas.Top="344" BoneName="j_f_mabdn_01_l" FlippedBoneName="j_f_mabdn_01_r"/>
+						<local:BoneView Canvas.Left="386" Canvas.Top="344" BoneName="j_f_mabdn_01_r" FlippedBoneName="j_f_mabdn_01_l"/>
+						<local:BoneView Canvas.Left="174" Canvas.Top="334" BoneName="j_f_mabdn_02out_l" FlippedBoneName="j_f_mabdn_02out_r"/>
+						<local:BoneView Canvas.Left="424" Canvas.Top="334" BoneName="j_f_mabdn_02out_r" FlippedBoneName="j_f_mabdn_02out_l"/>
+
+						<!-- Nose -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="350" BoneName="j_f_uhana"/>
+						<local:BoneView Canvas.Left="284" Canvas.Top="404" BoneName="j_f_hana_l" FlippedBoneName="j_f_hana_r"/>
+						<local:BoneView Canvas.Left="316" Canvas.Top="404" BoneName="j_f_hana_r" FlippedBoneName="j_f_hana_l"/>
+
+						<!-- Nose Bridge -->
+						<local:BoneView Canvas.Left="280" Canvas.Top="294" BoneName="j_f_miken_02_l" FlippedBoneName="j_f_miken_02_r"/>
+						<local:BoneView Canvas.Left="320" Canvas.Top="294" BoneName="j_f_miken_02_r" FlippedBoneName="j_f_miken_02_l"/>
+						<local:BoneView Canvas.Left="290" Canvas.Top="320" BoneName="j_f_dmiken_l" FlippedBoneName="j_f_dmiken_r"/>
+						<local:BoneView Canvas.Left="310" Canvas.Top="320" BoneName="j_f_dmiken_r" FlippedBoneName="j_f_dmiken_l"/>
+
+						<!-- Cheekbones -->
+						<local:BoneView Canvas.Left="260" Canvas.Top="370" BoneName="j_f_dmemoto_l" FlippedBoneName="j_f_dmemoto_r"/>
+						<local:BoneView Canvas.Left="340" Canvas.Top="370" BoneName="j_f_dmemoto_r" FlippedBoneName="j_f_dmemoto_l"/>
+
+						<!-- Inner cheeks -->
+						<local:BoneView Canvas.Left="210" Canvas.Top="440" BoneName="j_f_shoho_l" FlippedBoneName="j_f_shoho_r"/>
+						<local:BoneView Canvas.Left="390" Canvas.Top="440" BoneName="j_f_shoho_r" FlippedBoneName="j_f_shoho_l"/>
+
+						<!-- Outer cheeks -->
+						<local:BoneView Canvas.Left="160" Canvas.Top="410" BoneName="j_f_dhoho_l" FlippedBoneName="j_f_dhoho_r"/>
+						<local:BoneView Canvas.Left="440" Canvas.Top="410" BoneName="j_f_dhoho_r" FlippedBoneName="j_f_dhoho_l"/>
+
+						<!-- Teeth -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="444" BoneName="j_f_hagukiup"/>
+						<local:BoneView Canvas.Left="300" Canvas.Top="474" BoneName="j_f_hagukidn"/>
+
+						<!-- Jaw -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="502" BoneName="j_f_ago"/>
+
+						<!-- Chin -->
+						<local:BoneView Canvas.Left="300" Canvas.Top="538" BoneName="j_f_dago"/>
+					</Canvas>
 				</Canvas>
 			</Viewbox>
 		</DataTemplate>
@@ -565,7 +625,7 @@
 
 					<!-- Tongue -->
 					<Viewbox Grid.Row="0">
-						<Canvas Height="200" Width="200">
+						<Canvas Height="200" Width="200" Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
 							<Image Canvas.Left="0" Canvas.Top="15" Height="170" Width="200" Opacity="0.3" Stretch="Uniform"
 								   Source="pack://application:,,,/Assets/Pose/CharTongueBackground.png" IsHitTestVisible="False"/>
 
@@ -590,36 +650,55 @@
 									   Source="pack://application:,,,/Assets/Pose/CharFMiqoMouthBackground.png" IsHitTestVisible="True"/>
 							</Border>
 
-							<!-- Upper Mouth Corners -->
-							<local:BoneView Canvas.Left="25" Canvas.Top="115" BoneName="j_f_uslip_l" FlippedBoneName="j_f_uslip_r"/>
-							<local:BoneView Canvas.Left="175" Canvas.Top="115" BoneName="j_f_uslip_r" FlippedBoneName="j_f_uslip_l"/>
+							<!-- Legacy bones -->
+							<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+								<!-- Upper lip -->
+								<local:BoneView Canvas.Left="102" Canvas.Top="95" BoneName="j_f_ulip_b"/>
+								<local:BoneView Canvas.Left="102" Canvas.Top="120" BoneName="j_f_ulip_a"/>
 
-							<!-- Lower Mouth Corners-->
-							<local:BoneView Canvas.Left="25" Canvas.Top="145" BoneName="j_f_dslip_l" FlippedBoneName="j_f_dslip_r"/>
-							<local:BoneView Canvas.Left="175" Canvas.Top="145" BoneName="j_f_dslip_r" FlippedBoneName="j_f_dslip_l"/>
+								<!-- Lower lip -->
+								<local:BoneView Canvas.Left="102" Canvas.Top="145" BoneName="j_f_dlip_a"/>
+								<local:BoneView Canvas.Left="102" Canvas.Top="170" BoneName="j_f_dlip_b"/>
+								
+								<!-- Lips Left -->
+								<local:BoneView Canvas.Left="40" Canvas.Top="130" BoneName="j_f_lip_l" FlippedBoneName="j_f_lip_r"/>
+								
+								<!-- Lips Right -->
+								<local:BoneView Canvas.Left="160" Canvas.Top="130" BoneName="j_f_lip_r" FlippedBoneName="j_f_lip_l"/>
+							</Canvas>
 
-							<!-- Upper lip -->
-							<local:BoneView Canvas.Left="58" Canvas.Top="115" BoneName="j_f_umlip_02_l" FlippedBoneName="j_f_umlip_02_r"/>
-							<local:BoneView Canvas.Left="142" Canvas.Top="115" BoneName="j_f_umlip_02_r" FlippedBoneName="j_f_umlip_02_l"/>
-							<local:BoneView Canvas.Left="85" Canvas.Top="115" BoneName="j_f_ulip_02_l" FlippedBoneName="j_f_ulip_02_r"/>
-							<local:BoneView Canvas.Left="115" Canvas.Top="115" BoneName="j_f_ulip_02_r" FlippedBoneName="j_f_ulip_02_l"/>
+							<!-- Modern bones -->
+							<Canvas Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+								<!-- Upper Mouth Corners -->
+								<local:BoneView Canvas.Left="25" Canvas.Top="115" BoneName="j_f_uslip_l" FlippedBoneName="j_f_uslip_r"/>
+								<local:BoneView Canvas.Left="175" Canvas.Top="115" BoneName="j_f_uslip_r" FlippedBoneName="j_f_uslip_l"/>
 
-							<local:BoneView Canvas.Left="58" Canvas.Top="90" BoneName="j_f_umlip_01_l" FlippedBoneName="j_f_umlip_01_r"/>
-							<local:BoneView Canvas.Left="142" Canvas.Top="90" BoneName="j_f_umlip_01_r" FlippedBoneName="j_f_umlip_01_l"/>
-							<local:BoneView Canvas.Left="85" Canvas.Top="90" BoneName="j_f_ulip_01_l" FlippedBoneName="j_f_ulip_01_r"/>
-							<local:BoneView Canvas.Left="115" Canvas.Top="90" BoneName="j_f_ulip_01_r" FlippedBoneName="j_f_ulip_01_l"/>
+								<!-- Lower Mouth Corners-->
+								<local:BoneView Canvas.Left="25" Canvas.Top="145" BoneName="j_f_dslip_l" FlippedBoneName="j_f_dslip_r"/>
+								<local:BoneView Canvas.Left="175" Canvas.Top="145" BoneName="j_f_dslip_r" FlippedBoneName="j_f_dslip_l"/>
 
-							<!-- Lower lip -->
-							<local:BoneView Canvas.Left="58" Canvas.Top="145" BoneName="j_f_dmlip_02_l" FlippedBoneName="j_f_dmlip_02_r"/>
-							<local:BoneView Canvas.Left="142" Canvas.Top="145" BoneName="j_f_dmlip_02_r" FlippedBoneName="j_f_dmlip_02_l"/>
-							<local:BoneView Canvas.Left="85" Canvas.Top="145" BoneName="j_f_dlip_02_l" FlippedBoneName="j_f_dlip_02_r"/>
-							<local:BoneView Canvas.Left="115" Canvas.Top="145" BoneName="j_f_dlip_02_r" FlippedBoneName="j_f_dlip_02_l"/>
+								<!-- Upper lip -->
+								<local:BoneView Canvas.Left="58" Canvas.Top="115" BoneName="j_f_umlip_02_l" FlippedBoneName="j_f_umlip_02_r"/>
+								<local:BoneView Canvas.Left="142" Canvas.Top="115" BoneName="j_f_umlip_02_r" FlippedBoneName="j_f_umlip_02_l"/>
+								<local:BoneView Canvas.Left="85" Canvas.Top="115" BoneName="j_f_ulip_02_l" FlippedBoneName="j_f_ulip_02_r"/>
+								<local:BoneView Canvas.Left="115" Canvas.Top="115" BoneName="j_f_ulip_02_r" FlippedBoneName="j_f_ulip_02_l"/>
 
+								<local:BoneView Canvas.Left="58" Canvas.Top="90" BoneName="j_f_umlip_01_l" FlippedBoneName="j_f_umlip_01_r"/>
+								<local:BoneView Canvas.Left="142" Canvas.Top="90" BoneName="j_f_umlip_01_r" FlippedBoneName="j_f_umlip_01_l"/>
+								<local:BoneView Canvas.Left="85" Canvas.Top="90" BoneName="j_f_ulip_01_l" FlippedBoneName="j_f_ulip_01_r"/>
+								<local:BoneView Canvas.Left="115" Canvas.Top="90" BoneName="j_f_ulip_01_r" FlippedBoneName="j_f_ulip_01_l"/>
 
-							<local:BoneView Canvas.Left="58" Canvas.Top="170" BoneName="j_f_dmlip_01_l" FlippedBoneName="j_f_dmlip_01_r"/>
-							<local:BoneView Canvas.Left="142" Canvas.Top="170" BoneName="j_f_dmlip_01_r" FlippedBoneName="j_f_dmlip_01_l"/>
-							<local:BoneView Canvas.Left="85" Canvas.Top="170" BoneName="j_f_dlip_01_l" FlippedBoneName="j_f_dlip_01_r"/>
-							<local:BoneView Canvas.Left="115" Canvas.Top="170" BoneName="j_f_dlip_01_r" FlippedBoneName="j_f_dlip_01_l"/>
+								<!-- Lower lip -->
+								<local:BoneView Canvas.Left="58" Canvas.Top="145" BoneName="j_f_dmlip_02_l" FlippedBoneName="j_f_dmlip_02_r"/>
+								<local:BoneView Canvas.Left="142" Canvas.Top="145" BoneName="j_f_dmlip_02_r" FlippedBoneName="j_f_dmlip_02_l"/>
+								<local:BoneView Canvas.Left="85" Canvas.Top="145" BoneName="j_f_dlip_02_l" FlippedBoneName="j_f_dlip_02_r"/>
+								<local:BoneView Canvas.Left="115" Canvas.Top="145" BoneName="j_f_dlip_02_r" FlippedBoneName="j_f_dlip_02_l"/>
+
+								<local:BoneView Canvas.Left="58" Canvas.Top="170" BoneName="j_f_dmlip_01_l" FlippedBoneName="j_f_dmlip_01_r"/>
+								<local:BoneView Canvas.Left="142" Canvas.Top="170" BoneName="j_f_dmlip_01_r" FlippedBoneName="j_f_dmlip_01_l"/>
+								<local:BoneView Canvas.Left="85" Canvas.Top="170" BoneName="j_f_dlip_01_l" FlippedBoneName="j_f_dlip_01_r"/>
+								<local:BoneView Canvas.Left="115" Canvas.Top="170" BoneName="j_f_dlip_01_r" FlippedBoneName="j_f_dlip_01_l"/>
+							</Canvas>
 						</Canvas>
 					</Viewbox>
 				</Grid>

--- a/Anamnesis/Actor/Posing/Views/PoseMatrixView.xaml
+++ b/Anamnesis/Actor/Posing/Views/PoseMatrixView.xaml
@@ -20,272 +20,401 @@
 	<ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
 		<Grid x:Name="ContentArea" Margin="3">
 			<StackPanel>
-				<GroupBox>
-					<GroupBox.Header>
-						<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
-							<XivToolsWpf:TextBlock Key="Pose_Matrix_HeadCategory"/>
-						</Button>
-					</GroupBox.Header>
-					<Grid>
+				<!-- Legacy bones -->
+				<StackPanel Visibility="{Binding HasPreDTFace, Converter={StaticResource B2V}}">
+					<GroupBox>
+						<GroupBox.Header>
+							<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
+								<XivToolsWpf:TextBlock Key="Pose_Matrix_HeadCategory"/>
+							</Button>
+						</GroupBox.Header>
+						<Grid>
 
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
 
-						<Grid.RowDefinitions>
-							<RowDefinition/>
-							<RowDefinition/>
-							<RowDefinition/>
-						</Grid.RowDefinitions>
+							<Grid.RowDefinitions>
+								<RowDefinition/>
+								<RowDefinition/>
+								<RowDefinition/>
+							</Grid.RowDefinitions>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Head" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<local:BoneView Grid.Column="1" Grid.Row="0" BoneName="Head"/>
+							<!-- Head -->
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Head" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<local:BoneView Grid.Column="1" Grid.Row="0" BoneName="j_kao"/>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_Jaw" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_ago" Label="1"/>
-							<local:BoneView BoneName="j_f_dago" Label="2"/>
-						</StackPanel>
+							<!-- Nose -->
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_Nose" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_hana"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="0" Key="Pose_Ears" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="EarLeft" Label="L"/>
-							<local:BoneView BoneName="EarRight" Label="R"/>
-						</StackPanel>
+							<!-- Nose Bridge -->
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="0" Key="Pose_Bridge" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_memoto"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_Cheeks" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_hoho_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_shoho_l" Label="L2"/>
-							<local:BoneView BoneName="j_f_hoho_r" Label="R1"/>
-							<local:BoneView BoneName="j_f_shoho_r" Label="R2"/>
-						</StackPanel>
+							<!-- Ears -->
+							<XivToolsWpf:TextBlock Grid.Column="6" Grid.Row="0" Key="Pose_Ears" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="7" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="EarLeft" Label="L"/>
+								<local:BoneView BoneName="EarRight" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_FrontalCheekbones" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_dmemoto_l" Label="L"/>
-							<local:BoneView BoneName="j_f_dmemoto_r" Label="R"/>
-						</StackPanel>
+							<!-- Eyes -->
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_Eyes" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_eye_l" Label="L"/>
+								<local:BoneView BoneName="j_f_eye_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_CheekboneSides" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_dhoho_l" Label="L"/>
-							<local:BoneView BoneName="j_f_dhoho_r" Label="R"/>
-						</StackPanel>
+							<!-- Eyebrows -->
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_Eyebrows" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mayu_l" Label="L"/>
+								<local:BoneView BoneName="j_f_mayu_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_Nose" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_uhana" Label="C"/>
-							<local:BoneView BoneName="j_f_hana_l" Label="L"/>
-							<local:BoneView BoneName="j_f_hana_r" Label="R"/>
-						</StackPanel>
-						
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_NoseBridge" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_dmiken_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_miken_02_l" Label="L2"/>
-							<local:BoneView BoneName="j_f_dmiken_r" Label="R1"/>
-							<local:BoneView BoneName="j_f_miken_02_r" Label="R2"/>
-						</StackPanel>
+							<!-- Brows -->
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_Brows" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_miken_l" Label="L"/>
+								<local:BoneView BoneName="j_f_miken_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="2" Key="Pose_VieraEars" Style="{DynamicResource Label}" Visibility="{Binding IsViera, Converter={StaticResource B2V}}" Margin="16, 0, 3, 0"/>
-						<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars01, Converter={StaticResource B2V}}">
-							<local:BoneView BoneName="VieraEar01ALeft" Label="L1"/>
-							<local:BoneView BoneName="VieraEar01BLeft" Label="L2"/>
-							<local:BoneView BoneName="VieraEar01ARight" Label="R1"/>
-							<local:BoneView BoneName="VieraEar01BRight" Label="R2"/>
-						</StackPanel>
-						<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
-							<local:BoneView BoneName="VieraEar02ALeft" Label="L1"/>
-							<local:BoneView BoneName="VieraEar02BLeft" Label="L2"/>
-							<local:BoneView BoneName="VieraEar02ARight" Label="R1"/>
-							<local:BoneView BoneName="VieraEar02BRight" Label="R2"/>
-						</StackPanel>
-						<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
-							<local:BoneView BoneName="VieraEar03ALeft" Label="L1"/>
-							<local:BoneView BoneName="VieraEar03BLeft" Label="L2"/>
-							<local:BoneView BoneName="VieraEar03ARight" Label="R1"/>
-							<local:BoneView BoneName="VieraEar03BRight" Label="R2"/>
-						</StackPanel>
-						<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars04, Converter={StaticResource B2V}}">
-							<local:BoneView BoneName="VieraEar04ALeft" Label="L1"/>
-							<local:BoneView BoneName="VieraEar04BLeft" Label="L2"/>
-							<local:BoneView BoneName="VieraEar04ARight" Label="R1"/>
-							<local:BoneView BoneName="VieraEar04BRight" Label="R2"/>
-						</StackPanel>
+							<!-- Upper Eyelids -->
+							<XivToolsWpf:TextBlock Grid.Column="6" Grid.Row="1" Key="Pose_Eyelids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="7" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_umab_l" Label="L"/>
+								<local:BoneView BoneName="j_f_umab_r" Label="R"/>
+							</StackPanel>
 
-					</Grid>
-				</GroupBox>
+							<!-- Lower Eyelids -->
+							<XivToolsWpf:TextBlock Grid.Column="8" Grid.Row="1" Key="Pose_LowerLids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="9" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dmab_l" Label="L"/>
+								<local:BoneView BoneName="j_f_dmab_r" Label="R"/>
+							</StackPanel>
 
-				<GroupBox>
-					<GroupBox.Header>
-						<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
-							<XivToolsWpf:TextBlock Key="Pose_Matrix_EyeCategory"/>
-						</Button>
-					</GroupBox.Header>
-					<Grid>
+							<!-- Inner cheeks -->
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_Cheeks" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_hoho_l" Label="L"/>
+								<local:BoneView BoneName="j_f_hoho_r" Label="R"/>
+							</StackPanel>
 
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
+							<!-- Jaw -->
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_Jaw" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_ago"/>
+							</StackPanel>
 
-						<Grid.RowDefinitions>
-							<RowDefinition/>
-							<RowDefinition/>
-							<RowDefinition/>
-						</Grid.RowDefinitions>
+							<!-- Mouth -->
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="2" Key="Pose_Mouth" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_lip_l" Label="L"/>
+								<local:BoneView BoneName="j_f_lip_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Eyes" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_eye_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_eyepuru_l" Label="L2"/>
-							<local:BoneView BoneName="j_f_eye_r" Label="R2"/>
-							<local:BoneView BoneName="j_f_eyepuru_r" Label="R2"/>
-						</StackPanel>
+							<!-- Upper Lip -->
+							<XivToolsWpf:TextBlock Grid.Column="6" Grid.Row="2" Key="Pose_UpperLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="7" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_ulip_a" Label="A"/>
+								<local:BoneView BoneName="j_f_ulip_b" Label="B"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_LeftEyelids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mabup_01_l" Label="U"/>
-							<local:BoneView BoneName="j_f_mabdn_01_l" Label="L"/>
-						</StackPanel>
+							<!-- Lower Lip -->
+							<XivToolsWpf:TextBlock Grid.Column="8" Grid.Row="2" Key="Pose_LowerLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="9" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dlip_a" Label="A"/>
+								<local:BoneView BoneName="j_f_dlip_b" Label="B"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="0" Key="Pose_RightEyelids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mabup_01_r" Label="U"/>
-							<local:BoneView BoneName="j_f_mabdn_01_r" Label="L"/>
-						</StackPanel>
+							<!-- Note: There are no legacy viera characters so we don't need to display the viera ear nodes here -->
+						</Grid>
+					</GroupBox>
+				</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_Eyebrows" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mmayu_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_mayu_l" Label="L2"/>
-							<local:BoneView BoneName="j_f_mmayu_r" Label="R1"/>
-							<local:BoneView BoneName="j_f_mayu_r" Label="R2"/>
-						</StackPanel>
+				<!-- Modern bones -->
+				<StackPanel Visibility="{Binding HasPreDTFace, Converter={StaticResource !B2V}}">
+					<GroupBox>
+						<GroupBox.Header>
+							<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
+								<XivToolsWpf:TextBlock Key="Pose_Matrix_HeadCategory"/>
+							</Button>
+						</GroupBox.Header>
+						<Grid>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_LeftEyeCorner" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mabup_03in_l" Label="U1"/>
-							<local:BoneView BoneName="j_f_mabup_02out_l" Label="U2"/>
-							<local:BoneView BoneName="j_f_mabdn_03in_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_mabdn_02out_l" Label="L2"/>
-						</StackPanel>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_RightEyeCorner" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mabup_03in_r" Label="U1"/>
-							<local:BoneView BoneName="j_f_mabup_02out_r" Label="U2"/>
-							<local:BoneView BoneName="j_f_mabdn_03in_r" Label="L1"/>
-							<local:BoneView BoneName="j_f_mabdn_02out_r" Label="L2"/>
-						</StackPanel>
+							<Grid.RowDefinitions>
+								<RowDefinition/>
+								<RowDefinition/>
+								<RowDefinition/>
+							</Grid.RowDefinitions>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_EyeSocket" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_mab_l" Label="L"/>
-							<local:BoneView BoneName="j_f_mab_r" Label="R"/>
-						</StackPanel>
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Head" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<local:BoneView Grid.Column="1" Grid.Row="0" BoneName="Head"/>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_Iris" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_irisprm_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_eyeprm_01_l" Label="L2"/>
-							<local:BoneView BoneName="j_f_irisprm_r" Label="R1"/>
-							<local:BoneView BoneName="j_f_eyeprm_01_r" Label="R2"/>
-						</StackPanel>
-					</Grid>
-				</GroupBox>
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_Jaw" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_ago" Label="1"/>
+								<local:BoneView BoneName="j_f_dago" Label="2"/>
+							</StackPanel>
 
-				<GroupBox>
-					<GroupBox.Header>
-						<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
-							<XivToolsWpf:TextBlock Key="Pose_Matrix_MouthCategory"/>
-						</Button>
-					</GroupBox.Header>
-					<Grid>
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="0" Key="Pose_Ears" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="EarLeft" Label="L"/>
+								<local:BoneView BoneName="EarRight" Label="R"/>
+							</StackPanel>
 
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="Auto"/>
-						</Grid.ColumnDefinitions>
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_Cheeks" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_hoho_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_shoho_l" Label="L2"/>
+								<local:BoneView BoneName="j_f_hoho_r" Label="R1"/>
+								<local:BoneView BoneName="j_f_shoho_r" Label="R2"/>
+							</StackPanel>
 
-						<Grid.RowDefinitions>
-							<RowDefinition/>
-							<RowDefinition/>
-							<RowDefinition/>
-						</Grid.RowDefinitions>
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_FrontalCheekbones" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dmemoto_l" Label="L"/>
+								<local:BoneView BoneName="j_f_dmemoto_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Teeth" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_hagukiup" Label="1"/>
-							<local:BoneView BoneName="j_f_hagukidn" Label="2"/>
-						</StackPanel>
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_CheekboneSides" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dhoho_l" Label="L"/>
+								<local:BoneView BoneName="j_f_dhoho_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_Tongue" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_bero_01" Label="1"/>
-							<local:BoneView BoneName="j_f_bero_02" Label="2"/>
-							<local:BoneView BoneName="j_f_bero_03" Label="3"/>
-						</StackPanel>
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_Nose" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_uhana" Label="C"/>
+								<local:BoneView BoneName="j_f_hana_l" Label="L"/>
+								<local:BoneView BoneName="j_f_hana_r" Label="R"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_LeftUpperLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_ulip_01_l" Label="1"/>
-							<local:BoneView BoneName="j_f_ulip_02_l" Label="2"/>
-							<local:BoneView BoneName="j_f_umlip_01_l" Label="3"/>
-							<local:BoneView BoneName="j_f_umlip_02_l" Label="4"/>
-						</StackPanel>
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_NoseBridge" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dmiken_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_miken_02_l" Label="L2"/>
+								<local:BoneView BoneName="j_f_dmiken_r" Label="R1"/>
+								<local:BoneView BoneName="j_f_miken_02_r" Label="R2"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_RightUpperLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_ulip_01_r" Label="1"/>
-							<local:BoneView BoneName="j_f_ulip_02_r" Label="2"/>
-							<local:BoneView BoneName="j_f_umlip_01_r" Label="3"/>
-							<local:BoneView BoneName="j_f_umlip_02_r" Label="4"/>
-						</StackPanel>
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="2" Key="Pose_VieraEars" Style="{DynamicResource Label}" Visibility="{Binding IsViera, Converter={StaticResource B2V}}" Margin="16, 0, 3, 0"/>
+							<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars01, Converter={StaticResource B2V}}">
+								<local:BoneView BoneName="VieraEar01ALeft" Label="L1"/>
+								<local:BoneView BoneName="VieraEar01BLeft" Label="L2"/>
+								<local:BoneView BoneName="VieraEar01ARight" Label="R1"/>
+								<local:BoneView BoneName="VieraEar01BRight" Label="R2"/>
+							</StackPanel>
+							<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars02, Converter={StaticResource B2V}}">
+								<local:BoneView BoneName="VieraEar02ALeft" Label="L1"/>
+								<local:BoneView BoneName="VieraEar02BLeft" Label="L2"/>
+								<local:BoneView BoneName="VieraEar02ARight" Label="R1"/>
+								<local:BoneView BoneName="VieraEar02BRight" Label="R2"/>
+							</StackPanel>
+							<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars03, Converter={StaticResource B2V}}">
+								<local:BoneView BoneName="VieraEar03ALeft" Label="L1"/>
+								<local:BoneView BoneName="VieraEar03BLeft" Label="L2"/>
+								<local:BoneView BoneName="VieraEar03ARight" Label="R1"/>
+								<local:BoneView BoneName="VieraEar03BRight" Label="R2"/>
+							</StackPanel>
+							<StackPanel Orientation="Horizontal" Grid.Column="5" Grid.ColumnSpan="4" Grid.Row="2" Visibility="{Binding IsEars04, Converter={StaticResource B2V}}">
+								<local:BoneView BoneName="VieraEar04ALeft" Label="L1"/>
+								<local:BoneView BoneName="VieraEar04BLeft" Label="L2"/>
+								<local:BoneView BoneName="VieraEar04ARight" Label="R1"/>
+								<local:BoneView BoneName="VieraEar04BRight" Label="R2"/>
+							</StackPanel>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_LeftLipCorners" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_uslip_l" Label="L1"/>
-							<local:BoneView BoneName="j_f_dslip_l" Label="L2"/>
-						</StackPanel>
+						</Grid>
+					</GroupBox>
 
-						<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_LeftLowerLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_dlip_01_l" Label="1"/>
-							<local:BoneView BoneName="j_f_dlip_02_l" Label="2"/>
-							<local:BoneView BoneName="j_f_dmlip_01_l" Label="3"/>
-							<local:BoneView BoneName="j_f_dmlip_02_l" Label="4"/>
-						</StackPanel>
+					<GroupBox>
+						<GroupBox.Header>
+							<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
+								<XivToolsWpf:TextBlock Key="Pose_Matrix_EyeCategory"/>
+							</Button>
+						</GroupBox.Header>
+						<Grid>
 
-						<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_RightLowerLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_dlip_01_r" Label="1"/>
-							<local:BoneView BoneName="j_f_dlip_02_r" Label="2"/>
-							<local:BoneView BoneName="j_f_dmlip_01_r" Label="3"/>
-							<local:BoneView BoneName="j_f_dmlip_02_r" Label="4"/>
-						</StackPanel>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
 
-						<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="2" Key="Pose_RightLipCorners" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
-						<StackPanel Grid.Column="5" Grid.Row="2" Orientation="Horizontal">
-							<local:BoneView BoneName="j_f_uslip_r" Label="R1"/>
-							<local:BoneView BoneName="j_f_dslip_r" Label="R2"/>
-						</StackPanel>
-					</Grid>
-				</GroupBox>
+							<Grid.RowDefinitions>
+								<RowDefinition/>
+								<RowDefinition/>
+								<RowDefinition/>
+							</Grid.RowDefinitions>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Eyes" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_eye_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_eyepuru_l" Label="L2"/>
+								<local:BoneView BoneName="j_f_eye_r" Label="R2"/>
+								<local:BoneView BoneName="j_f_eyepuru_r" Label="R2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_LeftEyelids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mabup_01_l" Label="U"/>
+								<local:BoneView BoneName="j_f_mabdn_01_l" Label="L"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="0" Key="Pose_RightEyelids" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mabup_01_r" Label="U"/>
+								<local:BoneView BoneName="j_f_mabdn_01_r" Label="L"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_Eyebrows" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mmayu_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_mayu_l" Label="L2"/>
+								<local:BoneView BoneName="j_f_mmayu_r" Label="R1"/>
+								<local:BoneView BoneName="j_f_mayu_r" Label="R2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_LeftEyeCorner" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mabup_03in_l" Label="U1"/>
+								<local:BoneView BoneName="j_f_mabup_02out_l" Label="U2"/>
+								<local:BoneView BoneName="j_f_mabdn_03in_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_mabdn_02out_l" Label="L2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_RightEyeCorner" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mabup_03in_r" Label="U1"/>
+								<local:BoneView BoneName="j_f_mabup_02out_r" Label="U2"/>
+								<local:BoneView BoneName="j_f_mabdn_03in_r" Label="L1"/>
+								<local:BoneView BoneName="j_f_mabdn_02out_r" Label="L2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_EyeSocket" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_mab_l" Label="L"/>
+								<local:BoneView BoneName="j_f_mab_r" Label="R"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_Iris" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_irisprm_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_eyeprm_01_l" Label="L2"/>
+								<local:BoneView BoneName="j_f_irisprm_r" Label="R1"/>
+								<local:BoneView BoneName="j_f_eyeprm_01_r" Label="R2"/>
+							</StackPanel>
+						</Grid>
+					</GroupBox>
+
+					<GroupBox>
+						<GroupBox.Header>
+							<Button Style="{StaticResource LinkButton}" Click="OnGroupClicked">
+								<XivToolsWpf:TextBlock Key="Pose_Matrix_MouthCategory"/>
+							</Button>
+						</GroupBox.Header>
+						<Grid>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+								<ColumnDefinition Width="Auto"/>
+							</Grid.ColumnDefinitions>
+
+							<Grid.RowDefinitions>
+								<RowDefinition/>
+								<RowDefinition/>
+								<RowDefinition/>
+							</Grid.RowDefinitions>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="Pose_Teeth" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_hagukiup" Label="1"/>
+								<local:BoneView BoneName="j_f_hagukidn" Label="2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="0" Key="Pose_Tongue" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="0" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_bero_01" Label="1"/>
+								<local:BoneView BoneName="j_f_bero_02" Label="2"/>
+								<local:BoneView BoneName="j_f_bero_03" Label="3"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="1" Key="Pose_LeftUpperLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_ulip_01_l" Label="1"/>
+								<local:BoneView BoneName="j_f_ulip_02_l" Label="2"/>
+								<local:BoneView BoneName="j_f_umlip_01_l" Label="3"/>
+								<local:BoneView BoneName="j_f_umlip_02_l" Label="4"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="1" Key="Pose_RightUpperLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_ulip_01_r" Label="1"/>
+								<local:BoneView BoneName="j_f_ulip_02_r" Label="2"/>
+								<local:BoneView BoneName="j_f_umlip_01_r" Label="3"/>
+								<local:BoneView BoneName="j_f_umlip_02_r" Label="4"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="1" Key="Pose_LeftLipCorners" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="1" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_uslip_l" Label="L1"/>
+								<local:BoneView BoneName="j_f_dslip_l" Label="L2"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="2" Key="Pose_LeftLowerLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dlip_01_l" Label="1"/>
+								<local:BoneView BoneName="j_f_dlip_02_l" Label="2"/>
+								<local:BoneView BoneName="j_f_dmlip_01_l" Label="3"/>
+								<local:BoneView BoneName="j_f_dmlip_02_l" Label="4"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="2" Grid.Row="2" Key="Pose_RightLowerLip" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_dlip_01_r" Label="1"/>
+								<local:BoneView BoneName="j_f_dlip_02_r" Label="2"/>
+								<local:BoneView BoneName="j_f_dmlip_01_r" Label="3"/>
+								<local:BoneView BoneName="j_f_dmlip_02_r" Label="4"/>
+							</StackPanel>
+
+							<XivToolsWpf:TextBlock Grid.Column="4" Grid.Row="2" Key="Pose_RightLipCorners" Style="{DynamicResource Label}" Margin="16, 0, 3, 0"/>
+							<StackPanel Grid.Column="5" Grid.Row="2" Orientation="Horizontal">
+								<local:BoneView BoneName="j_f_uslip_r" Label="R1"/>
+								<local:BoneView BoneName="j_f_dslip_r" Label="R2"/>
+							</StackPanel>
+						</Grid>
+					</GroupBox>
+				</StackPanel>
 
 				<GroupBox>
 					<GroupBox.Header>

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -30,6 +30,8 @@ public class ActorMemory : ActorBasicMemory
 		this.refreshDebounceTimer.Elapsed += async (s, e) => { await this.Refresh(); };
 	}
 
+	public event EventHandler? Refreshed;
+
 	public enum CharacterModes : byte
 	{
 		None = 0,
@@ -200,6 +202,7 @@ public class ActorMemory : ActorBasicMemory
 		}
 
 		this.OnPropertyChanged(nameof(this.IsHuman));
+		this.OnRefreshed();
 	}
 
 	public async Task BackupAsync()
@@ -213,6 +216,11 @@ public class ActorMemory : ActorBasicMemory
 	public void RaiseRefreshChanged()
 	{
 		this.OnPropertyChanged(nameof(this.CanRefresh));
+	}
+
+	protected virtual void OnRefreshed()
+	{
+		this.Refreshed?.Invoke(this, EventArgs.Empty);
 	}
 
 	private void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Anamnesis/Memory/InplaceFixedArrayMemory.cs
+++ b/Anamnesis/Memory/InplaceFixedArrayMemory.cs
@@ -7,7 +7,6 @@ using PropertyChanged;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 /// <summary>
 /// Represents an inplace fixed-length array in memory.
@@ -154,14 +153,6 @@ public abstract class InplaceFixedArrayMemory<TValue> : MemoryBase, IEnumerable<
 				Log.Warning(ex, "Failed to read array object from memory");
 			}
 		}
-	}
-
-	/// <summary>Called when a property of the object changes.</summary>
-	/// <param name="sender">The sender of the event.</param>
-	/// <param name="e">The event arguments.</param>
-	protected override void OnSelfPropertyChanged(object? sender, PropertyChangedEventArgs e)
-	{
-		this.Synchronize();
 	}
 
 	/// <summary>


### PR DESCRIPTION
This pull request adds bone selectors to the body, face, and matrix views in the pose tab to allow users to pose NPCs with the old skeleton.

**Additional fixes:**
- Changing between appearances was causing stale bone nodes. This was resolved by force refreshing the skeleton every time the actor is refreshed.
- Moved the "Reset camera" button in the 3D pose view to fix the overlap.