### PR TITLE
Mitigation of garbage collector pressure

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -6,6 +6,7 @@ namespace Anamnesis.Actor.Pages;
 using Anamnesis.Actor.Posing;
 using Anamnesis.Actor.Views;
 using Anamnesis.Core;
+using Anamnesis.Core.Extensions;
 using Anamnesis.Files;
 using Anamnesis.GUI.Dialogs;
 using Anamnesis.Memory;
@@ -496,9 +497,9 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 
 			// Positions are not frozen yet, that will happen at the appropriate moment
 			PoseService.Instance.SetEnabled(true);
-			PoseService.Instance.FreezeScale |= mode.HasFlag(PoseFile.Mode.Scale);
-			PoseService.Instance.FreezeRotation |= mode.HasFlag(PoseFile.Mode.Rotation);
-			PoseService.Instance.FreezePositions |= mode.HasFlag(PoseFile.Mode.Position);
+			PoseService.Instance.FreezeScale |= mode.HasFlagUnsafe(PoseFile.Mode.Scale);
+			PoseService.Instance.FreezeRotation |= mode.HasFlagUnsafe(PoseFile.Mode.Rotation);
+			PoseService.Instance.FreezePositions |= mode.HasFlagUnsafe(PoseFile.Mode.Position);
 
 			if (importOption == PoseImportOptions.SelectedBones)
 			{
@@ -532,7 +533,7 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 
 				// Don't import body with positions during default pose import.
 				// Otherwise, the body will be deformed if the pose file was created for another race.
-				bool doLegacyImport = importOption == PoseImportOptions.Character && mode.HasFlag(PoseFile.Mode.Position);
+				bool doLegacyImport = importOption == PoseImportOptions.Character && mode.HasFlagUnsafe(PoseFile.Mode.Position);
 				if (doLegacyImport)
 				{
 					mode &= ~PoseFile.Mode.Position;
@@ -558,7 +559,7 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 
 				// Pre-DT faces need to be imported without positions.
 				bool doLegacyImport = this.Actor.Customize!.Age == ActorCustomizeMemory.Ages.None
-									|| (poseFile.IsPreDTPoseFile() && this.Skeleton.HasPreDTFace && mode.HasFlag(PoseFile.Mode.Position));
+									|| (poseFile.IsPreDTPoseFile() && this.Skeleton.HasPreDTFace && mode.HasFlagUnsafe(PoseFile.Mode.Position));
 				if (doLegacyImport)
 				{
 					mode &= ~PoseFile.Mode.Position;

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -30,9 +30,9 @@ public partial class CustomizeEditor : UserControl
 		this.InitializeComponent();
 		this.ContentArea.DataContext = this;
 
-		this.GenderComboBox.ItemsSource = Enum.GetValues(typeof(ActorCustomizeMemory.Genders));
+		this.GenderComboBox.ItemsSource = Enum.GetValues<Genders>();
 		this.AgeComboBox.ItemsSource =
-			Enum.GetValues(typeof(ActorCustomizeMemory.Ages))
+			Enum.GetValues<Ages>()
 				.Cast<ActorCustomizeMemory.Ages>()
 				.Where(age => age != ActorCustomizeMemory.Ages.None);
 

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml
@@ -219,18 +219,7 @@
 								   Foreground="{DynamicResource MaterialDesignBody}"
 								   TextWrapping="NoWrap"
 								   TextTrimming="CharacterEllipsis"
-								   Visibility="{Binding Description, Converter={StaticResource IsEmptyToVisibilityConverter}}"
 								   VerticalAlignment="Center"/>
-
-						<TextBlock Grid.Row="0" Grid.Column="1"
-								   Text="{Binding Name}"
-								   Margin="6, 0, 0, 0"
-								   FontWeight="DemiBold"
-								   Foreground="{DynamicResource MaterialDesignBody}"
-								   TextWrapping="NoWrap"
-								   TextTrimming="CharacterEllipsis"
-								    Visibility="{Binding Description, Converter={StaticResource NotEmptyToVisibilityConverter}}"/>
-
 
 						<!--<fa:IconBlock Icon="pen" FontSize="8" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>-->
 						<Grid Grid.Row="1" Grid.Column="1">

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -3,17 +3,17 @@
 
 namespace Anamnesis.Actor.Views;
 
-using System;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
 using Anamnesis.Actor.Utilities;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using Anamnesis.GameData.Excel;
 using Anamnesis.Keyboard;
 using Anamnesis.Services;
 using Anamnesis.Styles.Drawers;
-using PropertyChanged;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
 using XivToolsWpf;
 
 public abstract class EquipmentSelectorDrawer : SelectorDrawer<IItem>
@@ -143,6 +143,8 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	public override void OnClosed()
 	{
+		base.OnClosed();
+
 		HotkeyService.ClearHotkeyHandler("AppearancePage.ClearEquipment", this);
 	}
 
@@ -251,12 +253,12 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	private bool HasClass(Classes a, Classes b)
 	{
-		foreach (Classes? job in Enum.GetValues(typeof(Classes)))
+		foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
 		{
 			if (job == null || job == Classes.None)
 				continue;
 
-			if (a.HasFlag(job) && b.HasFlag(job))
+			if (a.HasFlagUnsafe(job.Value) && b.HasFlagUnsafe(job.Value))
 			{
 				return true;
 			}
@@ -270,17 +272,17 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 		ItemCategories itemCategory = item.Category;
 
 		// Include none category
-		bool categoryFiltered = this.CategoryFilter.HasFlag(ItemCategories.Standard) && itemCategory == ItemCategories.None;
+		bool categoryFiltered = this.CategoryFilter.HasFlagUnsafe(ItemCategories.Standard) && itemCategory == ItemCategories.None;
 
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Standard) && itemCategory.HasFlag(ItemCategories.Standard);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Premium) && itemCategory.HasFlag(ItemCategories.Premium);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Limited) && itemCategory.HasFlag(ItemCategories.Limited);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Deprecated) && itemCategory.HasFlag(ItemCategories.Deprecated);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.CustomEquipment) && itemCategory.HasFlag(ItemCategories.CustomEquipment);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Performance) && itemCategory.HasFlag(ItemCategories.Performance);
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Modded) && item.Mod != null;
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Favorites) && item.IsFavorite;
-		categoryFiltered |= this.CategoryFilter.HasFlag(ItemCategories.Owned) && item.IsOwned;
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Standard) && itemCategory.HasFlagUnsafe(ItemCategories.Standard);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Premium) && itemCategory.HasFlagUnsafe(ItemCategories.Premium);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Limited) && itemCategory.HasFlagUnsafe(ItemCategories.Limited);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Deprecated) && itemCategory.HasFlagUnsafe(ItemCategories.Deprecated);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.CustomEquipment) && itemCategory.HasFlagUnsafe(ItemCategories.CustomEquipment);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Performance) && itemCategory.HasFlagUnsafe(ItemCategories.Performance);
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Modded) && item.Mod != null;
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Favorites) && item.IsFavorite;
+		categoryFiltered |= this.CategoryFilter.HasFlagUnsafe(ItemCategories.Owned) && item.IsOwned;
 		return categoryFiltered;
 	}
 

