### PR TITLE
Removed obsolete Brio API code & resolved issue causing actors to be teleported to world origin (0, 0, 0)

### DIFF
--- a/Anamnesis/Actor/Pages/CharacterPage.xaml
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml
@@ -130,13 +130,32 @@
 			</Grid>
 		</GroupBox>
 
-		<!-- Warning for making sure the actor can be edited. (Out of GPOSE when not using Brio or Penumbra integrations) -->
+		<!-- Warning messages indicating that the actor's appearance cannot be edited. -->
+		<XivToolsWpf:InfoControl
+			Key="Character_WarningGposeWorldPosFrozen"
+			Grid.Column="0"
+			Grid.ColumnSpan="2"
+			Margin="12">
+			<XivToolsWpf:InfoControl.Visibility>
+				<MultiBinding Converter="{StaticResource MultiBoolAndToVisibility}">
+					<Binding Path="Actor.CanRefresh" Converter="{StaticResource !B}"/>
+					<Binding Path="PoseService.FreezeWorldPosition"/>
+				</MultiBinding>
+			</XivToolsWpf:InfoControl.Visibility>
+		</XivToolsWpf:InfoControl>
+
 		<XivToolsWpf:InfoControl
 			Key="Character_WarningGpose"
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
-			Margin="12"
-			Visibility="{Binding Actor.CanRefresh, Converter={StaticResource !B2V}}" />
+			Margin="12">	
+			<XivToolsWpf:InfoControl.Visibility>
+				<MultiBinding Converter="{StaticResource MultiBoolAndToVisibility}">
+					<Binding Path="Actor.CanRefresh" Converter="{StaticResource !B}"/>
+					<Binding Path="PoseService.WorldPositionNotFrozen"/>
+				</MultiBinding>
+			</XivToolsWpf:InfoControl.Visibility>
+		</XivToolsWpf:InfoControl>
 
 		<!-- Other Actor Settings - Incl Subactor (Mount/Minion/FashAcc), Facewear, Extended Appearance -->
 		<Grid Grid.Column="2">

--- a/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
@@ -47,6 +47,7 @@ public partial class CharacterPage : UserControl
 
 	public ActorMemory? Actor { get; private set; }
 	public ListCollectionView VoiceEntries { get; private set; }
+	public PoseService PoseService => PoseService.Instance;
 
 	private void OnLoaded(object sender, RoutedEventArgs e)
 	{

--- a/Anamnesis/Brio/Brio.cs
+++ b/Anamnesis/Brio/Brio.cs
@@ -3,71 +3,47 @@
 
 namespace Anamnesis.Brio;
 
-using System;
 using System.Threading.Tasks;
 
 public static class Brio
 {
-	public static async Task<string> Redraw(int targetIndex, RedrawType redrawType)
+	public static async Task<string> Redraw(int targetIndex)
 	{
-		RedrawData data = new();
-		data.ObjectIndex = targetIndex;
-		data.RedrawType = redrawType;
+		RedrawData data = new() { ObjectIndex = targetIndex };
 		var result = await BrioApi.Post("/redraw", data);
 		return result;
 	}
 
-	public static async Task<int> Spawn(SpawnOptions options)
+	public static async Task<int> Spawn()
 	{
-		SpawnRequest data = new();
-		data.SpawnOptions = options;
-		var resultRaw = await BrioApi.Post("/spawn", data);
+		var resultRaw = await BrioApi.Post("/spawn");
 		var resultId = int.Parse(resultRaw);
 		return resultId;
 	}
 
 	public static async Task<bool> Despawn(int actorIndex)
 	{
-		DespawnData data = new();
-		data.ObjectIndex = actorIndex;
+		DespawnData data = new() { ObjectIndex = actorIndex };
 		var resultRaw = await BrioApi.Post("/despawn", data);
 		var result = bool.Parse(resultRaw);
 		return result;
 	}
 }
 
-[Flags]
-public enum RedrawType
+public enum RedrawResult
 {
-	None = 0,
-	AllowOptimized = 1,
-	AllowFull = 2,
-	ForceRedrawWeaponsOnOptimized = 4,
-	PreservePosition = 8,
-	ForceAllowNPCAppearance = 16,
-
-	All = AllowOptimized | AllowFull | ForceRedrawWeaponsOnOptimized | PreservePosition | ForceAllowNPCAppearance,
-}
-
-[Flags]
-public enum SpawnOptions
-{
-	None = 0,
-	ApplyModelPosition = 1,
+	NoChange,
+	Optimized,
+	Full,
+	Failed,
 }
 
 public class RedrawData
 {
-	public int ObjectIndex { get; set; } = -1;
-	public RedrawType? RedrawType { get; set; } = Anamnesis.Brio.RedrawType.All;
+	public int ObjectIndex { get; set; }
 }
 
 public class DespawnData
 {
 	public int ObjectIndex { get; set; } = -1;
-}
-
-public class SpawnRequest
-{
-	public SpawnOptions SpawnOptions { get; set; }
 }

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -272,6 +272,7 @@
   "Character_ExWeapons_Header": "Extended Weapons",
 
   "Character_WarningGpose": "Appearance and Equipment can only be changed while not in Group Pose.",
+  "Character_WarningGposeWorldPosFrozen": "Appearance and Equipment can only be changed while world positions are not frozen.",
 
   "Character_Action_AnimationData": "Actor Data",
   "Character_Action_AnimationStatus": "Animation Status",

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -183,13 +183,9 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 
 	private async void OnCreateActorClicked(object sender, RoutedEventArgs e)
 	{
-		SpawnOptions options = SpawnOptions.None;
-		if (PoseService.Instance.IsEnabled || PoseService.Instance.FreezeWorldPosition)
-			options |= SpawnOptions.ApplyModelPosition;
-
 		try
 		{
-			var nextActorId = await Brio.Spawn(options);
+			var nextActorId = await Brio.Spawn();
 			if (nextActorId != -1)
 			{
 				var actors = ActorService.Instance.GetAllActors(true);


### PR DESCRIPTION
**Changes:**
- Removed deprecated/obsolete Brio API code & simplified HTTP client.
  - Brio's Web API changed in version 0.2 ([Changes](https://github.com/Etheirys/Brio/commit/d226dd30fb74ce327f7ad5df66213cd6486e17a9#diff-948084f974ceba3822a45f7a64d05f64880c2ad1bd11a2d36a28a92b20048a61)). Anamnesis' interface was never updated to accommodate these changes. The changes introduced in this PR bring our API interface up-to-date.
- Added a safeguard to prevent users from updating actor appearance or equipment while world positions are frozen.
  - Without this change, redrawn actors would teleport to world origin (coordinates 0, 0, 0).
- Added a new warning message to the character appearance/equipment page for the safeguard mentioned above.