### PR TITLE
Fixes for NPC Appearance and Job Action Loading Issues

### DIFF
--- a/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
@@ -213,7 +213,7 @@ public partial class CharacterPage : UserControl
 		if (await GenericDialog.ShowLocalizedAsync("Character_Reset_Confirm", "Character_Reset", MessageBoxButton.YesNo) != true)
 			return;
 
-		await this.Actor.Pinned.RestoreCharacterBackup(PinnedActor.BackupModes.Original);
+		this.Actor.Pinned.RestoreCharacterBackup(PinnedActor.BackupModes.Original);
 	}
 
 	private async void OnImportClicked(object sender, RoutedEventArgs e)
@@ -273,11 +273,11 @@ public partial class CharacterPage : UserControl
 			if (npc == null)
 				return;
 
-			Task.Run(() => this.ApplyNpc(npc, mode));
+			this.ApplyNpc(npc, mode);
 		});
 	}
 
-	private async Task ApplyNpc(INpcBase? npc, CharacterFile.SaveModes mode = CharacterFile.SaveModes.All)
+	private void ApplyNpc(INpcBase? npc, CharacterFile.SaveModes mode = CharacterFile.SaveModes.All)
 	{
 		if (this.Actor == null || npc == null)
 			return;
@@ -285,7 +285,7 @@ public partial class CharacterPage : UserControl
 		try
 		{
 			CharacterFile apFile = npc.ToFile();
-			await apFile.Apply(this.Actor, mode);
+			apFile.Apply(this.Actor, mode);
 		}
 		catch (Exception ex)
 		{
@@ -329,7 +329,7 @@ public partial class CharacterPage : UserControl
 
 			if (result.File is CharacterFile apFile)
 			{
-				await apFile.Apply(this.Actor, mode);
+				apFile.Apply(this.Actor, mode);
 			}
 		}
 		catch (Exception ex)

--- a/Anamnesis/Actor/Utilities/SubActorUtility.cs
+++ b/Anamnesis/Actor/Utilities/SubActorUtility.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 public class SubActorUtility
 {
-	public static async Task SwitchMount(ActorMemory memory, Mount mount)
+	public static void SwitchMount(ActorMemory memory, Mount mount)
 	{
 		if (memory.IsMounted == true && memory.Mount != null)
 		{
@@ -23,9 +23,8 @@ public class SubActorUtility
 			float mountScale = CalculateMountScale(mount, memory);
 			memory.Mount.Scale = mountScale;
 
-			await Apply(mount, memory.Mount);
-
-			await memory.Refresh();
+			Apply(mount, memory.Mount);
+			Task.Run(memory.Refresh);
 		}
 		else
 		{
@@ -33,12 +32,12 @@ public class SubActorUtility
 		}
 	}
 
-	public static async Task SwitchCompanion(ActorMemory memory, Companion companion)
+	public static void SwitchCompanion(ActorMemory memory, Companion companion)
 	{
 		if (memory.Companion != null)
 		{
 			memory.Companion.DataId = companion.RowId;
-			await Apply(companion, memory.Companion);
+			Apply(companion, memory.Companion);
 		}
 		else
 		{
@@ -46,13 +45,13 @@ public class SubActorUtility
 		}
 	}
 
-	public static async Task SwitchOrnament(ActorMemory memory, Ornament ornament)
+	public static void SwitchOrnament(ActorMemory memory, Ornament ornament)
 	{
 		if (memory.IsUsingOrnament == true && memory.Ornament != null)
 		{
 			memory.OrnamentId = (ushort)ornament.RowId;
 			memory.Ornament.AttachmentPoint = (byte)ornament.AttachPoint;
-			await Apply(ornament, memory.Ornament);
+			Apply(ornament, memory.Ornament);
 		}
 		else
 		{
@@ -60,12 +59,12 @@ public class SubActorUtility
 		}
 	}
 
-	private static async Task Apply(INpcBase npc, ActorMemory targetActor)
+	private static void Apply(INpcBase npc, ActorMemory targetActor)
 	{
 		try
 		{
 			CharacterFile apFile = npc.ToFile();
-			await apFile.Apply(targetActor, CharacterFile.SaveModes.EquipmentGear);
+			apFile.Apply(targetActor, CharacterFile.SaveModes.EquipmentGear);
 		}
 		catch (Exception ex)
 		{

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -199,7 +199,7 @@ public partial class ItemView : UserControl
 		}
 	}
 
-	private async void OnResetSlotClicked(object sender, RoutedEventArgs e)
+	private void OnResetSlotClicked(object sender, RoutedEventArgs e)
 	{
 		if (this.Actor == null)
 			return;
@@ -207,7 +207,7 @@ public partial class ItemView : UserControl
 		if (this.Actor.Pinned == null)
 			return;
 
-		await this.Actor.Pinned.RestoreCharacterBackup(PinnedActor.BackupModes.Original, this.Slot);
+		this.Actor.Pinned.RestoreCharacterBackup(PinnedActor.BackupModes.Original, this.Slot);
 	}
 
 	private void OnClearSlotClicked(object sender, RoutedEventArgs e)

--- a/Anamnesis/Actor/Views/SubActorEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/SubActorEditor.xaml.cs
@@ -184,7 +184,7 @@ public partial class SubActorEditor : UserControl
 		}
 	}
 