--- a/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
+++ b/Anamnesis/Actor/Views/FacialFeaturesControl.xaml.cs
@@ -3,14 +3,15 @@
 
 namespace Anamnesis.Actor.Views;
 
-using System;
-using System.Collections.Generic;
-using System.Windows.Controls;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData.Excel;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Memory;
 using Anamnesis.Services;
 using PropertyChanged;
+using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
 using XivToolsWpf.DependencyProperties;
 
 /// <summary>
@@ -80,7 +81,7 @@ public partial class FacialFeaturesControl : UserControl
 		sender.locked = true;
 		foreach (Option op in sender.features)
 		{
-			op.Selected = sender.Value.HasFlag(op.Value);
+			op.Selected = sender.Value.HasFlagUnsafe(op.Value);
 
 			if (op.Selected)
 			{
@@ -135,7 +136,7 @@ public partial class FacialFeaturesControl : UserControl
 
 		for (byte i = 0; i < 7; i++)
 		{
-			int id = (this.Head - (1 + hrothOffset)) + (8 * i);
+			int id = this.Head - (1 + hrothOffset) + (8 * i);
 
 			if (id < 0 || id >= facialFeatures.Length)
 				continue;

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -3,15 +3,8 @@
 
 namespace Anamnesis.Actor.Views;
 
-using System;
-using System.ComponentModel;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Media;
 using Anamnesis.Actor.Utilities;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using Anamnesis.GameData.Excel;
 using Anamnesis.Memory;
@@ -20,6 +13,14 @@ using Anamnesis.Styles.Drawers;
 using Anamnesis.Utils;
 using PropertyChanged;
 using Serilog;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using XivToolsWpf;
 using XivToolsWpf.DependencyProperties;
 
@@ -133,20 +134,20 @@ public partial class ItemView : UserControl
 
 			// Invalid if we're naked in some way other than Emperor's.
 			ushort[] invalidItems = { 0, 9901, 9903 };
-			if(invalidItems.Contains(this.Item.ModelBase))
+			if (invalidItems.Contains(this.Item.ModelBase))
 				return false;
 
 			// Invalid if row Id is 0, which would be the case if we have a
 			// set/subset combo which doesn't match an actual item.
-			if(this.Item.RowId == 0)
+			if (this.Item.RowId == 0)
 				return false;
 
 			// Most items will have the None category. Shop items will be premium, and old items will be deprecated.
 			// If we aren't one of these, then invalid. CustomEquipment is for things like Forum Attire.
-			bool isNormalCategory = this.Item.Category.HasFlag(ItemCategories.None) ||
-									this.Item.Category.HasFlag(ItemCategories.Standard) ||
-									this.Item.Category.HasFlag(ItemCategories.Premium) ||
-									this.Item.Category.HasFlag(ItemCategories.Limited);
+			bool isNormalCategory = this.Item.Category.HasFlagUnsafe(ItemCategories.None) ||
+									this.Item.Category.HasFlagUnsafe(ItemCategories.Standard) ||
+									this.Item.Category.HasFlagUnsafe(ItemCategories.Premium) ||
+									this.Item.Category.HasFlagUnsafe(ItemCategories.Limited);
 			if (!isNormalCategory)
 				return false;
 
@@ -161,7 +162,7 @@ public partial class ItemView : UserControl
 			if (this.Item == null)
 				return false;
 
-			if(this.Item.ModelBase == 0)
+			if (this.Item.ModelBase == 0)
 				return false;
 
 			return true;

--- a/Anamnesis/Core/Extensions/EnumExtensions.cs
+++ b/Anamnesis/Core/Extensions/EnumExtensions.cs
@@ -1,0 +1,38 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Core.Extensions;
+
+using System;
+using System.Runtime.CompilerServices;
+
+public static class EnumExtensions
+{
+	/// <summary>
+	/// Determines whether one or more bit fields are set in the current instance.
+	/// </summary>
+	/// <typeparam name="TEnum">The enumeration type of the value and flag.</typeparam>
+	/// <param name="value">An enumeration value.</param>
+	/// <param name="flag">An enumeration value to test.</param>
+	/// <returns>true if the bit field or bit fields that are set in flag are also set in the current instance; otherwise, false.</returns>
+	/// <remarks>
+	/// This method provides a performance-optimized alternative to <see cref="Enum.HasFlag(Enum)"/> by avoiding boxing and using unsafe code
+	/// to perform bitwise operations directly on the underlying values.
+	/// </remarks>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool HasFlagUnsafe<TEnum>(this TEnum value, TEnum flag)
+		where TEnum : unmanaged, Enum
+	{
+		unsafe
+		{
+			return sizeof(TEnum) switch
+			{
+				1 => (*(byte*)&value & *(byte*)&flag) == *(byte*)&flag,
+				2 => (*(ushort*)&value & *(ushort*)&flag) == *(ushort*)&flag,
+				4 => (*(uint*)&value & *(uint*)&flag) == *(uint*)&flag,
+				8 => (*(ulong*)&value & *(ulong*)&flag) == *(ulong*)&flag,
+				_ => throw new ArgumentException("Unsupported enum size"),
+			};
+		}
+	}
+}

--- a/Anamnesis/Core/Memory/Types/ActorTypes.cs
+++ b/Anamnesis/Core/Memory/Types/ActorTypes.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 namespace Anamnesis.Memory;
 
+using Anamnesis.Styles;
 using System;
 using System.Collections.Generic;
-using Anamnesis.Styles;
 
 public enum ActorTypes : byte
 {
@@ -40,11 +40,11 @@ public class ActorType
 	{
 		get
 		{
-			List<ActorType> actorTypes = new();
+			List<ActorType> actorTypes = [];
 
-			foreach (ActorTypes value in Enum.GetValues(typeof(ActorTypes)))
+			foreach (ActorTypes value in Enum.GetValues<ActorTypes>())
 			{
-				var name = Enum.GetName(typeof(ActorTypes), value);
+				var name = Enum.GetName(value);
 				actorTypes.Add(new ActorType(name!, value));
 			}
 

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -4,6 +4,7 @@
 namespace Anamnesis.Files;
 
 using Anamnesis.Actor.Utilities;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using Anamnesis.Memory;
 using Serilog;
@@ -478,7 +479,7 @@ public class CharacterFile : JsonFileBase
 
 	private bool IncludeSection(SaveModes section, SaveModes mode)
 	{
-		return this.SaveMode.HasFlag(section) && mode.HasFlag(section);
+		return this.SaveMode.HasFlagUnsafe(section) && mode.HasFlagUnsafe(section);
 	}
 
 	[Serializable]

--- a/Anamnesis/Files/FileService.cs
+++ b/Anamnesis/Files/FileService.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -79,7 +80,7 @@ public class FileService : ServiceBase<FileService>
 	/// </summary>
 	public static string ParseToFilePath(string path)
 	{
-		foreach (Environment.SpecialFolder? specialFolder in Enum.GetValues(typeof(Environment.SpecialFolder)))
+		foreach (Environment.SpecialFolder? specialFolder in Enum.GetValues<Environment.SpecialFolder>().Select(v => (Environment.SpecialFolder?)v))
 		{
 			if (specialFolder == null)
 				continue;
@@ -102,7 +103,7 @@ public class FileService : ServiceBase<FileService>
 		// Special case for "AppData" instead of "ApplicationData"
 		path = path.Replace(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), $"%AppData%");
 
-		foreach (Environment.SpecialFolder? specialFolder in Enum.GetValues(typeof(Environment.SpecialFolder)))
+		foreach (Environment.SpecialFolder? specialFolder in Enum.GetValues<Environment.SpecialFolder>().Select(v => (Environment.SpecialFolder?)v))
 		{
 			if (specialFolder == null)
 				continue;

--- a/Anamnesis/Files/PoseFile.cs
+++ b/Anamnesis/Files/PoseFile.cs
@@ -5,6 +5,7 @@ namespace Anamnesis.Files;
 
 using Anamnesis.Actor;
 using Anamnesis.Core;
+using Anamnesis.Core.Extensions;
 using Anamnesis.Memory;
 using Anamnesis.Posing;
 using Serilog;
@@ -118,10 +119,10 @@ public class PoseFile : JsonFileBase
 
 		if (bones == null)
 		{
-			if (mode.HasFlag(Mode.WorldScale) && this.Scale.HasValue)
+			if (mode.HasFlagUnsafe(Mode.WorldScale) && this.Scale.HasValue)
 				actor.ModelObject.Transform.Scale = this.Scale.Value;
 
-			if (mode.HasFlag(Mode.WorldRotation) && this.Rotation.HasValue)
+			if (mode.HasFlagUnsafe(Mode.WorldRotation) && this.Rotation.HasValue)
 				actor.ModelObject.Transform.Rotation = this.Rotation.Value;
 		}
 
@@ -191,7 +192,7 @@ public class PoseFile : JsonFileBase
 			unposedBoneTransforms.Remove(bone);
 			posedBonePos.TryAdd(bone, bone.Position);
 
-			if (savedBone.Position != null && !mode.HasFlag(Mode.Position))
+			if (savedBone.Position != null && !mode.HasFlagUnsafe(Mode.Position))
 			{
 				bonePosRestore.Add(bone);
 			}
@@ -249,17 +250,17 @@ public class PoseFile : JsonFileBase
 
 				foreach (TransformMemory transformMemory in bone.TransformMemories)
 				{
-					if (savedBone.Position != null && mode.HasFlag(Mode.Position) && bone.CanTranslate)
+					if (savedBone.Position != null && mode.HasFlagUnsafe(Mode.Position) && bone.CanTranslate)
 					{
 						transformMemory.Position = (Vector3)savedBone.Position;
 					}
 
-					if (savedBone.Rotation != null && mode.HasFlag(Mode.Rotation) && bone.CanRotate)
+					if (savedBone.Rotation != null && mode.HasFlagUnsafe(Mode.Rotation) && bone.CanRotate)
 					{
 						transformMemory.Rotation = (Quaternion)savedBone.Rotation;
 					}
 
-					if (savedBone.Scale != null && mode.HasFlag(Mode.Scale) && bone.CanScale)
+					if (savedBone.Scale != null && mode.HasFlagUnsafe(Mode.Scale) && bone.CanScale)
 					{
 						transformMemory.Scale = (Vector3)savedBone.Scale;
 					}
@@ -278,7 +279,7 @@ public class PoseFile : JsonFileBase
 		}
 
 		// If we are not loading the position of bones, restore the positions of all bones that were not explicitly written to.
-		if (!mode.HasFlag(Mode.Position))
+		if (!mode.HasFlagUnsafe(Mode.Position))
 		{
 			var sortedBones = Core.Bone.SortBonesByHierarchy(posedBonePos.Keys);
 

--- a/Anamnesis/Files/SceneFile.cs
+++ b/Anamnesis/Files/SceneFile.cs
@@ -4,6 +4,7 @@
 namespace Anamnesis.Files;
 
 using Anamnesis.Core;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GUI.Dialogs;
 using Anamnesis.Memory;
 using System;
@@ -89,17 +90,17 @@ public class SceneFile : JsonFileBase
 
 		TargetService.SetPlayerTarget(targetActor);
 
-		if (mode.HasFlag(Mode.Weather))
+		if (mode.HasFlagUnsafe(Mode.Weather))
 			TerritoryService.Instance.CurrentWeatherId = this.Weather;
 
-		if (mode.HasFlag(Mode.Time))
+		if (mode.HasFlagUnsafe(Mode.Time))
 		{
 			TimeService.Instance.Freeze = true;
 			TimeService.Instance.DayOfMonth = this.DayOfMonth;
 			TimeService.Instance.TimeOfDay = this.TimeOfDay;
 		}
 
-		if (mode.HasFlag(Mode.WorldPosition))
+		if (mode.HasFlagUnsafe(Mode.WorldPosition))
 		{
 			if (TerritoryService.Instance.CurrentTerritoryId != this.Territory)
 				throw new Exception("Could not restore world positions as you are not in the correct territory");
@@ -118,7 +119,7 @@ public class SceneFile : JsonFileBase
 		Vector3 rootCurrentWaist = rootSkeleton.GetBone("n_hara")?.Position ?? Vector3.Zero;
 		Vector3 rootAdjustedWaist = Vector3.Transform(rootCurrentWaist - rootOriginalWaist, rootRotation);
 
-		if (mode.HasFlag(Mode.WorldPosition))
+		if (mode.HasFlagUnsafe(Mode.WorldPosition))
 		{
 			rootActor!.ModelObject!.Transform!.Position -= rootAdjustedWaist;
 		}
@@ -131,7 +132,7 @@ public class SceneFile : JsonFileBase
 			var skeleton = new Skeleton(actor);
 			ActorEntry entry = this.ActorEntries[name];
 
-			if (actor != rootActor && mode.HasFlag(Mode.RelativePosition))
+			if (actor != rootActor && mode.HasFlagUnsafe(Mode.RelativePosition))
 			{
 				Quaternion rotatedRotation = rootRotation * entry.Rotation;
 
@@ -143,20 +144,20 @@ public class SceneFile : JsonFileBase
 				actor.ModelObject!.Transform!.Position = rootPosition + rotatedRelativePosition - adjustedWaist;
 				actor.ModelObject!.Transform!.Rotation = rotatedRotation;
 
-				if (!mode.HasFlag(Mode.WorldPosition))
+				if (!mode.HasFlagUnsafe(Mode.WorldPosition))
 				{
 					actor.ModelObject!.Transform!.Position += rootAdjustedWaist;
 				}
 			}
 
-			if (mode.HasFlag(Mode.Pose))
+			if (mode.HasFlagUnsafe(Mode.Pose))
 			{
 				// TODO: This should follow the same approach as the pose page imports
 				entry.Pose!.Apply(actor, skeleton, null, PoseFile.Mode.Rotation, true);
 			}
 		}
 
-		if (mode.HasFlag(Mode.Camera))
+		if (mode.HasFlagUnsafe(Mode.Camera))
 		{
 			this.CameraShot!.Apply(CameraService.Instance, targetActor);
 		}

--- a/Anamnesis/GameData/Classes.cs
+++ b/Anamnesis/GameData/Classes.cs
@@ -3,10 +3,12 @@
 
 namespace Anamnesis.GameData;
 
+using Anamnesis.Core.Extensions;
+using Anamnesis.GameData.Sheets;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
-using Anamnesis.GameData.Sheets;
 
 #pragma warning disable SA1649
 
@@ -246,7 +248,7 @@ public static class ClassesExtensions
 			if (onlyJobs && !job.IsJob())
 				continue;
 
-			if (!self.HasFlag(job))
+			if (!self.HasFlagUnsafe(job))
 			{
 				return false;
 			}
@@ -289,8 +291,8 @@ public static class ClassesExtensions
 		if (self == Classes.None)
 			return "None";
 
-		List<Classes> selected = new List<Classes>();
-		foreach (Classes? job in Enum.GetValues(typeof(Classes)))
+		List<Classes> selected = new();
+		foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
 		{
 			if (job == null)
 				continue;
@@ -303,7 +305,7 @@ public static class ClassesExtensions
 			if (onlyJobs && !cls.IsJob())
 				continue;
 
-			if (self.HasFlag(cls))
+			if (self.HasFlagUnsafe(cls))
 			{
 				selected.Add(cls);
 			}
@@ -324,8 +326,8 @@ public static class ClassesExtensions
 		}
 
 		// Get all the roles that are entirely included
-		HashSet<Roles> entireRoles = new HashSet<Roles>();
-		foreach (Roles? role in Enum.GetValues(typeof(Roles)))
+		HashSet<Roles> entireRoles = new();
+		foreach (Roles? role in Enum.GetValues<Roles>().Select(v => (Roles?)v))
 		{
 			if (role == null)
 				continue;
@@ -337,7 +339,7 @@ public static class ClassesExtensions
 		}
 
 		// check if there are any extra classes that werent part of the enire role
-		foreach (Roles? role in Enum.GetValues(typeof(Roles)))
+		foreach (Roles? role in Enum.GetValues<Roles>().Select(v => (Roles?)v))
 		{
 			if (role == null)
 				continue;
@@ -350,7 +352,7 @@ public static class ClassesExtensions
 				if (onlyJobs && !job.IsJob())
 					continue;
 
-				if (self.HasFlag(job))
+				if (self.HasFlagUnsafe(job))
 				{
 					return "Mixed";
 				}

--- a/Anamnesis/GameData/Excel/ClassJobCategory.cs
+++ b/Anamnesis/GameData/Excel/ClassJobCategory.cs
@@ -3,12 +3,12 @@
 
 namespace Anamnesis.GameData.Excel;
 
-using System;
-using System.Collections.Generic;
 using Anamnesis.GameData.Sheets;
 using Lumina.Data;
 using Lumina.Excel;
-
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using ExcelRow = Anamnesis.GameData.Sheets.ExcelRow;
 
 [Sheet("ClassJobCategory", 0x65bbdb12)]
@@ -71,8 +71,8 @@ public class ClassJobCategory : ExcelRow
 
 	public bool Contains(Classes classJob)
 	{
-		if (this.ClassJobs.ContainsKey(classJob))
-			return this.ClassJobs[classJob];
+		if (this.ClassJobs.TryGetValue(classJob, out bool value))
+			return value;
 
 		return false;
 	}
@@ -81,7 +81,7 @@ public class ClassJobCategory : ExcelRow
 	{
 		Classes classes = Classes.None;
 
-		foreach (Classes? job in Enum.GetValues(typeof(Classes)))
+		foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
 		{
 			if (job == null || job == Classes.None || job == Classes.All)
 				continue;

--- a/Anamnesis/GameData/Excel/Item.cs
+++ b/Anamnesis/GameData/Excel/Item.cs
@@ -3,7 +3,7 @@
 
 namespace Anamnesis.GameData.Excel;
 
-using System;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Services;
 using Anamnesis.TexTools;
@@ -12,7 +12,8 @@ using Lumina.Data;
 using Lumina.Excel;
 using Lumina.Excel.GeneratedSheets;
 using Lumina.Text;
-
+using System;
+using System.Linq;
 using ExcelRow = Anamnesis.GameData.Sheets.ExcelRow;
 
 [Sheet("Item", 0xe9a33c9d)]
@@ -43,7 +44,7 @@ public class Item : ExcelRow, IItem
 		set => FavoritesService.SetFavorite<IItem>(this, nameof(FavoritesService.Favorites.Items), value);
 	}
 
-	public bool CanOwn => this.Category.HasFlag(ItemCategories.Premium) || this.Category.HasFlag(ItemCategories.Limited);
+	public bool CanOwn => this.Category.HasFlagUnsafe(ItemCategories.Premium) || this.Category.HasFlagUnsafe(ItemCategories.Limited);
 	public bool IsOwned
 	{
 		get => FavoritesService.IsOwned(this);
@@ -103,7 +104,7 @@ public class Item : ExcelRow, IItem
 	{
 		Classes classes = Classes.None;
 
-		foreach (Classes? job in Enum.GetValues(typeof(Classes)))
+		foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
 		{
 			if (job == null || job == Classes.None || job == Classes.All)
 				continue;

--- a/Anamnesis/GameData/ItemCategory.cs
+++ b/Anamnesis/GameData/ItemCategory.cs
@@ -26,15 +26,5 @@ public enum ItemCategories
 #pragma warning disable SA1649
 public static class ItemCategoriesExtensions
 {
-	public static ItemCategories SetFlag(this ItemCategories a, ItemCategories b, bool enabled)
-	{
-		if (enabled)
-		{
-			return a | b;
-		}
-		else
-		{
-			return a & ~b;
-		}
-	}
+	public static ItemCategories SetFlag(this ItemCategories a, ItemCategories b, bool enabled) => enabled ? a | b : a & ~b;
 }

--- a/Anamnesis/GameData/Roles.cs
+++ b/Anamnesis/GameData/Roles.cs
@@ -5,6 +5,7 @@ namespace Anamnesis.GameData;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 #pragma warning disable SA1649
 
@@ -25,9 +26,9 @@ public static class RolesExtensions
 	{
 		if (classLookup == null)
 		{
-			classLookup = new Dictionary<Roles, List<Classes>>();
+			classLookup = [];
 
-			foreach (Classes? job in Enum.GetValues(typeof(Classes)))
+			foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
 			{
 				if (job == null || job == Classes.None)
 					continue;

--- a/Anamnesis/GameData/Sheets/Equipment.cs
+++ b/Anamnesis/GameData/Sheets/Equipment.cs
@@ -3,11 +3,12 @@
 
 namespace Anamnesis.GameData;
 
-using System.Text.Json.Serialization;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Serialization.Converters;
 using Anamnesis.Services;
 using Anamnesis.TexTools;
+using System.Text.Json.Serialization;
 
 public class Equipment : IItem
 {
@@ -66,13 +67,13 @@ public class Equipment : IItem
 	{
 		return slot switch
 		{
-			ItemSlots.MainHand => this.Slot.HasFlag(FitsSlots.MainHand),
-			ItemSlots.Head => this.Slot.HasFlag(FitsSlots.Head),
-			ItemSlots.Body => this.Slot.HasFlag(FitsSlots.Body),
-			ItemSlots.Hands => this.Slot.HasFlag(FitsSlots.Hands),
-			ItemSlots.Legs => this.Slot.HasFlag(FitsSlots.Legs),
-			ItemSlots.Feet => this.Slot.HasFlag(FitsSlots.Feet),
-			ItemSlots.OffHand => this.Slot.HasFlag(FitsSlots.OffHand),
+			ItemSlots.MainHand => this.Slot.HasFlagUnsafe(FitsSlots.MainHand),
+			ItemSlots.Head => this.Slot.HasFlagUnsafe(FitsSlots.Head),
+			ItemSlots.Body => this.Slot.HasFlagUnsafe(FitsSlots.Body),
+			ItemSlots.Hands => this.Slot.HasFlagUnsafe(FitsSlots.Hands),
+			ItemSlots.Legs => this.Slot.HasFlagUnsafe(FitsSlots.Legs),
+			ItemSlots.Feet => this.Slot.HasFlagUnsafe(FitsSlots.Feet),
+			ItemSlots.OffHand => this.Slot.HasFlagUnsafe(FitsSlots.OffHand),
 
 			_ => false,
 		};

--- a/Anamnesis/MainWindow.xaml.cs
+++ b/Anamnesis/MainWindow.xaml.cs
@@ -213,10 +213,10 @@ public partial class MainWindow : ChromedWindow
 			// If this is a drawer view, bind to its events.
 			if (view is IDrawer drawer)
 			{
-				drawer.OnClosing += () => this.DrawerHost.IsLeftDrawerOpen = false;
-				drawer.OnClosing += () => this.DrawerHost.IsTopDrawerOpen = false;
-				drawer.OnClosing += () => this.DrawerHost.IsRightDrawerOpen = false;
-				drawer.OnClosing += () => this.DrawerHost.IsBottomDrawerOpen = false;
+				drawer.OnClosing += this.OnLeftDrawerClosing;
+				drawer.OnClosing += this.OnTopDrawerClosing;
+				drawer.OnClosing += this.OnRightDrawerClosing;
+				drawer.OnClosing += this.OnBottomDrawerClosing;
 			}
 
 			this.IsDrawerOpen = true;
@@ -263,6 +263,11 @@ public partial class MainWindow : ChromedWindow
 
 			if (view is IDrawer drawer2)
 			{
+				drawer2.OnClosing -= this.OnLeftDrawerClosing;
+				drawer2.OnClosing -= this.OnTopDrawerClosing;
+				drawer2.OnClosing -= this.OnRightDrawerClosing;
+				drawer2.OnClosing -= this.OnBottomDrawerClosing;
+
 				drawer2.OnClosed();
 			}
 
@@ -427,5 +432,25 @@ public partial class MainWindow : ChromedWindow
 			return;
 
 		this.DragMove();
+	}
+
+	private void OnLeftDrawerClosing()
+	{
+		this.DrawerHost.IsLeftDrawerOpen = false;
+	}
+
+	private void OnTopDrawerClosing()
+	{
+		this.DrawerHost.IsTopDrawerOpen = false;
+	}
+
+	private void OnRightDrawerClosing()
+	{
+		this.DrawerHost.IsRightDrawerOpen = false;
+	}
+
+	private void OnBottomDrawerClosing()
+	{
+		this.DrawerHost.IsBottomDrawerOpen = false;
 	}
 }

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -4,6 +4,7 @@
 namespace Anamnesis.Memory;
 
 using Anamnesis.Actor;
+using Anamnesis.Core.Extensions;
 using Anamnesis.Services;
 using Anamnesis.Utils;
 using PropertyChanged;
@@ -124,7 +125,7 @@ public class ActorMemory : ActorBasicMemory
 	[DependsOn(nameof(CharacterFlags))]
 	public bool VisorToggled
 	{
-		get => this.CharacterFlags.HasFlag(CharacterFlagDefs.VisorToggled);
+		get => this.CharacterFlags.HasFlagUnsafe(CharacterFlagDefs.VisorToggled);
 		set
 		{
 			if (value)
@@ -146,7 +147,7 @@ public class ActorMemory : ActorBasicMemory
 	}
 
 	[DependsOn(nameof(ObjectIndex), nameof(CharacterMode))]
-	public bool CanAnimate => (this.CharacterMode == CharacterModes.Normal || this.CharacterMode == CharacterModes.AnimLock) || !ActorService.IsLocalOverworldPlayer(this.ObjectIndex);
+	public bool CanAnimate => this.CharacterMode == CharacterModes.Normal || this.CharacterMode == CharacterModes.AnimLock || !ActorService.IsLocalOverworldPlayer(this.ObjectIndex);
 
 	[DependsOn(nameof(CharacterMode))]
 	public bool IsAnimationOverridden => this.CharacterMode == CharacterModes.AnimLock;
@@ -235,7 +236,7 @@ public class ActorMemory : ActorBasicMemory
 			return;
 
 		// Only record changes that originate from the user
-		if (!change.OriginBind.Flags.HasFlag(BindFlags.DontRecordHistory) && !HistoryService.Instance.IsRestoring)
+		if (!change.OriginBind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && !HistoryService.Instance.IsRestoring)
 		{
 			if (change.Origin == PropertyChange.Origins.User)
 			{
@@ -255,13 +256,13 @@ public class ActorMemory : ActorBasicMemory
 		this.backupQueue.Invoke();
 
 		// Refresh the actor
-		if (this.AutomaticRefreshEnabled && change.OriginBind.Flags.HasFlag(BindFlags.ActorRefresh))
+		if (this.AutomaticRefreshEnabled && change.OriginBind.Flags.HasFlagUnsafe(BindFlags.ActorRefresh))
 		{
 			// Don't refresh because of a refresh
 			if (this.IsRefreshing && (change.OriginBind.Name == nameof(this.ObjectKind) || change.OriginBind.Name == nameof(this.RenderMode)))
 				return;
 
-			if (change.OriginBind.Flags.HasFlag(BindFlags.WeaponRefresh))
+			if (change.OriginBind.Flags.HasFlagUnsafe(BindFlags.WeaponRefresh))
 				this.IsWeaponDirty = true;
 
 			// Restart the debounce timer if it's already running, otherwise start it

--- a/Anamnesis/Memory/Binds/PropertyBindInfo.cs
+++ b/Anamnesis/Memory/Binds/PropertyBindInfo.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.Memory;
 
+using Anamnesis.Core.Extensions;
 using System;
 using System.Diagnostics;
 using System.Reflection;
@@ -46,7 +47,7 @@ public class PropertyBindInfo : BindInfo
 		if (this.cachedOffsets == null || this.cachedOffsets.Length == 0)
 			throw new NullReferenceException("Cached offsets are not initialized.");
 
-		if (this.cachedOffsets.Length > 1 && !this.flags.HasFlag(BindFlags.Pointer))
+		if (this.cachedOffsets.Length > 1 && !this.flags.HasFlagUnsafe(BindFlags.Pointer))
 			throw new InvalidOperationException("Bind address has multiple offsets but is not a pointer. This is not supported.");
 	}
 
@@ -77,7 +78,7 @@ public class PropertyBindInfo : BindInfo
 	{
 		IntPtr bindAddress = this.Memory.Address + this.cachedOffsets[0];
 
-		if (this.flags.HasFlag(BindFlags.Pointer))
+		if (this.flags.HasFlagUnsafe(BindFlags.Pointer))
 		{
 			bindAddress = MemoryService.Read<IntPtr>(bindAddress);
 

--- a/Anamnesis/Memory/PropertyChange.cs
+++ b/Anamnesis/Memory/PropertyChange.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.Memory;
 
+using Anamnesis.Core.Extensions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -105,7 +106,7 @@ public struct PropertyChange
 
 		foreach (BindInfo bind in this.BindPath)
 		{
-			if (bind.Flags.HasFlag(BindFlags.DontRecordHistory))
+			if (bind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory))
 				return false;
 		}
 

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -4,6 +4,7 @@
 namespace Anamnesis.Memory;
 
 using Anamnesis.Actor.Utilities;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using PropertyChanged;
 using System;
@@ -29,7 +30,7 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 	[DependsOn(nameof(WeaponFlags), nameof(IsSheathed))]
 	public bool WeaponHidden
 	{
-		get => (this.IsSheathed && this.WeaponFlags.HasFlag(WeaponFlagDefs.WeaponHidden)) || (!this.IsSheathed && this.Model?.Transform?.Scale == Vector3.Zero);
+		get => (this.IsSheathed && this.WeaponFlags.HasFlagUnsafe(WeaponFlagDefs.WeaponHidden)) || (!this.IsSheathed && this.Model?.Transform?.Scale == Vector3.Zero);
 		set
 		{
 			if (value)
@@ -70,8 +71,8 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 				IItem? mainHandItem = ItemUtility.GetItem(ItemSlots.MainHand, actor.MainHand.Set, actor.MainHand.Base, actor.MainHand.Variant, actor.IsChocobo);
 
 				if (mainHandItem != null &&
-					(mainHandItem.EquipableClasses.HasFlag(Classes.Pugilist) ||
-					mainHandItem.EquipableClasses.HasFlag(Classes.Monk)))
+					(mainHandItem.EquipableClasses.HasFlagUnsafe(Classes.Pugilist) ||
+					mainHandItem.EquipableClasses.HasFlagUnsafe(Classes.Monk)))
 				{
 					useEmperorsFists = true;
 				}

--- a/Anamnesis/Styles/Controls/ClassFilterItem.xaml.cs
+++ b/Anamnesis/Styles/Controls/ClassFilterItem.xaml.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 namespace Anamnesis.Styles.Controls;
-using System.ComponentModel;
-using System.Windows.Controls;
+
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using Anamnesis.GameData.Sheets;
 using PropertyChanged;
+using System.ComponentModel;
+using System.Windows.Controls;
 using XivToolsWpf.DependencyProperties;
 
 /// <summary>
@@ -50,7 +52,7 @@ public partial class ClassFilterItem : UserControl, INotifyPropertyChanged
 	{
 		get
 		{
-			return this.Value.HasFlag(this.Class);
+			return this.Value.HasFlagUnsafe(this.Class);
 		}
 
 		set

--- a/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml.cs
+++ b/Anamnesis/Styles/Controls/ItemCategoryFilterItem.xaml.cs
@@ -3,10 +3,11 @@
 
 namespace Anamnesis.Styles.Controls;
 
-using System.ComponentModel;
-using System.Windows.Controls;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using PropertyChanged;
+using System.ComponentModel;
+using System.Windows.Controls;
 using XivToolsWpf.DependencyProperties;
 
 /// <summary>
@@ -43,7 +44,7 @@ public partial class ItemCategoryFilterItem : UserControl, INotifyPropertyChange
 
 	public bool IsSelected
 	{
-		get => this.Value.HasFlag(this.Category);
+		get => this.Value.HasFlagUnsafe(this.Category);
 		set => this.Value = this.Value.SetFlag(this.Category, value);
 	}
 

--- a/Anamnesis/Styles/Controls/RoleFilterItem.xaml.cs
+++ b/Anamnesis/Styles/Controls/RoleFilterItem.xaml.cs
@@ -3,11 +3,12 @@
 
 namespace Anamnesis.Styles.Controls;
 
+using Anamnesis.Core.Extensions;
+using Anamnesis.GameData;
+using PropertyChanged;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-using Anamnesis.GameData;
-using PropertyChanged;
 using XivToolsWpf.DependencyProperties;
 
 /// <summary>
@@ -54,7 +55,7 @@ public partial class RoleFilterItem : UserControl, INotifyPropertyChanged
 		{
 			foreach (Classes job in this.Role.GetClasses())
 			{
-				if (!this.Value.HasFlag(job))
+				if (!this.Value.HasFlagUnsafe(job))
 				{
 					return false;
 				}

--- a/Anamnesis/Styles/Controls/SliderInputBox.xaml.cs
+++ b/Anamnesis/Styles/Controls/SliderInputBox.xaml.cs
@@ -94,7 +94,7 @@ public partial class SliderInputBox : UserControl
 	/// </summary>
 	public SliderInputBox()
 	{
-		InitializeComponent();
+		this.InitializeComponent();
 		this.ContentArea.DataContext = this;
 
 		// Default property configuration
@@ -106,7 +106,7 @@ public partial class SliderInputBox : UserControl
 		this.InputField.IsReadOnly = true;
 		this.InputField.IsReadOnlyCaretVisible = false;
 
-		this.OnPropertyChanged(nameof(Label));
+		this.OnPropertyChanged(nameof(this.Label));
 	}
 
 	/// <summary>Defines the overflow behavior modes.</summary>
@@ -153,7 +153,7 @@ public partial class SliderInputBox : UserControl
 	/// <summary>Gets the label text combining the value and suffix.</summary>
 
 	[DependsOn(nameof(Value), nameof(Suffix))]
-	public string Label => $"{FormatValue(Value)} {Suffix}";
+	public string Label => $"{this.FormatValue(this.Value)} {this.Suffix}";
 
 
 	/// <summary>Gets or sets the suffix text.</summary>
@@ -176,7 +176,7 @@ public partial class SliderInputBox : UserControl
 		set
 		{
 			this.InputField.IsReadOnly = !value;
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(value || !this.IsMouseHovered ? NORMAL_BG_KEY : HOVER_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(value || !this.IsMouseHovered ? NORMAL_BG_KEY : HOVER_BG_KEY));
 		}
 	}
 
@@ -382,20 +382,21 @@ public partial class SliderInputBox : UserControl
 			{
 				// Set the cursor clipping
 				this.SetCursorClip(true);
-			}
 
-			e.Handled = true;
-			return;
+				e.Handled = true;
+				return;
+			}
 		}
 		else if (e.MiddleButton == MouseButtonState.Pressed && this.DefaultValue != null)
 		{
-			this.Value = (decimal)this.DefaultValue;
+			if (!this.IsInputFieldActive)
+			{
+				this.Value = (decimal)this.DefaultValue;
 
-			e.Handled = true;
-			return;
+				e.Handled = true;
+				return;
+			}
 		}
-
-		base.OnPreviewMouseDown(e);
 	}
 
 	/// <summary>Handles the preview mouse move event.</summary>
@@ -413,7 +414,7 @@ public partial class SliderInputBox : UserControl
 				if (!this.isDragging)
 				{
 					Mouse.OverrideCursor = Cursors.None;
-					this.ContentArea.Background = new SolidColorBrush((Color)FindResource(DRAG_BG_KEY));
+					this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(DRAG_BG_KEY));
 				}
 
 
@@ -455,7 +456,7 @@ public partial class SliderInputBox : UserControl
 		else
 		{
 			Mouse.OverrideCursor = this.IsMouseHovered ? Cursors.SizeWE : null;
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(this.IsMouseHovered ? HOVER_BG_KEY : NORMAL_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(this.IsMouseHovered ? HOVER_BG_KEY : NORMAL_BG_KEY));
 		}
 
 		this.isDragging = false;
@@ -473,7 +474,7 @@ public partial class SliderInputBox : UserControl
 		this.IsMouseHovered = true;
 		if (this.IsMouseHovered && !this.IsInputFieldActive)
 		{
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(HOVER_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(HOVER_BG_KEY));
 		}
 	}
 
@@ -486,7 +487,7 @@ public partial class SliderInputBox : UserControl
 		this.IsMouseHovered = false;
 		if (!this.IsInputFieldActive)
 		{
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(NORMAL_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(NORMAL_BG_KEY));
 		}
 	}
 
@@ -653,9 +654,9 @@ public partial class SliderInputBox : UserControl
 	private void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
 	{
 		if ((bool)e.NewValue)
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(this.IsMouseHovered ? HOVER_BG_KEY : NORMAL_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(this.IsMouseHovered ? HOVER_BG_KEY : NORMAL_BG_KEY));
 		else
-			this.ContentArea.Background = new SolidColorBrush((Color)FindResource(DISABLED_BG_KEY));
+			this.ContentArea.Background = new SolidColorBrush((Color)this.FindResource(DISABLED_BG_KEY));
 	}
 
 	/// <summary>

--- a/Anamnesis/Styles/Controls/VectorEditorNew.xaml.cs
+++ b/Anamnesis/Styles/Controls/VectorEditorNew.xaml.cs
@@ -189,9 +189,9 @@ public partial class VectorEditorNew : UserControl, INotifyPropertyChanged
 		{
 			ColorModeDp.Set(this, value);
 
-			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(XColor)));
-			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(YColor)));
-			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ZColor)));
+			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.XColor)));
+			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.YColor)));
+			this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.ZColor)));
 		}
 	}
 

--- a/Anamnesis/Styles/Drawers/SelectorDrawer.cs
+++ b/Anamnesis/Styles/Drawers/SelectorDrawer.cs
@@ -3,13 +3,13 @@
 
 namespace Anamnesis.Styles.Drawers;
 
+using Anamnesis.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using Anamnesis.Services;
 using XivToolsWpf.Selectors;
 
 public abstract class SelectorDrawer : UserControl, IDrawer, INotifyPropertyChanged
@@ -114,6 +114,15 @@ public abstract class SelectorDrawer : UserControl, IDrawer, INotifyPropertyChan
 
 	public virtual void OnClosed()
 	{
+		if (this.SelectorLoaded)
+		{
+			this.Selector.Filter -= this.Filter;
+			this.Selector.SelectionChanged -= this.OnSelectionChanged;
+			this.Selector.LoadItems -= this.LoadItems;
+			this.Selector.Sort -= this.Compare;
+		}
+
+		this.Selector.ClearItems();
 	}
 
 	// forward selector APIs
@@ -176,7 +185,7 @@ public abstract class SelectorDrawer<T> : SelectorDrawer
 		return 0;
 	}
 
