### PR TITLE
Fix: synchronize eye colors when link eye color is toggled on

### DIFF
--- a/Anamnesis/Memory/ActorCustomizeMemory.cs
+++ b/Anamnesis/Memory/ActorCustomizeMemory.cs
@@ -8,6 +8,8 @@ using System;
 
 public class ActorCustomizeMemory : MemoryBase
 {
+	private bool linkEyeColors;
+
 	public enum Genders : byte
 	{
 		Masculine = 0,
@@ -127,7 +129,18 @@ public class ActorCustomizeMemory : MemoryBase
 	}
 
 	[AlsoNotifyFor(nameof(LEyeColor), nameof(REyeColor))]
-	public bool LinkEyeColors { get; set; }
+	public bool LinkEyeColors
+	{
+		get => this.linkEyeColors;
+		set
+		{
+			this.linkEyeColors = value;
+
+			// Synchronize the eye colors
+			if (value)
+				this.REyeColor = this.LEyeColor;
+		}
+	}
 
 	[AlsoNotifyFor(nameof(LEyeColor))]
 	public byte MainEyeColor


### PR DESCRIPTION
Now the right eye color syncs to the left eye color when the link is toggled on via the UI.