-	private async void Apply(INpcBase npc)
+	private void Apply(INpcBase npc)
 	{
 		if (this.Actor == null || npc == null)
 			return;
@@ -193,15 +193,15 @@ public partial class SubActorEditor : UserControl
 
 		if (npc is Mount mount)
 		{
-			await SubActorUtility.SwitchMount(this.Actor, mount);
+			SubActorUtility.SwitchMount(this.Actor, mount);
 		}
 		else if (npc is Companion companion)
 		{
-			await SubActorUtility.SwitchCompanion(this.Actor, companion);
+			SubActorUtility.SwitchCompanion(this.Actor, companion);
 		}
 		else if (npc is Ornament ornament)
 		{
-			await SubActorUtility.SwitchOrnament(this.Actor, ornament);
+			SubActorUtility.SwitchOrnament(this.Actor, ornament);
 		}
 	}
 }

--- a/Anamnesis/Extensions/LuminaExtensions.cs
+++ b/Anamnesis/Extensions/LuminaExtensions.cs
@@ -5,7 +5,6 @@ namespace Lumina;
 
 using Anamnesis.Actor.Utilities;
 using Anamnesis.GameData;
-using Serilog;
 using System.Runtime.CompilerServices;
 
 public static class LuminaExtensions
@@ -16,16 +15,6 @@ public static class LuminaExtensions
 			return ItemUtility.NoneItem;
 
 		GetModel(val, true, out ushort modelSet, out ushort modelBase, out ushort modelVariant);
-
-		if (modelSet < 0 || modelBase < 0 || modelVariant < 0)
-		{
-			Log.Warning($"Invalid item value: {val}");
-
-			modelSet = 0;
-			modelBase = 0;
-			modelVariant = 0;
-		}
-
 		return ItemUtility.GetItem(slot, modelSet, modelBase, modelVariant, false);
 	}
 
@@ -35,16 +24,6 @@ public static class LuminaExtensions
 			return ItemUtility.NoneItem;
 
 		GetModel(val, false, out ushort modelSet, out ushort modelBase, out ushort modelVariant);
-
-		if (modelSet < 0 || modelBase < 0 || modelVariant < 0)
-		{
-			Log.Warning($"Invalid item value: {val}");
-
-			modelSet = 0;
-			modelBase = 0;
-			modelVariant = 0;
-		}
-
 		return ItemUtility.GetItem(slot, modelSet, modelBase, modelVariant, false);
 	}
 

--- a/Anamnesis/Extensions/LuminaExtensions.cs
+++ b/Anamnesis/Extensions/LuminaExtensions.cs
@@ -15,9 +15,7 @@ public static class LuminaExtensions
 		if (val == 0)
 			return ItemUtility.NoneItem;
 
-		short modelSet = (short)val;
-		short modelBase = (short)(val >> 16);
-		short modelVariant = (short)(val >> 32);
+		GetModel(val, true, out ushort modelSet, out ushort modelBase, out ushort modelVariant);
 
 		if (modelSet < 0 || modelBase < 0 || modelVariant < 0)
 		{
@@ -28,7 +26,7 @@ public static class LuminaExtensions
 			modelVariant = 0;
 		}
 
-		return ItemUtility.GetItem(slot, (ushort)modelSet, (ushort)modelBase, (ushort)modelVariant, false);
+		return ItemUtility.GetItem(slot, modelSet, modelBase, modelVariant, false);
 	}
 
 	public static IItem GetGearItem(ItemSlots slot, uint val)
@@ -36,9 +34,7 @@ public static class LuminaExtensions
 		if (val == 0)
 			return ItemUtility.NoneItem;
 
