### PR TITLE
Hide non-valid glasses entries from the selector drawer.

### DIFF
--- a/Anamnesis/GameData/Excel/Glasses.cs
+++ b/Anamnesis/GameData/Excel/Glasses.cs
@@ -33,7 +33,7 @@ public class Glasses : ExcelRow
 		}
 		else
 		{
-			this.Name = parser.ReadString(13) ?? $"Glasses #{this.RowId}";
+			this.Name = parser.ReadString(13) ?? string.Empty;
 			this.Description = parser.ReadString(12) ?? string.Empty;
 			this.Icon = parser.ReadImageReference<int>(2);
 		}


### PR DESCRIPTION
This massive pull request sets the name of Glasses rows to an empty string if the parser is unable to read a name for that row. This has the effect of hiding those invalid entries from the selector drawer, preventing them from being selected and saved to favorites and chara files. These entries might be placeholders for 3 future sets of facewear (as seen in the GlassesStyle sheet).