### PR TITLE
Various actor redraw related fixes and improvements

### DIFF
--- a/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
@@ -3,10 +3,9 @@
 
 namespace Anamnesis.Actor.Refresh;
 
-using System.Threading.Tasks;
 using Anamnesis.Memory;
 using Anamnesis.Services;
-using static Anamnesis.Memory.ActorBasicMemory;
+using System.Threading.Tasks;
 
 public class PenumbraActorRefresher : IActorRefresher
 {
@@ -32,22 +31,19 @@ public class PenumbraActorRefresher : IActorRefresher
 
 	public async Task RefreshActor(ActorMemory actor)
 	{
-		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
-		{
+		bool doNpcHack = SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player;
+
+		if (doNpcHack)
 			actor.ObjectKind = ActorTypes.BattleNpc;
-			try
-			{
-				await Penumbra.Penumbra.Redraw(actor.ObjectIndex);
-				await Task.Delay(200);
-			}
-			finally
-			{
-				actor.ObjectKind = ActorTypes.Player;
-			}
-		}
-		else
+
+		try
 		{
-			await Penumbra.Penumbra.Redraw(actor.ObjectIndex);
+			await Penumbra.Penumbra.Redraw(actor.Name, actor.ObjectIndex);
+		}
+		finally
+		{
+			if (doNpcHack)
+				actor.ObjectKind = ActorTypes.Player;
 		}
 	}
 }

--- a/Anamnesis/Memory/InplaceFixedArrayMemory.cs
+++ b/Anamnesis/Memory/InplaceFixedArrayMemory.cs
@@ -45,8 +45,20 @@ public abstract class InplaceFixedArrayMemory<TValue> : MemoryBase, IEnumerable<
 	[DoNotNotify]
 	public TValue this[int index]
 	{
-		get => this.items[index];
-		set => this.items[index] = value;
+		get
+		{
+			if (index < 0 || index >= this.items.Count)
+				throw new ArgumentOutOfRangeException(nameof(index), "Index was out of range. Must be non-negative and less than the size of the collection.");
+
+			return this.items[index];
+		}
+		set
+		{
+			if (index < 0 || index >= this.items.Count)
+				throw new ArgumentOutOfRangeException(nameof(index), "Index was out of range. Must be non-negative and less than the size of the collection.");
+
+			this.items[index] = value;
+		}
 	}
 
 	/// <summary>

--- a/Anamnesis/Penumbra/Penumbra.cs
+++ b/Anamnesis/Penumbra/Penumbra.cs
@@ -7,15 +7,16 @@ using System.Threading.Tasks;
 
 public static class Penumbra
 {
-	public static async Task Redraw(int targetIndex)
+	public static async Task Redraw(string name, int targetIndex)
 	{
-		RedrawData data = new();
-		data.ObjectTableIndex = targetIndex;
-		data.Type = RedrawData.RedrawType.Redraw;
+		RedrawData data = new()
+		{
+			Name = name,
+			ObjectTableIndex = targetIndex,
+			Type = RedrawData.RedrawType.Redraw
+		};
 
 		await PenumbraApi.Post("/redraw", data);
-
-		await Task.Delay(500);
 	}
 
 	public class RedrawData

--- a/Anamnesis/Penumbra/PenumbraApi.cs
+++ b/Anamnesis/Penumbra/PenumbraApi.cs
@@ -3,37 +3,32 @@
 
 namespace Anamnesis.Penumbra;
 
+using Anamnesis.Serialization;
+using Serilog;
 using System;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using Anamnesis.Serialization;
-using Serilog;
 
 internal static class PenumbraApi
 {
 	private const string Url = "http://localhost:42069/api";
 	private const int TimeoutMs = 500;
 
-	public static async Task Post(string route, object content)
+	private static readonly HttpClient Client = new()
 	{
-		await PostRequest(route, content);
+		Timeout = TimeSpan.FromMilliseconds(TimeoutMs),
+	};
+
+	public static async Task<string> Post(string route, object content)
+	{
+		var response = await PostRequest(route, content);
+		return response;
 	}
 
-	public static async Task<T> Post<T>(string route, object content)
-		where T : notnull
-	{
-		HttpResponseMessage response = await PostRequest(route, content);
-
-		using StreamReader? sr = new StreamReader(await response.Content.ReadAsStreamAsync());
-		string json = sr.ReadToEnd();
-
-		return SerializerService.Deserialize<T>(json);
-	}
-
-	private static async Task<HttpResponseMessage> PostRequest(string route, object content)
+	private static async Task<string> PostRequest(string route, object content)
 	{
 		if (!route.StartsWith('/'))
 			route = '/' + route;
@@ -42,15 +37,19 @@ internal static class PenumbraApi
 		{
 			string json = SerializerService.Serialize(content);
 
-			using HttpClient client = new HttpClient();
-			client.Timeout = TimeSpan.FromMilliseconds(TimeoutMs);
 			var buffer = Encoding.UTF8.GetBytes(json);
 			var byteContent = new ByteArrayContent(buffer);
 			byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+			HttpContent httpContent = byteContent;
 
-			using var response = await client.PostAsync(Url + route, byteContent);
+			using var response = await Client.PostAsync(Url + route, httpContent);
+			response.EnsureSuccessStatusCode();
 
-			return response;
+			using var responseContent = await response.Content.ReadAsStreamAsync();
+			using var sr = new StreamReader(responseContent);
+			string body = await sr.ReadToEndAsync();
+
+			return body;
 		}
 		catch (Exception ex)
 		{

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -210,6 +210,19 @@ public class TargetService : ServiceBase<TargetService>
 		{
 			// This section can only fail when FFXIV isn't running (fail to set address) so it should be safe to ignore
 		}
+
+		// Tick the actor if it still exists
+		if (this.PlayerTarget != null && this.PlayerTarget.Address != IntPtr.Zero)
+		{
+			try
+			{
+				this.PlayerTarget.Synchronize();
+			}
+			catch
+			{
+				// Should only fail to tick if the game isn't running
+			}
+		}
 	}
 
 	public override async Task Start()
@@ -416,6 +429,10 @@ public class TargetService : ServiceBase<TargetService>
 
 			for (int i = this.PinnedActors.Count - 1; i >= 0; i--)
 			{
+				// Skip the player target as it is already updated in the preceding function call
+				if (this.PinnedActors[i].Memory?.Address == this.PlayerTarget.Address)
+					continue;
+
 				this.PinnedActors[i].Tick();
 			}
 


### PR DESCRIPTION
**Changes:**
- Fixed issue where NPC appearances were not applying correctly using Brio redraw.
- Cleaned up Penumbra redraw.
- Added a retry mechanism for the skeleton initialization.
  - If Anamnesis is spammed with redraw calls, every now and then the skeleton create call can take place before the actor's bones are made available in memory. I added a retry mechanism to make it more fault tolerant.
- Moved the player target synchronization call in `UpdatePlayerTarget()`, instead of relying on it to be updated by the `TickPinnedActors()` method.