-		short modelSet = 0;
-		short modelBase = (short)val;
-		short modelVariant = (short)(val >> 16);
+		GetModel(val, false, out ushort modelSet, out ushort modelBase, out ushort modelVariant);
 
 		if (modelSet < 0 || modelBase < 0 || modelVariant < 0)
 		{
@@ -49,7 +45,7 @@ public static class LuminaExtensions
 			modelVariant = 0;
 		}
 
-		return ItemUtility.GetItem(slot, (ushort)modelSet, (ushort)modelBase, (ushort)modelVariant, false);
+		return ItemUtility.GetItem(slot, modelSet, modelBase, modelVariant, false);
 	}
 
 	public static void GetModel(ulong val, bool isWeapon, out ushort modelSet, out ushort modelBase, out ushort modelVariant)

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -269,21 +269,25 @@ public class CharacterFile : JsonFileBase
 
 			if (this.IncludeSection(SaveModes.EquipmentGear, mode))
 			{
-				this.HeadGear?.Write(actor.Equipment?.Head);
-				this.Body?.Write(actor.Equipment?.Chest);
-				this.Hands?.Write(actor.Equipment?.Arms);
-				this.Legs?.Write(actor.Equipment?.Legs);
-				this.Feet?.Write(actor.Equipment?.Feet);
-				this.Glasses?.Write(actor.Glasses);
+				WriteEquipment(this.HeadGear, actor.Equipment?.Head);
+				WriteEquipment(this.Body, actor.Equipment?.Chest);
+				WriteEquipment(this.Hands, actor.Equipment?.Arms);
+				WriteEquipment(this.Legs, actor.Equipment?.Legs);
+				WriteEquipment(this.Feet, actor.Equipment?.Feet);
+
+				if (this.Glasses != null)
+					this.Glasses.Write(actor.Glasses);
+				else if (actor.Glasses != null)
+					actor.Glasses.GlassesId = 0;
 			}
 
 			if (this.IncludeSection(SaveModes.EquipmentAccessories, mode))
 			{
-				this.Ears?.Write(actor.Equipment?.Ear);
-				this.Neck?.Write(actor.Equipment?.Neck);
-				this.Wrists?.Write(actor.Equipment?.Wrist);
-				this.RightRing?.Write(actor.Equipment?.RFinger);
-				this.LeftRing?.Write(actor.Equipment?.LFinger);
+				WriteEquipment(this.Ears, actor.Equipment?.Ear);
+				WriteEquipment(this.Neck, actor.Equipment?.Neck);
+				WriteEquipment(this.Wrists, actor.Equipment?.Wrist);
+				WriteEquipment(this.LeftRing, actor.Equipment?.LFinger);
+				WriteEquipment(this.RightRing, actor.Equipment?.RFinger);
 			}
 
 			if (mode == SaveModes.EquipmentSlot && slot != null)
@@ -474,6 +478,21 @@ public class CharacterFile : JsonFileBase
 	private bool IncludeSection(SaveModes section, SaveModes mode)
 	{
 		return this.SaveMode.HasFlagUnsafe(section) && mode.HasFlagUnsafe(section);
+	}
+
+	private static void WriteEquipment(ItemSave? itemSave, ItemMemory? itemMemory)
+	{
+		if (itemSave != null)
+		{
+			itemSave.Write(itemMemory);
+		}
+		else if (itemMemory != null)
+		{
+			itemMemory.Base = ItemUtility.NoneItem.ModelBase;
+			itemMemory.Variant = (byte)ItemUtility.NoneItem.ModelVariant;
+			itemMemory.Dye = (byte)ItemUtility.NoneDye.RowId;
+			itemMemory.Dye2 = (byte)ItemUtility.NoneDye.RowId;
+		}
 	}
 
 	[Serializable]

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -10,7 +10,6 @@ using Anamnesis.Memory;
 using Serilog;
 using System;
 using System.Numerics;
-using System.Threading.Tasks;
 using XivToolsWpf.Math3D.Extensions;
 
 [Serializable]
@@ -229,12 +228,7 @@ public class CharacterFile : JsonFileBase
 		}
 	}
 
