### PR TITLE
Fixed an issue causing a Lumina error due to missing dye row IDs

### DIFF
--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -410,8 +410,26 @@ public partial class ItemView : UserControl
 				if (valueVm is ItemMemory itemVm)
 				{
 					IItem? item = ItemUtility.GetItem(slots, 0, itemVm.Base, itemVm.Variant, this.Actor.IsChocobo);
-					IDye? dye = GameDataService.Dyes.GetRow(itemVm.Dye);
-					IDye? dye2 = GameDataService.Dyes.GetRow(itemVm.Dye2);
+					IDye? dye;
+					IDye? dye2;
+
+					try
+					{
+						dye = GameDataService.Dyes.GetRow(itemVm.Dye);
+					}
+					catch (ArgumentOutOfRangeException)
+					{
+						dye = DyeUtility.NoneDye;
+					}
+
+					try
+					{
+						dye2 = GameDataService.Dyes.GetRow(itemVm.Dye2);
+					}
+					catch (ArgumentOutOfRangeException)
+					{
+						dye2 = DyeUtility.NoneDye;
+					}
 
 					await Dispatch.MainThread();
 
@@ -426,8 +444,26 @@ public partial class ItemView : UserControl
 					if (weaponVm.Set == 0)
 						weaponVm.Dye = 0;
 
-					IDye? dye = GameDataService.Dyes.GetRow(weaponVm.Dye);
-					IDye? dye2 = GameDataService.Dyes.GetRow(weaponVm.Dye2);
+					IDye? dye;
+					IDye? dye2;
+
+					try
+					{
+						dye = GameDataService.Dyes.GetRow(weaponVm.Dye);
+					}
+					catch (ArgumentOutOfRangeException)
+					{
+						dye = DyeUtility.NoneDye;
+					}
+
+					try
+					{
+						dye2 = GameDataService.Dyes.GetRow(weaponVm.Dye2);
+					}
+					catch (ArgumentOutOfRangeException)
+					{
+						dye2 = DyeUtility.NoneDye;
+					}
 
 					await Dispatch.MainThread();
 


### PR DESCRIPTION
This pull request ensures items with invalid dye IDs default the dye to 'None' during item slot changes.

The steps I used to reproduce the original issue:
1) Open Anamnesis
2) Load in NPC appearance with Brio that has an invalid item slot. (e.g. Guydelot [Event NPC: 1022527, Model: 0], which has an invalid headgear piece).