### PR TITLE
Fixed issue to hide the age selector for masculine miqote

### DIFF
--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -49,7 +49,7 @@ public partial class CustomizeEditor : UserControl
 
 		this.debounceTimer = new DispatcherTimer
 		{
-			Interval = TimeSpan.FromMilliseconds(200),
+			Interval = TimeSpan.FromMilliseconds(100),
 		};
 		this.debounceTimer.Tick += this.DebounceTimer_Tick;
 	}
@@ -127,7 +127,8 @@ public partial class CustomizeEditor : UserControl
 
 	private void OnAppearancePropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName == nameof(ActorCustomizeMemory.Race) ||
+		if (e.PropertyName == nameof(ActorCustomizeMemory.Gender) ||
+			e.PropertyName == nameof(ActorCustomizeMemory.Race) ||
 			e.PropertyName == nameof(ActorCustomizeMemory.Tribe) ||
 			e.PropertyName == nameof(ActorCustomizeMemory.Hair) ||
 			e.PropertyName == nameof(ActorCustomizeMemory.FacePaint))


### PR DESCRIPTION
This fix triggers an UI update on character gender change. Previously, if a user changed from female to male Miqo'te, the age selector stayed visible in the UI. However, age selection for masculine Miqo'te is unsupported by the game. So attempting to change the age will cause the game to crash.