### PR TITLE
Added a converter for glasses favorites.

### DIFF
--- a/Anamnesis/Serialization/Converters/GlassesConverter.cs
+++ b/Anamnesis/Serialization/Converters/GlassesConverter.cs
@@ -1,0 +1,50 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Serialization.Converters;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Anamnesis.GameData.Excel;
+using Anamnesis.Services;
+using Serilog;
+
+public class GlassesConverter : JsonConverter<Glasses>
+{
+	public override Glasses Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		uint glassesRowId;
+
+		// Favorites for glasses should be stored as an array of numbers (as strings), for example: ["1", "88"]
+		// Legacy favorites files mistakenly had the entire object, so the second condition accounts for this.
+		//    (It will be converted to normal if the user favortes something else.)
+		// If none of those work, throw.
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			string? str = reader.GetString();
+
+			if (!string.IsNullOrEmpty(str))
+			{
+				glassesRowId = uint.Parse(str);
+				return GameDataService.Glasses.Get(glassesRowId);
+			}
+		}
+		else if (reader.TokenType == JsonTokenType.StartObject)
+		{
+			JsonDocument jsonDoc = JsonDocument.ParseValue(ref reader);
+			if (jsonDoc.RootElement.TryGetProperty("GlassesId", out JsonElement glassesIdEl))
+			{
+				glassesRowId = glassesIdEl.GetUInt32();
+				return GameDataService.Glasses.Get(glassesRowId);
+			}
+		}
+
+		throw new Exception($"Invalid serialized glasses value");
+	}
+
+	public override void Write(Utf8JsonWriter writer, Glasses value, JsonSerializerOptions options)
+	{
+		writer.WriteStringValue($"{value.RowId}");
+	}
+}

--- a/Anamnesis/Serialization/SerializerService.cs
+++ b/Anamnesis/Serialization/SerializerService.cs
@@ -38,6 +38,7 @@ public class SerializerService : ServiceBase<SerializerService>
 		Options.Converters.Add(new PointConverter());
 		Options.Converters.Add(new VersionConverter());
 		Options.Converters.Add(new GlassesSaveConverter());
+		Options.Converters.Add(new GlassesConverter());
 	}
 
 	public static string Serialize(object obj)


### PR DESCRIPTION
This pull request addresses the issue raised in Discord where Anamnesis will crash when attempting to load the facewear selector drawer with glasses favorited. This was caused by the entire glasses object being stored in the Favorites.json file by mistake.

I've added a converter to address this, as well as including a condition to load that whole object and attempt to parse the glassesId from it. Users can "normalize" their favorites by simply favoriting or unfavoriting anything, if they wish.