### PR TITLE
Fixed issue that prevented Anamnesis from detecting 'n_ex_top' bone

### DIFF
--- a/Anamnesis/Core/Skeleton.cs
+++ b/Anamnesis/Core/Skeleton.cs
@@ -334,7 +334,7 @@ public class Skeleton : INotifyPropertyChanged
 			int count = bestHkaPose.Transforms.Length;
 
 			// Load all bones first
-			for (int boneIndex = partialSkeletonIndex == 0 ? 0 : 1; boneIndex < count; boneIndex++)
+			for (int boneIndex = 0; boneIndex < count; boneIndex++)
 			{
 				string originalName = bestHkaPose.Skeleton.Bones[boneIndex].Name.ToString();
 				string name = ConvertBoneName(namePrefix, originalName);


### PR DESCRIPTION
This change fixes an issue where clothing that uses the "n_ex_top" bone would be partially detected by Anamnesis but result in the following error and prevent the skeleton from binding to the actor:

![image](https://github.com/user-attachments/assets/078a7ec7-d8d1-46d3-85d2-64a2ef79fafa)