-	protected override sealed bool Filter(object item, string[]? search)
+	protected sealed override bool Filter(object item, string[]? search)
 	{
 		if (item is T tItem)
 			return this.Filter(tItem, search);
@@ -184,7 +193,7 @@ public abstract class SelectorDrawer<T> : SelectorDrawer
 		return false;
 	}
 
-	protected override sealed int Compare(object itemA, object itemB)
+	protected sealed override int Compare(object itemA, object itemB)
 	{
 		if (itemA == itemB)
 			return 0;

--- a/Anamnesis/Tabs/Settings/InputSettingsPage.xaml.cs
+++ b/Anamnesis/Tabs/Settings/InputSettingsPage.xaml.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.Tabs.Settings;
 
+using Anamnesis.Core.Extensions;
 using Anamnesis.Keyboard;
 using Anamnesis.Services;
 using PropertyChanged;
@@ -120,16 +121,16 @@ public partial class InputSettingsPage : UserControl, ISettingSection
 		{
 			var builder = new StringBuilder();
 
-			if (this.keys.Modifiers.HasFlag(ModifierKeys.Control))
+			if (this.keys.Modifiers.HasFlagUnsafe(ModifierKeys.Control))
 				builder.Append("Ctrl + ");
 
-			if (this.keys.Modifiers.HasFlag(ModifierKeys.Shift))
+			if (this.keys.Modifiers.HasFlagUnsafe(ModifierKeys.Shift))
 				builder.Append("Shift + ");
 
-			if (this.keys.Modifiers.HasFlag(ModifierKeys.Alt))
+			if (this.keys.Modifiers.HasFlagUnsafe(ModifierKeys.Alt))
 				builder.Append("Alt + ");
 
-			if (this.keys.Modifiers.HasFlag(ModifierKeys.Windows))
+			if (this.keys.Modifiers.HasFlagUnsafe(ModifierKeys.Windows))
 				builder.Append("Win + ");
 
 			return builder.ToString().TrimEnd('+', ' ');

--- a/Anamnesis/Views/HotkeyPrompt.xaml.cs
+++ b/Anamnesis/Views/HotkeyPrompt.xaml.cs
@@ -3,9 +3,10 @@
 
 namespace Anamnesis.Views;
 
+using Anamnesis.Core.Extensions;
+using Anamnesis.Keyboard;
 using System.Text;
 using System.Windows.Input;
-using Anamnesis.Keyboard;
 using XivToolsWpf.DependencyProperties;
 
 /// <summary>
@@ -45,17 +46,17 @@ public partial class HotkeyPrompt : System.Windows.Controls.TextBlock
 
 		StringBuilder str = new StringBuilder();
 
-		if (keys.Modifiers.HasFlag(ModifierKeys.Control))
+		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Control))
 		{
 			str.Append("[CTRL] +");
 		}
 
