### PR TITLE
Added a 'Weapons Only' pose import option

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml
+++ b/Anamnesis/Actor/Pages/PosePage.xaml
@@ -271,6 +271,15 @@
 							</MenuItem.ToolTip>
 						</MenuItem>
 
+						<!-- (Import) Weapons Only -->
+						<MenuItem Header="Pose_WeaponsOnly"
+								  Style="{StaticResource AnaMenuItem}"
+								  Click="OnImportWeaponsClicked">
+							<MenuItem.ToolTip>
+								<XivToolsWpf:TextBlock Key="Pose_WeaponsOnlyTooltip" />
+							</MenuItem.ToolTip>
+						</MenuItem>
+
 						<!-- (Import) Selected Bones -->
 						<MenuItem Header="Pose_Selected"
 								  Style="{StaticResource AnaMenuItem}"

--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -81,6 +81,7 @@ public partial class PosePage : UserControl
 		BodyOnly,       // Imports only the body part of the pose.
 		ExpressionOnly, // Imports only the facial expression part of the pose.
 		SelectedBones,  // Imports only the selected bones.
+		WeaponsOnly,    // Imports only the weapons (main hand and off-hand).
 	}
 
 	public SettingsService SettingsService => SettingsService.Instance;
@@ -395,6 +396,11 @@ public partial class PosePage : UserControl
 		await this.HandleSecondaryOptionImport(PoseImportOptions.SelectedBones);
 	}
 
+	private async void OnImportWeaponsClicked(object sender, RoutedEventArgs e)
+	{
+		await this.HandleSecondaryOptionImport(PoseImportOptions.WeaponsOnly);
+	}
+
 	private async Task ImportPose(PoseImportOptions importOption, PoseFile.Mode mode)
 	{
 		if (this.Actor == null || this.Skeleton == null)
@@ -460,6 +466,15 @@ public partial class PosePage : UserControl
 				// Don't unselected bones after import. Let the user decide what to do with the selection.
 				var selectedBones = this.Skeleton.SelectedBones.Select(bone => bone.BoneName).ToHashSet();
 				poseFile.Apply(this.Actor, this.Skeleton, selectedBones, mode, false);
+				return;
+			}
+
+			if (importOption == PoseImportOptions.WeaponsOnly)
+			{
+				this.Skeleton.SelectWeapons();
+				var selectedBoneNames = this.Skeleton.SelectedBones.Select(bone => bone.BoneName).ToHashSet();
+				poseFile.Apply(this.Actor, this.Skeleton, selectedBoneNames, mode, false);
+				this.Skeleton.ClearSelection();
 				return;
 			}
 

--- a/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
@@ -441,6 +441,20 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 		this.Select(headBones, SkeletonVisual3d.SelectMode.Add);
 	}
 
+	public void SelectWeapons()
+	{
+		this.ClearSelection();
+		var bonesToSelect = this.mainHandBones.Concat(this.offHandBones).ToList();
+
+		if (this.GetBone("n_buki_l") is BoneVisual3d boneLeft)
+			bonesToSelect.Add(boneLeft);
+
+		if (this.GetBone("n_buki_r") is BoneVisual3d boneRight)
+			bonesToSelect.Add(boneRight);
+
+		this.Select(bonesToSelect, SkeletonVisual3d.SelectMode.Add);
+	}
+
 	public void InvertSelection()
 	{
 		foreach ((string name, BoneVisual3d bone) in this.Bones)

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -327,6 +327,8 @@
   "Pose_SelectedTooltip": "Loads a pose onto the actor's selected bones",
   "Pose_Expression": "Expression Only",
   "Pose_ExpressionTooltip": "Loads a pose onto the actor's face",
+  "Pose_WeaponsOnly": "Weapons Only",
+  "Pose_WeaponsOnlyTooltip": "Loads a pose onto the actor's main hand and off-hand",
   "Pose_ScalePack": "Body Scale",
   "Pose_Body": "Body Only",
   "Pose_BodyTooltip": "Loads a pose onto the entire actor, excluding the face",


### PR DESCRIPTION
_Note: This pull request currently targets the `testing` branch._

Proposed feature addition to Anamnesis:
- A "Weapons only" import option added to the import dropdown menu.
  - The default import workflow has not changed. Weapons will continue to be imported with rotation data only unless the user explicitly chooses to use this import option. This allows for the highest compatibility of pose files.