### PR TITLE
Fixed incorrect equipment import priority for event and resident NPCs

### DIFF
--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -264,7 +264,6 @@ public class CharacterFile : JsonFileBase
 			{
 				this.MainHand?.Write(actor.MainHand, true);
 				this.OffHand?.Write(actor.OffHand, false);
-				actor.IsWeaponDirty = true;
 			}
 
 			if (this.IncludeSection(SaveModes.EquipmentGear, mode))
@@ -296,11 +295,9 @@ public class CharacterFile : JsonFileBase
 				{
 					case ItemSlots.MainHand:
 						this.MainHand?.Write(actor.MainHand, true);
-						actor.IsWeaponDirty = true;
 						break;
 					case ItemSlots.OffHand:
 						this.OffHand?.Write(actor.OffHand, false);
-						actor.IsWeaponDirty = true;
 						break;
 					case ItemSlots.Head:
 						this.HeadGear?.Write(actor.Equipment?.Head);

--- a/Anamnesis/GameData/Excel/EventNpc.cs
+++ b/Anamnesis/GameData/Excel/EventNpc.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.GameData.Excel;
 
+using Anamnesis.Actor.Utilities;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Services;
 using Anamnesis.TexTools;
@@ -289,10 +290,13 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	/// <returns></returns>
 	private static IItem GetWeaponItem(ItemSlots slot, ulong baseVal, ulong? equipVal)
 	{
+		if (baseVal != 0 && baseVal != uint.MaxValue)
+			return LuminaExtensions.GetWeaponItem(slot, baseVal);
+
 		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != long.MaxValue)
 			return LuminaExtensions.GetWeaponItem(slot, (ulong)equipVal);
 
-		return LuminaExtensions.GetWeaponItem(slot, baseVal);
+		return ItemUtility.EmperorsNewFists;
 	}
 
 	/// <summary>
@@ -305,10 +309,13 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	/// <returns>The found item in the game data.</returns>
 	private static IItem GetGearItem(ItemSlots slot, uint baseVal, uint? equipVal)
 	{
-		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != long.MaxValue)
+		if (baseVal != 0 && baseVal != uint.MaxValue)
+			return LuminaExtensions.GetGearItem(slot, baseVal);
+
+		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != uint.MaxValue)
 			return LuminaExtensions.GetGearItem(slot, (uint)equipVal);
 
-		return LuminaExtensions.GetGearItem(slot, baseVal);
+		return ItemUtility.NoneItem;
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes https://github.com/imchillin/Anamnesis/issues/1325.

The issue was that the the NPC Equipment struct was prioritized instead of the columns directly associated with the particular NPC, which acted as fallback values. This should be flipped as the former acts as a template shared across different NPCs and the latter are changes applied on top of that template.