-		if (keys.Modifiers.HasFlag(ModifierKeys.Alt))
+		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Alt))
 		{
 			str.Append("[ALT] +");
 		}
 
-		if (keys.Modifiers.HasFlag(ModifierKeys.Shift))
+		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Shift))
 		{
 			str.Append("[SHIFT] +");
 		}

--- a/Anamnesis/XamlBehaviours/Behaviours.cs
+++ b/Anamnesis/XamlBehaviours/Behaviours.cs
@@ -18,6 +18,6 @@ public static class Behaviours
 
 	public static void SetTooltip(DependencyObject host, string key)
 	{
-		host.AttachHandler<LocalizedTooltipBehaiour>(true, key);
+		host.AttachHandler<LocalizedTooltipBehaviour>(true, key);
 	}
 }

--- a/Anamnesis/XamlBehaviours/LocalizedTooltipBehaviour.cs
+++ b/Anamnesis/XamlBehaviours/LocalizedTooltipBehaviour.cs
@@ -10,11 +10,11 @@ using System.Windows.Media;
 using System.Windows.Shapes;
 using XivToolsWpf.Behaviours;
 
-public class LocalizedTooltipBehaiour : Behaviour
+public class LocalizedTooltipBehaviour : Behaviour
 {
 	public readonly string Key;
 
-	public LocalizedTooltipBehaiour(DependencyObject host, string key)
+	public LocalizedTooltipBehaviour(DependencyObject host, string key)
 		: base(host, key)
 	{
 		this.Key = key;


### PR DESCRIPTION
_Note: Marked pull request as draft until https://github.com/Aether-Tools/AetherToolsWpf/pull/11 is merged._

**Changes:**
- Optimized to avoid boxing of enums and frequent memory allocations in `MemoryBase` synchronization.
- Fixed `SliderInputBox` not capturing mouse events properly when the input field is active.
- Misc. changes: Fixing typos and adding missing event unsubcriptions.
- Included selector virtualization fix from XiVToolsWpf library.

---

It is difficult to generate a report under the same circumstances due to the background actor synchronization that happens. Nonetheless, an example of the optimizations.

**Before:**
![image](https://github.com/user-attachments/assets/4002ff23-4856-401e-8eb3-c3a61e69850e)

**After:**
![image](https://github.com/user-attachments/assets/1f81e3c6-7a46-4afa-9390-4a4a987d2ded)
