### PR TITLE
Fixed access denied issue in auto-save service

### DIFF
--- a/Anamnesis/Files/FileService.cs
+++ b/Anamnesis/Files/FileService.cs
@@ -408,6 +408,25 @@ public class FileService : ServiceBase<FileService>
 		return await CacheRemoteFile(url, imagePath);
 	}
 
+	/// <summary>
+	/// Recursively sets the attributes of all files and sub-directories in the directory to FileAttributes.Normal.
+	/// </summary>
+	/// <param name="directory">The directory to process.</param>
+	public static void SetAttributesNormal(DirectoryInfo directory)
+	{
+		directory.Attributes = FileAttributes.Normal;
+
+		foreach (var subDirectory in directory.GetDirectories())
+		{
+			SetAttributesNormal(subDirectory);
+		}
+
+		foreach (var file in directory.GetFiles())
+		{
+			file.Attributes = FileAttributes.Normal;
+		}
+	}
+
 	private static string ToAnyFilter(params Type[] types)
 	{
 		StringBuilder builder = new StringBuilder();

--- a/Anamnesis/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Anamnesis/Properties/PublishProfiles/FolderProfile.pubxml
@@ -5,10 +5,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
+    <Platform>x64</Platform>
     <PublishDir>..\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Anamnesis/Services/AutoSaveService.cs
+++ b/Anamnesis/Services/AutoSaveService.cs
@@ -194,6 +194,10 @@ public class AutoSaveService : ServiceBase<AutoSaveService>
 				int directoriesToDelete = autoSaveDirectories.Length - SettingsService.Current.AutoSaveFileCount;
 				for (int i = 0; i < directoriesToDelete; i++)
 				{
+					// Ensure all subdirectories and files are not read-only
+					var dirInfo = new DirectoryInfo(autoSaveDirectories[i]);
+					FileService.SetAttributesNormal(dirInfo);
+
 					Directory.Delete(autoSaveDirectories[i], true);
 				}
 			}

--- a/UpdateExtractor/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/UpdateExtractor/Properties/PublishProfiles/FolderProfile.pubxml
@@ -5,13 +5,13 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
+    <Platform>x64</Platform>
     <PublishDir>..\publish\Updater\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
-    <PublishSingleFile>True</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
_Note: Marking this pull request as draft until it is confirmed that the suggested fix works._

**Changes:**
- Updated publish profiles for .NET 9.
- Added a step in the auto-save procedure to ensure that created (sub)directories and files are writable before deletion.