### PR TITLE
Fixed issue preventing child bones from updating transforms when parenting is off

### DIFF
--- a/Anamnesis/Core/Bone.cs
+++ b/Anamnesis/Core/Bone.cs
@@ -390,11 +390,18 @@ public class Bone : ITransform
 						}
 					}
 
-					if (writeChildren && PoseService.Instance.EnableParenting)
+					if (writeChildren)
 					{
 						foreach (var child in currentBone.Children)
 						{
-							bonesToProcess.Push((child, currentWriteLinked));
+							if (PoseService.Instance.EnableParenting)
+							{
+								bonesToProcess.Push((child, currentWriteLinked));
+							}
+							else
+							{
+								child.ReadTransform(true);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This pull request resolves an issue reported on Discord.

The issue is: When updating a bone's transform with parenting off, child bones retain outdated parent-relative transforms. This causes misplacement of child bones when selected, following the initial movement.