-	public async Task Apply(ActorMemory actor, SaveModes mode, ItemSlots? slot = null)
-	{
-		await Task.Run(() => this.ApplyInternal(actor, mode, slot));
-	}
-
-	public void ApplyInternal(ActorMemory actor, SaveModes mode, ItemSlots? slot = null)
+	public void Apply(ActorMemory actor, SaveModes mode, ItemSlots? slot = null)
 	{
 		if (this.Tribe == 0)
 			this.Tribe = ActorCustomizeMemory.Tribes.Midlander;

--- a/Anamnesis/GameData/Excel/Action.cs
+++ b/Anamnesis/GameData/Excel/Action.cs
@@ -23,12 +23,12 @@ public readonly struct Action(ExcelPage page, uint offset, uint row)
 	public readonly ImgRef? Icon => new(page.ReadUInt16(offset + 8));
 
 	/// <inheritdoc/>
-	public ActionTimeline? Timeline => this.ActionTimelineHit.RowId >= 0 ? GameDataService.ActionTimelines.GetRow(this.ActionTimelineHit.RowId) : null;
+	public ActionTimeline? Timeline => this.AnimationEnd.IsValid && this.AnimationEnd.RowId >= 0 ? GameDataService.ActionTimelines.GetRow(this.AnimationEnd.RowId) : null;
 
 	/// <summary>
 	/// Gets a reference to the action timeline associated with the action.
 	/// </summary>
-	public readonly RowRef<ActionTimeline> ActionTimelineHit => new(page.Module, page.ReadUInt16(offset + 12), page.Language);
+	public readonly RowRef<ActionTimeline> AnimationEnd => new(page.Module, (uint)page.ReadInt16(offset + 32), page.Language);
 
 	/// <inheritdoc/>
 	public IAnimation.AnimationPurpose Purpose => IAnimation.AnimationPurpose.Action;

--- a/Anamnesis/GameData/Excel/BattleNpc.cs
+++ b/Anamnesis/GameData/Excel/BattleNpc.cs
@@ -145,7 +145,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public byte HairColor => this.BNpcCustomize.Value.HairColor;
 
 	/// <inheritdoc/>
-	public IItem MainHand => LuminaExtensions.GetWeaponItem(ItemSlots.MainHand, this.NpcEquip.Value.ModelMainHand);
+	public IItem MainHand => LuminaExtensions.GetWeaponItem(ItemSlots.MainHand, this.NpcEquip.ValueNullable?.ModelMainHand ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeMainHand => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeMainHand.Value.RowId);
@@ -154,7 +154,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2MainHand => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2MainHand.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem OffHand => LuminaExtensions.GetWeaponItem(ItemSlots.OffHand, this.NpcEquip.Value.ModelOffHand);
+	public IItem OffHand => LuminaExtensions.GetWeaponItem(ItemSlots.OffHand, this.NpcEquip.ValueNullable?.ModelOffHand ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeOffHand => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeOffHand.Value.RowId);
@@ -163,7 +163,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2OffHand => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2OffHand.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Head => LuminaExtensions.GetGearItem(ItemSlots.Head, this.NpcEquip.Value.ModelHead);
+	public IItem Head => LuminaExtensions.GetGearItem(ItemSlots.Head, this.NpcEquip.ValueNullable?.ModelHead ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeHead => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeHead.Value.RowId);
@@ -172,7 +172,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Head => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Head.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Body => LuminaExtensions.GetGearItem(ItemSlots.Body, this.NpcEquip.Value.ModelBody);
+	public IItem Body => LuminaExtensions.GetGearItem(ItemSlots.Body, this.NpcEquip.ValueNullable?.ModelBody ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeBody => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeBody.Value.RowId);
@@ -181,7 +181,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Body => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Body.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Legs => LuminaExtensions.GetGearItem(ItemSlots.Legs, this.NpcEquip.Value.ModelLegs);
+	public IItem Legs => LuminaExtensions.GetGearItem(ItemSlots.Legs, this.NpcEquip.ValueNullable?.ModelLegs ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeLegs => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeLegs.Value.RowId);
@@ -190,7 +190,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Legs => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Legs.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Feet => LuminaExtensions.GetGearItem(ItemSlots.Feet, this.NpcEquip.Value.ModelFeet);
+	public IItem Feet => LuminaExtensions.GetGearItem(ItemSlots.Feet, this.NpcEquip.ValueNullable?.ModelFeet ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeFeet => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeFeet.Value.RowId);
@@ -199,7 +199,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Feet => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Feet.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Hands => LuminaExtensions.GetGearItem(ItemSlots.Hands, this.NpcEquip.Value.ModelHands);
+	public IItem Hands => LuminaExtensions.GetGearItem(ItemSlots.Hands, this.NpcEquip.ValueNullable?.ModelHands ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeHands => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeHands.Value.RowId);
@@ -208,7 +208,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Hands => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Hands.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Wrists => LuminaExtensions.GetGearItem(ItemSlots.Wrists, this.NpcEquip.Value.ModelWrists);
+	public IItem Wrists => LuminaExtensions.GetGearItem(ItemSlots.Wrists, this.NpcEquip.ValueNullable?.ModelWrists ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeWrists => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeWrists.Value.RowId);
@@ -217,7 +217,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Wrists => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Wrists.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Neck => LuminaExtensions.GetGearItem(ItemSlots.Neck, this.NpcEquip.Value.ModelNeck);
+	public IItem Neck => LuminaExtensions.GetGearItem(ItemSlots.Neck, this.NpcEquip.ValueNullable?.ModelNeck ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeNeck => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeNeck.Value.RowId);
@@ -226,7 +226,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Neck => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Neck.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem Ears => LuminaExtensions.GetGearItem(ItemSlots.Ears, this.NpcEquip.Value.ModelEars);
+	public IItem Ears => LuminaExtensions.GetGearItem(ItemSlots.Ears, this.NpcEquip.ValueNullable?.ModelEars ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeEars => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeEars.Value.RowId);
@@ -235,7 +235,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2Ears => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2Ears.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem LeftRing => LuminaExtensions.GetGearItem(ItemSlots.LeftRing, this.NpcEquip.Value.ModelLeftRing);
+	public IItem LeftRing => LuminaExtensions.GetGearItem(ItemSlots.LeftRing, this.NpcEquip.ValueNullable?.ModelLeftRing ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeLeftRing => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeLeftRing.Value.RowId);
@@ -244,7 +244,7 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public RowRef<Stain> Dye2LeftRing => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.Dye2LeftRing.Value.RowId);
 
 	/// <inheritdoc/>
