### PR TITLE
Fixed 2D skeleton not getting drawn when pose mode is toggled by importing pose file

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using XivToolsWpf;
 using XivToolsWpf.Math3D.Extensions;
 using CmQuaternion = System.Numerics.Quaternion;
@@ -307,7 +308,7 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			if (!this.PoseService.IsEnabled)
 				this.OnClearClicked(null, null);
 
-			BoneViewManager.Instance.Refresh();
+			Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Loaded, BoneViewManager.Instance.Refresh);
 		}
 	}
 


### PR DESCRIPTION
Indirectly toggling pose mode on using the pose file import caused bone node lines (i.e. the 2D skeleton) to not get drawn due to operation order. Fixed by dispatching the refresh command after UI loading completes.
