### PR TITLE
Added a prompt on application launch to install .NET 9 runtime

### DIFF
--- a/Anamnesis/Download dotNet desktop runtime.URL
+++ b/Anamnesis/Download dotNet desktop runtime.URL
@@ -1,5 +1,5 @@
 [InternetShortcut]
-URL=https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-6.0.6-windows-x64-installer
+URL=https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-9.0.1-windows-x64-installer
 IDList=
 HotKey=0
 IconFile=C:\Users\yukiw\AppData\Local\Mozilla\Firefox\Profiles\nmh78buc.default-release\shortcutCache\I5dsSbYJHpDZigeLere_Pg==.ico

--- a/Anamnesis/Install .NET Desktop Runtime.bat
+++ b/Anamnesis/Install .NET Desktop Runtime.bat
@@ -1,4 +1,4 @@
 @echo off
 title .NET Desktop Runtime Installer
-echo The Microsoft .NET Desktop Runtime will be installed. Please do not close the console until it has completed. 
-winget install Microsoft.DotNet.DesktopRuntime.6 -e -v 6.0.6 --accept-package-agreements
+echo The Microsoft .NET Desktop Runtime will be installed. Please do not close the console until it has completed.
+winget install Microsoft.DotNet.DesktopRuntime.9 -e -v 9.0.1 --accept-package-agreements

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -827,6 +827,9 @@
   "DevBuild_Title": "Development Build",
   "DevBuild_Body": "This is an experimental development build of Anamnesis and is not officially supported. These builds are likely to contain serious issues and should be avoided unless you know what you are doing.\n\nWould you like to continue using this build?\nSelecting no will offer you an update to the latest supported build.",
 
+  "DotNetPrompt_Title": "Install .NET 9",
+  "DotNetPrompt_Body": "In the upcoming version of Anamnesis, .NET 9 will be required.\nWould you like to install it now?\n\nClicking \"Yes\" will start the download process for you. Otherwise, you will be prompted again on next application launch.",
+
   "Item_Unknown": "Unknown",
   "Item_None": "None",
   "Item_NoneDesc": "Nothing",


### PR DESCRIPTION
As previously discussed, the prompt will serve as an aid to help transition users to install the .NET 9 runtime as it will become a requirement in the next version release.