### PR TITLE
Fixed auto-save causing fatal crash due to actors with missing model object

### DIFF
--- a/Anamnesis/Services/AutoSaveService.cs
+++ b/Anamnesis/Services/AutoSaveService.cs
@@ -168,7 +168,7 @@ public class AutoSaveService : ServiceBase<AutoSaveService>
 				foreach (var pinnedActor in TargetService.Instance.PinnedActors.ToList())
 				{
 					var actor = pinnedActor.Memory;
-					if (actor == null)
+					if (actor == null || actor.ModelObject == null || actor.ModelObject.Skeleton == null)
 						continue;
 
 					var skeleton = new Skeleton(actor);


### PR DESCRIPTION
Fix for the issue reported on Discord. In the original issue report, the auto-save service was causing fatal application crashes when trying to save actors, namely the non-minion variant of campfire, with no valid model object.