-	public IItem RightRing => LuminaExtensions.GetGearItem(ItemSlots.RightRing, this.NpcEquip.Value.ModelRightRing);
+	public IItem RightRing => LuminaExtensions.GetGearItem(ItemSlots.RightRing, this.NpcEquip.ValueNullable?.ModelRightRing ?? 0);
 
 	/// <inheritdoc/>
 	public RowRef<Stain> DyeRightRing => GameDataService.CreateRef<Stain>(this.NpcEquip.Value.DyeRightRing.Value.RowId);

--- a/Anamnesis/GameData/Excel/EventNpc.cs
+++ b/Anamnesis/GameData/Excel/EventNpc.cs
@@ -198,7 +198,7 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	public readonly RowRef<Stain> Dye2Body => new(page.Module, (uint)page.ReadUInt8(offset + 244), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Hands => GetItem(ItemSlots.Hands, (uint)page.ReadUInt32(offset + 156), this.NpcEquip.Value.ModelHands);
+	public readonly IItem Hands => LuminaExtensions.GetGearItem(ItemSlots.Hands, this.NpcEquip.ValueNullable?.ModelHands ?? 0);
 
 	/// <inheritdoc/>
 	public readonly RowRef<Stain> DyeHands => new(page.Module, (uint)page.ReadUInt8(offset + 235), page.Language);

--- a/Anamnesis/GameData/Excel/EventNpc.cs
+++ b/Anamnesis/GameData/Excel/EventNpc.cs
@@ -162,112 +162,112 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	public readonly byte FacePaintColor => page.ReadUInt8(offset + 227);
 
 	/// <inheritdoc/>
-	public readonly IItem MainHand => GetItem(ItemSlots.MainHand, (ulong)page.ReadUInt64(offset + 128), this.NpcEquip.Value.ModelMainHand);
+	public readonly IItem MainHand => GetWeaponItem(ItemSlots.MainHand, page.ReadUInt64(offset + 128), this.NpcEquip.ValueNullable?.ModelMainHand);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeMainHand => new(page.Module, (uint)page.ReadUInt8(offset + 229), page.Language);
+	public readonly RowRef<Stain> DyeMainHand => new(page.Module, page.ReadUInt8(offset + 229), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2MainHand => new(page.Module, (uint)page.ReadUInt8(offset + 230), page.Language);
+	public readonly RowRef<Stain> Dye2MainHand => new(page.Module, page.ReadUInt8(offset + 230), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem OffHand => GetItem(ItemSlots.OffHand, (ulong)page.ReadUInt64(offset + 136), this.NpcEquip.Value.ModelOffHand);
+	public readonly IItem OffHand => GetWeaponItem(ItemSlots.OffHand, page.ReadUInt64(offset + 136), this.NpcEquip.ValueNullable?.ModelOffHand);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeOffHand => new(page.Module, (uint)page.ReadUInt8(offset + 231), page.Language);
+	public readonly RowRef<Stain> DyeOffHand => new(page.Module, page.ReadUInt8(offset + 231), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2OffHand => new(page.Module, (uint)page.ReadUInt8(offset + 232), page.Language);
+	public readonly RowRef<Stain> Dye2OffHand => new(page.Module, page.ReadUInt8(offset + 232), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Head => GetItem(ItemSlots.Head, (uint)page.ReadUInt32(offset + 148), this.NpcEquip.Value.ModelHead);
+	public readonly IItem Head => GetGearItem(ItemSlots.Head, page.ReadUInt32(offset + 148), this.NpcEquip.ValueNullable?.ModelHead);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeHead => new(page.Module, (uint)page.ReadUInt8(offset + 233), page.Language);
+	public readonly RowRef<Stain> DyeHead => new(page.Module, page.ReadUInt8(offset + 233), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Head => new(page.Module, (uint)page.ReadUInt8(offset + 243), page.Language);
+	public readonly RowRef<Stain> Dye2Head => new(page.Module, page.ReadUInt8(offset + 243), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Body => GetItem(ItemSlots.Body, (uint)page.ReadUInt32(offset + 152), this.NpcEquip.Value.ModelBody);
+	public readonly IItem Body => GetGearItem(ItemSlots.Body, page.ReadUInt32(offset + 152), this.NpcEquip.ValueNullable?.ModelBody);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeBody => new(page.Module, (uint)page.ReadUInt8(offset + 234), page.Language);
+	public readonly RowRef<Stain> DyeBody => new(page.Module, page.ReadUInt8(offset + 234), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Body => new(page.Module, (uint)page.ReadUInt8(offset + 244), page.Language);
+	public readonly RowRef<Stain> Dye2Body => new(page.Module, page.ReadUInt8(offset + 244), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Hands => LuminaExtensions.GetGearItem(ItemSlots.Hands, this.NpcEquip.ValueNullable?.ModelHands ?? 0);
+	public readonly IItem Hands => GetGearItem(ItemSlots.Hands, page.ReadUInt32(offset + 156), this.NpcEquip.ValueNullable?.ModelHands);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeHands => new(page.Module, (uint)page.ReadUInt8(offset + 235), page.Language);
+	public readonly RowRef<Stain> DyeHands => new(page.Module, page.ReadUInt8(offset + 235), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Hands => new(page.Module, (uint)page.ReadUInt8(offset + 245), page.Language);
+	public readonly RowRef<Stain> Dye2Hands => new(page.Module, page.ReadUInt8(offset + 245), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Legs => GetItem(ItemSlots.Legs, (uint)page.ReadUInt32(offset + 160), this.NpcEquip.Value.ModelLegs);
+	public readonly IItem Legs => GetGearItem(ItemSlots.Legs, page.ReadUInt32(offset + 160), this.NpcEquip.ValueNullable?.ModelLegs);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeLegs => new(page.Module, (uint)page.ReadUInt8(offset + 236), page.Language);
+	public readonly RowRef<Stain> DyeLegs => new(page.Module, page.ReadUInt8(offset + 236), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Legs => new(page.Module, (uint)page.ReadUInt8(offset + 246), page.Language);
+	public readonly RowRef<Stain> Dye2Legs => new(page.Module, page.ReadUInt8(offset + 246), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Feet => GetItem(ItemSlots.Feet, (uint)page.ReadUInt32(offset + 164), this.NpcEquip.Value.ModelFeet);
+	public readonly IItem Feet => GetGearItem(ItemSlots.Feet, page.ReadUInt32(offset + 164), this.NpcEquip.ValueNullable?.ModelFeet);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeFeet => new(page.Module, (uint)page.ReadUInt8(offset + 237), page.Language);
+	public readonly RowRef<Stain> DyeFeet => new(page.Module, page.ReadUInt8(offset + 237), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Feet => new(page.Module, (uint)page.ReadUInt8(offset + 247), page.Language);
+	public readonly RowRef<Stain> Dye2Feet => new(page.Module, page.ReadUInt8(offset + 247), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Ears => GetItem(ItemSlots.Ears, (uint)page.ReadUInt32(offset + 168), this.NpcEquip.Value.ModelEars);
+	public readonly IItem Ears => GetGearItem(ItemSlots.Ears, page.ReadUInt32(offset + 168), this.NpcEquip.ValueNullable?.ModelEars);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeEars => new(page.Module, (uint)page.ReadUInt8(offset + 238), page.Language);
+	public readonly RowRef<Stain> DyeEars => new(page.Module, page.ReadUInt8(offset + 238), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Ears => new(page.Module, (uint)page.ReadUInt8(offset + 248), page.Language);
+	public readonly RowRef<Stain> Dye2Ears => new(page.Module, page.ReadUInt8(offset + 248), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Neck => GetItem(ItemSlots.Neck, (uint)page.ReadUInt32(offset + 172), this.NpcEquip.Value.ModelNeck);
+	public readonly IItem Neck => GetGearItem(ItemSlots.Neck, page.ReadUInt32(offset + 172), this.NpcEquip.ValueNullable?.ModelNeck);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeNeck => new(page.Module, (uint)page.ReadUInt8(offset + 239), page.Language);
+	public readonly RowRef<Stain> DyeNeck => new(page.Module, page.ReadUInt8(offset + 239), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Neck => new(page.Module, (uint)page.ReadUInt8(offset + 249), page.Language);
+	public readonly RowRef<Stain> Dye2Neck => new(page.Module, page.ReadUInt8(offset + 249), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem Wrists => GetItem(ItemSlots.Wrists, (uint)page.ReadUInt32(offset + 176), this.NpcEquip.Value.ModelWrists);
+	public readonly IItem Wrists => GetGearItem(ItemSlots.Wrists, page.ReadUInt32(offset + 176), this.NpcEquip.ValueNullable?.ModelWrists);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeWrists => new(page.Module, (uint)page.ReadUInt8(offset + 240), page.Language);
+	public readonly RowRef<Stain> DyeWrists => new(page.Module, page.ReadUInt8(offset + 240), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2Wrists => new(page.Module, (uint)page.ReadUInt8(offset + 250), page.Language);
+	public readonly RowRef<Stain> Dye2Wrists => new(page.Module, page.ReadUInt8(offset + 250), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem LeftRing => GetItem(ItemSlots.LeftRing, (uint)page.ReadUInt32(offset + 180), this.NpcEquip.Value.ModelLeftRing);
+	public readonly IItem LeftRing => GetGearItem(ItemSlots.LeftRing, page.ReadUInt32(offset + 180), this.NpcEquip.ValueNullable?.ModelLeftRing);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeLeftRing => new(page.Module, (uint)page.ReadUInt8(offset + 241), page.Language);
+	public readonly RowRef<Stain> DyeLeftRing => new(page.Module, page.ReadUInt8(offset + 241), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> DyeRightRing => new(page.Module, (uint)page.ReadUInt8(offset + 242), page.Language);
+	public readonly RowRef<Stain> DyeRightRing => new(page.Module, page.ReadUInt8(offset + 242), page.Language);
 
 	/// <inheritdoc/>
-	public readonly IItem RightRing => GetItem(ItemSlots.RightRing, page.ReadUInt32(offset + 184), this.NpcEquip.Value.ModelRightRing);
+	public readonly IItem RightRing => GetGearItem(ItemSlots.RightRing, page.ReadUInt32(offset + 184), this.NpcEquip.ValueNullable?.ModelRightRing);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2LeftRing => new(page.Module, (uint)page.ReadUInt8(offset + 251), page.Language);
+	public readonly RowRef<Stain> Dye2LeftRing => new(page.Module, page.ReadUInt8(offset + 251), page.Language);
 
 	/// <inheritdoc/>
-	public readonly RowRef<Stain> Dye2RightRing => new(page.Module, (uint)page.ReadUInt8(offset + 252), page.Language);
+	public readonly RowRef<Stain> Dye2RightRing => new(page.Module, page.ReadUInt8(offset + 252), page.Language);
 
 	/// <summary>
 	/// Creates a new instance of the <see cref="EventNpc"/> struct.
@@ -280,13 +280,30 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 		new(page, offset, row);
 
 	/// <summary>
-	/// Gets an item from the given slot and npc base and equipment model values.
+	/// Retrieves weapon with equipment model value if
+	/// available, otherwise retrieves using the the base model value.
+	/// </summary>
+	/// <param name="slot"></param>
+	/// <param name="baseVal"></param>
+	/// <param name="equipVal"></param>
+	/// <returns></returns>
+	private static IItem GetWeaponItem(ItemSlots slot, ulong baseVal, ulong? equipVal)
+	{
+		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != long.MaxValue)
+			return LuminaExtensions.GetWeaponItem(slot, (ulong)equipVal);
+
+		return LuminaExtensions.GetWeaponItem(slot, baseVal);
+	}
+
+	/// <summary>
+	/// Retrieves gear item with equipment model value if
+	/// available, otherwise retrieves using the the base model value.
 	/// </summary>
 	/// <param name="slot">The item slot.</param>
 	/// <param name="baseVal">The base value of the item.</param>
 	/// <param name="equipVal">The equipment model value of the item.</param>
 	/// <returns>The found item in the game data.</returns>
-	private static IItem GetItem(ItemSlots slot, uint baseVal, uint? equipVal)
+	private static IItem GetGearItem(ItemSlots slot, uint baseVal, uint? equipVal)
 	{
 		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != long.MaxValue)
 			return LuminaExtensions.GetGearItem(slot, (uint)equipVal);
@@ -301,8 +318,8 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	/// <param name="baseVal">The base value of the item.</param>
 	/// <param name="equipVal">The equipment model value of the item.</param>
 	/// <returns>The found item in the game data.</returns>
-	private static IItem GetItem(ItemSlots slot, ulong baseVal, ulong? equipVal)
+	private static IItem GetGearItem(ItemSlots slot, ulong baseVal, ulong? equipVal)
 	{
-		return GetItem(slot, (uint)baseVal, (uint?)equipVal);
+		return GetGearItem(slot, (uint)baseVal, (uint?)equipVal);
 	}
 }

--- a/Anamnesis/Memory/ActorCustomizeMemory.cs
+++ b/Anamnesis/Memory/ActorCustomizeMemory.cs
@@ -9,6 +9,7 @@ using System;
 public class ActorCustomizeMemory : MemoryBase
 {
 	private bool linkEyeColors;
+	private Races race;
 
 	public enum Genders : byte
 	{
@@ -83,7 +84,22 @@ public class ActorCustomizeMemory : MemoryBase
 		return ap;
 	}*/
 
-	[Bind(0x000, BindFlags.ActorRefresh)] public Races Race { get; set; }
+	[Bind(0x000, BindFlags.ActorRefresh)]
+	public Races Race
+	{
+		get => this.race;
+		set
+		{
+			if (this.race == value)
+				return;
+
+			// Reset race feature value for some races to avoid a game crash
+			if (value is Races.Hyur or Races.Roegadyn)
+				this.TailEarsType = 1;
+
+			this.race = value;
+		}
+	}
 	[Bind(0x001, BindFlags.ActorRefresh)] public Genders Gender { get; set; }
 	[Bind(0x002, BindFlags.ActorRefresh)] public Ages Age { get; set; }
 	[Bind(0x003, BindFlags.ActorRefresh)] public byte Height { get; set; }

--- a/Anamnesis/Services/PinnedActor.cs
+++ b/Anamnesis/Services/PinnedActor.cs
@@ -3,7 +3,6 @@
 
 namespace Anamnesis;
 
-using Anamnesis.Actor;
 using Anamnesis.Files;
 using Anamnesis.GameData;
 using Anamnesis.Memory;
@@ -15,8 +14,6 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading.Tasks;
-using XivToolsWpf.Extensions;
 
 [AddINotifyPropertyChangedInterface]
 public class PinnedActor : INotifyPropertyChanged, IDisposable
@@ -200,7 +197,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 		}
 	}
 
-	public async Task RestoreCharacterBackup(BackupModes mode, ItemSlots? slot = null)
+	public void RestoreCharacterBackup(BackupModes mode, ItemSlots? slot = null)
 	{
 		CharacterFile? backup = null;
 
@@ -224,7 +221,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 		}
 
 		this.isRestoringBackup = true;
-		await backup.Apply(memory, slot == null ? CharacterFile.SaveModes.All : CharacterFile.SaveModes.EquipmentSlot, slot);
+		backup.Apply(memory, slot == null ? CharacterFile.SaveModes.All : CharacterFile.SaveModes.EquipmentSlot, slot);
 
 		// If we were a player, really make sure we are again.
 		if (backup.ObjectKind == ActorTypes.Player)
@@ -431,7 +428,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 		// If we need to apply the appearance thanks to a GPose boundary changes?
 		if (SettingsService.Current.ReapplyAppearance || GposeService.GetIsGPose())
 		{
-			this.RestoreCharacterBackup(BackupModes.Gpose).Run();
+			this.RestoreCharacterBackup(BackupModes.Gpose);
 
 			// clear the appearance once it has been applied
 			if (!SettingsService.Current.ReapplyAppearance)


### PR DESCRIPTION
_Note: This pull request targets the `master` branch as it is intended to be part of a hotfix release._

**Changelog:**
- Resolved an issue that would cause a game crash whenever switching between races under certain conditions.
  - _Details:_ This can be reproduced by first loading in Wuk Lamat and then changing the race to Hyur. Due to the tail type value (201), the game crashes. I resolved it by resetting the tail type when the race switches to target value Hyur or Roegadyn.
- (Internal) Converted asynchronous character file apply function to synchronous.
- Fixed issue preventing some NPC weapons/equipment from importing correctly.
- Fixed job action animations.