### PR TITLE
Resolved miscellaneous issues preventing some pose panels from showing up-to-date state

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -310,8 +310,9 @@ public partial class PosePage : UserControl
 		await this.Refresh();
 	}
 
-	private void OnActorRefreshed(object? sender, EventArgs e)
+	private void OnActorRefreshed(object? sender, EventArgs? e)
 	{
+		// Restart the debounce timer if it's already running, otherwise start it.
 		this.refreshDebounceTimer.Stop();
 		this.refreshDebounceTimer.Start();
 	}
@@ -320,9 +321,7 @@ public partial class PosePage : UserControl
 	{
 		if (e.PropertyName == nameof(ActorModelMemory.Skeleton))
 		{
-			// Restart the debounce timer if it's already running, otherwise start it.
-			this.refreshDebounceTimer.Stop();
-			this.refreshDebounceTimer.Start();
+			this.OnActorRefreshed(null, default);
 		}
 	}
 
@@ -346,10 +345,9 @@ public partial class PosePage : UserControl
 
 		try
 		{
-			if (this.Skeleton == null)
-				this.Skeleton = new SkeletonVisual3d();
-
-			await this.Skeleton.SetActor(this.Actor);
+			SkeletonVisual3d newSkeleton = this.Skeleton ?? new SkeletonVisual3d();
+			await newSkeleton.SetActor(this.Actor);
+			this.Skeleton = newSkeleton;
 
 			this.ThreeDView.DataContext = this.Skeleton;
 			this.BodyGuiView.DataContext = this.Skeleton;

--- a/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
+++ b/Anamnesis/Actor/Posing/Visuals/SkeletonVisual3d.cs
@@ -149,6 +149,10 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 	{
 		get
 		{
+			// If the skeleton is not initialized, we can't determine if it's a pre-DT face.
+			if (this.Bones.Count == 0)
+				return false;
+
 			// We can determine if we have a DT-updated face if we have a tongue bone.
 			// EW faces don't have this bone, where as all updated faces in DT have it.
 			// It would be better to enumerate all of the faces and be more specific.
@@ -585,18 +589,6 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 			if (this.Actor.OffHand?.Model?.Skeleton != null)
 				this.AddBones(this.Actor.OffHand.Model.Skeleton, "oh_");
 
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.AllBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.HairBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.MetBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.TopBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.MainHandBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.OffHandBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.HasEquipmentBones));
-			this.RaisePropertyChanged(nameof(SkeletonVisual3d.HasWeaponBones));
-
-			if (!GposeService.Instance.IsGpose)
-				return;
-
 			// Create Bone links from the link database
 			foreach ((string name, BoneVisual3d bone) in this.Bones)
 			{
@@ -642,6 +634,10 @@ public class SkeletonVisual3d : ModelVisual3D, INotifyPropertyChanged
 					break;
 				}
 			}
+
+			// Notify that the skeleton has changed.
+			// All properties that depend on the skeleton are prompted to update.
+			this.RaisePropertyChanged(string.Empty);
 		}
 		catch (Exception)
 		{

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -216,6 +216,9 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 						}
 					}
 
+					// Wait for actor's model object to become available
+					await Task.Delay(300);
+
 					this.Value = newActor;
 					this.OnSelectionChanged(true);
 				}


### PR DESCRIPTION
This pull request contains the following changes:
- Added a delay to the brio spawn action to compensate for the actor's model object not being available right after spawn. This is a workaround and should ideally be removed in the future if a better solution is found.
- Added a check to the `HasPreDTFace` property so that actors outside of gpose return `true`. This will prompt the disabled pose panels to show the bone nodes for Dawntrail skeletons when the user is outside of gpose.
- Cleaned up and simplified some of the code.