### PR TITLE
Disable scaling by default & add option to import with scaling using Shift key

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -369,7 +369,9 @@ public partial class PosePage : UserControl
 
 	private async void OnImportClicked(object sender, RoutedEventArgs e)
 	{
-		await this.ImportPose(PoseImportOptions.Character, PoseFile.Mode.All);
+		bool isShiftPressed = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
+		PoseFile.Mode mode = isShiftPressed ? PoseFile.Mode.All : (PoseFile.Mode.All & ~PoseFile.Mode.Scale);
+		await this.ImportPose(PoseImportOptions.Character, mode);
 		this.Skeleton?.ClearSelection();
 	}
 

--- a/Anamnesis/Actor/Posing/Services/PoseService.cs
+++ b/Anamnesis/Actor/Posing/Services/PoseService.cs
@@ -175,7 +175,7 @@ public class PoseService : ServiceBase<PoseService>
 		this.FreezePhysics = enabled;
 		this.FreezeRotation = enabled;
 		this.FreezePositions = enabled;
-		this.FreezeScale = enabled;
+		this.FreezeScale = false;
 		this.EnableParenting = true;
 
 		/*if (enabled)

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -320,7 +320,7 @@
   "Pose_NoModel": "This actor does not have a model.",
   "Pose_NotEnabled": "Posing mode must be enabled.",
   "Pose_NothingSelected": "Character - Nothing Selected",
-  "Pose_LoadTip": "Load a pose from a file",
+  "Pose_LoadTip": "Load a pose from a file (Hold Shift to use pose file scaling)",
   "Pose_FullChar": "Full Character",
   "Pose_FullCharTooltip": "Loads a pose onto the entire actor",
   "Pose_Selected": "Selected Bones",


### PR DESCRIPTION
_Note: This pull request is currently targeting the `testing` branch._

Reverted scaling being enabled by default as discussed in the development channel. Instead, people can include scaling by holding down the Shift key when pressing the import button.

This seems like the simplest solution without compromising in a significant way in either direction.