### PR TITLE
Fixed flip functionality for actor models with no waist/spine bone.

### DIFF
--- a/Anamnesis/Actor/Pages/ActionPage.xaml
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml
@@ -470,7 +470,7 @@
 						</controls:TransformEditor.CanTranslateOverride>
 					</controls:TransformEditor>
 
-					<XivToolsWpf:InfoControl Key="Pose_WarningNotFrozen" Margin="0,0,-2,55">
+					<XivToolsWpf:InfoControl Key="Pose_WarningNotFrozen" Margin="0,0,-2,46">
 						<XivToolsWpf:InfoControl.Visibility>
 							<MultiBinding Converter="{StaticResource MultiBoolAndToVisibility}">
 								<Binding Path="Actor.IsMotionEnabled"/>

--- a/Anamnesis/Actor/Pages/PosePage.xaml
+++ b/Anamnesis/Actor/Pages/PosePage.xaml
@@ -157,7 +157,7 @@
 						<Grid Grid.Row="2" Grid.ColumnSpan="2" IsEnabled="{Binding GposeService.IsGpose, Converter={StaticResource B2V}}">
 							<controls:TransformEditor Skeleton="{Binding Skeleton, Mode=OneWay}"/>
 
-							<XivToolsWpf:InfoControl Key="Pose_WarningNotFrozen" Margin="0,0,0,55">
+							<XivToolsWpf:InfoControl Key="Pose_WarningNotFrozen" Margin="0,0,0,46">
 								<XivToolsWpf:InfoControl.Visibility>
 									<MultiBinding Converter="{StaticResource MultiBoolAndToVisibility}">
 										<Binding Path="TargetService.SelectedActor.IsMotionEnabled"/>

--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -689,12 +689,15 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			this.IsFlipping = true;
 			if (!this.Skeleton.HasSelection)
 			{
-				Bone? waistBone = this.Skeleton.GetBone("Waist");
-				Bone? lumbarBone = this.Skeleton.GetBone("SpineA");
-				this.FlipBone(waistBone);
-				this.FlipBone(lumbarBone);
-				waistBone?.ReadTransform(true);
-				lumbarBone?.ReadTransform(true);
+				if (this.Skeleton.GetBone("n_hara") is Bone abdomenBone)
+				{
+					this.FlipBone(abdomenBone);
+					abdomenBone.ReadTransform(true);
+				}
+				else
+				{
+					Log.Warning("Could not find abdomen bone");
+				}
 			}
 			else
 			{


### PR DESCRIPTION
**Changes:**
- Adjusted the motion disabled warning message position to better cover the position sliders.
- Fixed flip functionaliuty for non-humanoid actor models (no selection).
  - Previously, if no bones were selected, Anamnesis would attempt to flip the actor model using the waist and lumbar bones. However, not all models, such as non-humanoids and minions, have these bones. I updated the code to use the abdomen bone instead. The functionality remains the same for humanoid models. I am honestly a bit confused why the old implementaiton was split in two (upper/lower) half flips.