### PR TITLE
Linear gizmo drag inverse behaviour fix

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -308,7 +308,7 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			if (!this.PoseService.IsEnabled)
 				this.OnClearClicked(null, null);
 
-			Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Loaded, BoneViewManager.Instance.Refresh);
+			Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Loaded, BoneViewManager.Instance.Refresh);
 		}
 	}
 

--- a/Anamnesis/Styles/Controls/QuaternionEditor.xaml.cs
+++ b/Anamnesis/Styles/Controls/QuaternionEditor.xaml.cs
@@ -37,13 +37,35 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 	public static readonly IBind<CmQuaternion> ValueQuatDp = Binder.Register<CmQuaternion, QuaternionEditor>(nameof(ValueQuat), OnValueQuatChanged);
 	public static readonly IBind<CmVector> EulerDp = Binder.Register<CmVector, QuaternionEditor>(nameof(Euler), OnEulerChanged);
 
-	////private Vector3D euler;
 	private readonly RotationGizmo rotationGizmo;
 	private readonly bool isInitialized = false;
 	private bool lockdp = false;
 
 	private CmQuaternion worldSpaceDelta;
 	private bool worldSpace;
+	private readonly Sphere pivotSphere;
+
+	// [FOR DEBUGGING]
+	//// Represents the tangent along which the mouse is moving for the linear drag
+	// private readonly Line axisProjectionLine;
+
+	//// Represents the plane normal
+	// private readonly Line planeNormalLine;
+
+	//// Represents the tangent plane, created from the pivot point and the plane normal
+	// private readonly PlaneVisual3D tangentPlaneVisual;
+
+	//// Represents the intersection point of the raycast mouse position onto the tangent plane
+	// private readonly Sphere intersectionSphere;
+
+	//// Represents the near point of the unprojected camera ray
+	// private readonly Sphere nearSphere;
+
+	//// Represents the far point of the unprojected camera ray
+	// private readonly Sphere farSphere;
+
+	//// Represents the axis plane (i.e., the axis circle's plane)
+	// private readonly PlaneVisual3D axisPlane;
 
 	public QuaternionEditor()
 	{
@@ -74,7 +96,64 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 		this.rotationGizmo = new RotationGizmo(this);
 		this.Viewport.Children.Add(this.rotationGizmo);
 
-		this.Viewport.Camera = new PerspectiveCamera(new Point3D(0, 0, -2.0), new Vector3D(0, 0, 1), new Vector3D(0, 1, 0), 45);
+		// Create and add the pivot sphere directly to the viewport
+		this.pivotSphere = new Sphere
+		{
+			Radius = 0.03,
+			Material = new DiffuseMaterial(new SolidColorBrush(Colors.Yellow)),
+		};
+
+		// [FOR DEBUGGING]
+		// this.intersectionSphere = new Sphere
+		// {
+		//	 Radius = 0.03,
+		//	 Material = new DiffuseMaterial(new SolidColorBrush(Colors.Red)),
+		// };
+		// this.Viewport.Children.Add(this.intersectionSphere);
+
+		// this.nearSphere = new Sphere
+		// {
+		//	 Radius = 0.02,
+		//	 Material = new DiffuseMaterial(new SolidColorBrush(Colors.Magenta)),
+		// };
+		// this.Viewport.Children.Add(this.nearSphere);
+
+		// this.farSphere = new Sphere
+		// {
+		//	 Radius = 0.02,
+		//	 Material = new DiffuseMaterial(new SolidColorBrush(Colors.Cyan)),
+		// };
+		// this.Viewport.Children.Add(this.farSphere);
+
+		// this.axisProjectionLine = new Line
+		// {
+		//	 Thickness = 2,
+		//	 Color = Colors.Red,
+		// };
+		// this.Viewport.Children.Add(this.axisProjectionLine);
+
+		// this.planeNormalLine = new Line
+		// {
+		//	 Thickness = 2,
+		//	 Color = Colors.Green,
+		// };
+		// this.Viewport.Children.Add(this.planeNormalLine);
+
+		// this.tangentPlaneVisual = new PlaneVisual3D();
+		// this.Viewport.Children.Add(this.tangentPlaneVisual);
+
+		// this.axisPlane = new PlaneVisual3D();
+		// this.Viewport.Children.Add(this.axisPlane);
+
+		// Add a light source to the scene
+		this.Viewport.Children.Add(new ModelVisual3D() { Content = new AmbientLight(Colors.White) });
+
+		var camera = new PerspectiveCamera(new Point3D(0, 0, -2.0), new Vector3D(0, 0, 1), new Vector3D(0, 1, 0), 45)
+		{
+			FarPlaneDistance = 10000,
+		};
+
+		this.Viewport.Camera = camera;
 
 		this.worldSpace = false;
 
@@ -266,7 +345,41 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 
 	private void OnViewportMouseDown(object sender, MouseButtonEventArgs e)
 	{
-		Mouse.Capture(this.Viewport);
+		Mouse.Capture(this.Viewport, CaptureMode.SubTree);
+
+		if (e.LeftButton == MouseButtonState.Pressed)
+		{
+			Point mousePos = e.GetPosition(this.Viewport);
+			var activeAxis = this.rotationGizmo.Active;
+			if (activeAxis == null)
+				return;
+
+			// Find the nearest point on the active Axis gizmo circle
+			Point3D? nearestPoint = activeAxis.NearestPoint2D(mousePos);
+			if (nearestPoint == null)
+				return;
+
+			// Transform the nearest point from the Axis gizmo's space to the quaternion editor's transform space
+			Point3D transformedPoint = GetWorldMatrixFor(activeAxis).Transform((Point3D)nearestPoint);
+
+			// Set the pivot point for the active axis gizmo
+			activeAxis.SetPivotPoint(transformedPoint);
+
+			// Set the pivot sphere's position and color
+			this.pivotSphere.Transform = new TranslateTransform3D(transformedPoint.X, transformedPoint.Y, transformedPoint.Z);
+			this.pivotSphere.Material = new DiffuseMaterial(new SolidColorBrush(!activeAxis.Locked ? Colors.Yellow : Colors.White));
+
+			if (this.Viewport.Children.Contains(this.pivotSphere))
+				this.Viewport.Children.Remove(this.pivotSphere);
+
+			this.Viewport.Children.Add(this.pivotSphere);
+
+			// [FOR DEBUGGING]
+			// if (this.Viewport.Children.Contains(this.tangentPlaneVisual))
+			//	 this.Viewport.Children.Remove(this.tangentPlaneVisual);
+
+			// this.Viewport.Children.Add(this.tangentPlaneVisual);
+		}
 	}
 
 	private void OnViewportMouseUp(object sender, MouseButtonEventArgs e)
@@ -280,6 +393,8 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 			this.LockedAxisDisplay.Text = GetAxisName(this.rotationGizmo.Locked?.Axis);
 		}
 
+		this.Viewport.Children.Remove(this.pivotSphere);
+		// this.Viewport.Children.Remove(this.tangentPlaneVisual); [FOR DEBUGGING]
 		this.rotationGizmo.Hover(null);
 	}
 
@@ -405,9 +520,9 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 			};
 			this.Children.Add(sphere);
 
-			this.Children.Add(new AxisGizmo((Color)ColorConverter.ConvertFromString("#1c59ff"), new CmVector(1, 0, 0)));
-			this.Children.Add(new AxisGizmo((Color)ColorConverter.ConvertFromString("#94e800"), new CmVector(0, 1, 0)));
-			this.Children.Add(new AxisGizmo((Color)ColorConverter.ConvertFromString("#ff0d3e"), new CmVector(0, 0, 1)));
+			this.Children.Add(new AxisGizmo(this, target, (Color)ColorConverter.ConvertFromString("#1c59ff"), new CmVector(1, 0, 0)));
+			this.Children.Add(new AxisGizmo(this, target, (Color)ColorConverter.ConvertFromString("#94e800"), new CmVector(0, 1, 0)));
+			this.Children.Add(new AxisGizmo(this, target, (Color)ColorConverter.ConvertFromString("#ff0d3e"), new CmVector(0, 0, 1)));
 		}
 
 		public AxisGizmo? Locked
@@ -508,9 +623,7 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 		{
 			CmQuaternion angle = QuaternionExtensions.FromEuler(angleEuler);
 			CmQuaternion targetQuat = this.target.ValueQuat * angle;
-			CmQuaternion interpolatedQuat = CmQuaternion.Slerp(this.target.ValueQuat, targetQuat, 0.6f);
-
-			this.target.ValueQuat = interpolatedQuat;
+			this.target.ValueQuat = CmQuaternion.Slerp(this.target.ValueQuat, targetQuat, 0.6f);
 		}
 	}
 
@@ -521,14 +634,20 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 		private readonly Cylinder cylinder;
 		private Color color;
 
+		private readonly RotationGizmo rotationGizmo;
+		private readonly QuaternionEditor target;
 		private Point3D? lastPoint;
+		private Point3D pivotPoint;
+		private Vector3D planeNormal;
+		private Vector3D dragTangent;
+		private bool locked = false;
 
-		public AxisGizmo(Color color, CmVector axis)
+		public AxisGizmo(RotationGizmo rotationGizmo, QuaternionEditor target, Color color, CmVector axis)
 		{
+			this.rotationGizmo = rotationGizmo;
+			this.target = target;
 			this.Axis = axis;
 			this.color = color;
-
-			var rotationAxis = new Vector3D(axis.Z, 0, axis.X);
 
 			this.circle = new Circle
 			{
@@ -570,6 +689,7 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 
 		public bool Locked
 		{
+			get => this.locked;
 			set
 			{
 				if (!value)
@@ -583,7 +703,71 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 					this.circle.Color = Colors.White;
 					this.circle.Thickness = 3;
 				}
+
+				this.locked = value;
 			}
+		}
+
+		public Point3D? NearestPoint2D(Point mousePosition)
+		{
+			Point3D? nearestPoint = this.circle.NearestPoint2D(new Point3D(mousePosition.X, mousePosition.Y, 0));
+			if (nearestPoint == null)
+				return null;
+
+			return this.circle.TransformToAncestor(this).Transform((Point3D)nearestPoint);
+		}
+
+		public void SetPivotPoint(Point3D point)
+		{
+			// Pivot point
+			this.pivotPoint = point;
+
+			// Plane normal (From the center of the gizmo pointing outwards, passing through the pivot point)
+			Matrix3D worldMatrix = GetWorldMatrixFor(this.rotationGizmo);
+			Point3D gizmoCenter = worldMatrix.Transform(new Point3D(0, 0, 0));
+			Vector3D centerToPivot = this.pivotPoint - gizmoCenter;
+
+			// Get camera position in world space
+			var camera = (PerspectiveCamera)this.target.Viewport.Camera;
+			Point3D camOrigin = camera.Position;
+			if (camera.Transform != null)
+				camOrigin = camera.Transform.Value.Transform(camOrigin);
+
+			// Calculate plane normal
+			Vector3D normal = camOrigin - this.pivotPoint;
+			if (normal.LengthSquared < 1e-6)
+				normal = camera.LookDirection; // Fallback to camera look direction
+
+			normal.Normalize();
+			this.planeNormal = normal;
+
+			// Tangent direction
+			Vector3D axis = this.Axis.ToMedia3DVector();
+			if (axis.X >= 1)
+				axis = new Vector3D(0, 0, 1);
+			else if (axis.Z >= 1)
+				axis = new Vector3D(1, 0, 0);
+
+			Vector3D axisInWorld = worldMatrix.Transform(axis);
+			axisInWorld.Normalize();
+
+			Vector3D axisProjected = axisInWorld - (Vector3D.DotProduct(axisInWorld, centerToPivot) * centerToPivot);
+			if (axisProjected.LengthSquared < 1e-6)
+			{
+				axisProjected = new Vector3D(1, 0, 0); // Fallback if projection breaks down
+				if (axisProjected.LengthSquared < 1e-6)
+					axisProjected = new Vector3D(0, 1, 0);
+			}
+			axisProjected.Normalize();
+
+			this.dragTangent = Vector3D.CrossProduct(centerToPivot, axisProjected);
+			this.dragTangent.Normalize();
+
+			// [FOR DEBUGGING]
+			// this.target.axisProjectionLine.Points = [this.pivotPoint, this.pivotPoint + this.dragTangent];
+			// this.target.planeNormalLine.Points = [this.pivotPoint, this.pivotPoint + this.planeNormal];
+			// this.target.tangentPlaneVisual.UpdatePlane(this.pivotPoint, this.planeNormal);
+			// this.target.axisPlane.UpdatePlane(new Point3D(0, 0, 0), axisInWorld);
 		}
 
 		public CmVector Drag(Point3D mousePosition)
@@ -602,66 +786,203 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 					this.lastPoint = point;
 					return default;
 				}
-				else
-				{
-					Vector3D axis = new(0, 1, 0);
 
-					Vector3D from = (Vector3D)this.lastPoint;
-					Vector3D to = (Vector3D)point;
+				Vector3D axis = new(0, 1, 0);
 
-					this.lastPoint = null;
+				Vector3D from = (Vector3D)this.lastPoint;
+				Vector3D to = (Vector3D)point;
 
-					double angle = Vector3D.AngleBetween(from, to);
+				this.lastPoint = null;
 
-					Vector3D cross = Vector3D.CrossProduct(from, to);
-					if (Vector3D.DotProduct(axis, cross) < 0)
-						angle = -angle;
+				double angle = Vector3D.AngleBetween(from, to);
 
-					// X rotation gizmo is always backwards...
-					if (this.Axis.X >= 1)
-						angle = -angle;
+				Vector3D cross = Vector3D.CrossProduct(from, to);
+				if (Vector3D.DotProduct(axis, cross) < 0)
+					angle = -angle;
 
-					float speed = 2;
+				// X rotation gizmo is always backwards...
+				if (this.Axis.X >= 1)
+					angle = -angle;
 
-					if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
-						speed = 4;
+				float speed = 2;
 
-					if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
-						speed = 0.5f;
+				if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+					speed = 4;
 
-					return CmVector.Multiply(this.Axis, (float)(angle * speed));
-				}
+				if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+					speed = 0.5f;
+
+				return CmVector.Multiply(this.Axis, (float)(angle * speed));
 			}
-			else
+			else // Linear drag
 			{
 				if (this.lastPoint == null)
 				{
 					this.lastPoint = mousePosition;
 					return default;
 				}
-				else
-				{
-					Vector3D delta = (Point3D)this.lastPoint - mousePosition;
-					this.lastPoint = mousePosition;
 
-					float speed = 0.5f;
+				Point3D? prevIntersection = this.RaycastOnPlane(
+					new Point(this.lastPoint.Value.X, this.lastPoint.Value.Y),
+					this.pivotPoint,
+					this.planeNormal);
 
-					if (Keyboard.IsKeyDown(Key.LeftShift))
-						speed = 2;
+				Point3D? currentIntersection = this.RaycastOnPlane(
+					new Point(mousePosition.X, mousePosition.Y),
+					this.pivotPoint,
+					this.planeNormal);
 
-					if (Keyboard.IsKeyDown(Key.LeftCtrl))
-						speed = 0.25f;
+				if (prevIntersection == null || currentIntersection == null)
+					return default;
 
-					double distPos = Math.Max(delta.X, delta.Y);
-					double distNeg = Math.Min(delta.X, delta.Y);
+				// [FOR DEBUGGING]
+				// Visualize the intersection point of the mouse ray on the plane
+				// this.target.intersectionSphere.Transform = new TranslateTransform3D(
+				//	 currentIntersection.Value.X,
+				//	 currentIntersection.Value.Y,
+				//	 currentIntersection.Value.Z);
 
-					double dist = distNeg;
-					if (Math.Abs(distPos) > Math.Abs(distNeg))
-						dist = distPos;
+				Vector3D movement = (Vector3D)(currentIntersection - prevIntersection);
+				this.lastPoint = mousePosition;
 
-					return CmVector.Multiply(this.Axis, (float)(-dist * speed));
-				}
+				double distanceAlongTangent = Vector3D.DotProduct(movement, this.dragTangent);
+
+				// Apply modifiers
+				float baseSensitivity = 100.0f;
+				float keyModifier = 1.0f;
+				if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+					keyModifier = 4.0f;
+				else if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+					keyModifier = 0.25f;
+
+				float rotationDegrees = (float)(distanceAlongTangent * baseSensitivity * keyModifier);
+				return CmVector.Multiply(this.Axis, -rotationDegrees);
 			}
 		}
+
+		private Point3D? RaycastOnPlane(Point screenPos, Point3D pivotPoint, Vector3D planeNormal)
+		{
+			// Get camera and viewport dimensions
+			var camera = (PerspectiveCamera)this.target.Viewport.Camera;
+			double w = this.target.Viewport.ActualWidth;
+			double h = this.target.Viewport.ActualHeight;
+
+			// Convert screen position to normalized device coords
+			double vx = (screenPos.X / w * 2.0) - 1.0;
+			double vy = 1.0 - (screenPos.Y / h * 2.0);
+
+			// Unproject the 2D viewport coordinates to 3D world coordinates
+			Point3D nearPoint = Unproject(new Point3D(vx, vy, 0), camera, w, h);
+			Point3D farPoint = Unproject(new Point3D(vx, vy, 1), camera, w, h);
+
+			// [FOR DEBUGGING]
+			// this.target.nearSphere.Transform = new TranslateTransform3D(nearPoint.X, nearPoint.Y, nearPoint.Z);
+			// this.target.farSphere.Transform = new TranslateTransform3D(farPoint.X, farPoint.Y, farPoint.Z);
+
+			// Create a ray from the camera position through the unprojected world point
+			Vector3D rayDirection = farPoint - nearPoint;
+			rayDirection.Normalize();
+
+			// Plane intersection
+			double denom = Vector3D.DotProduct(planeNormal, rayDirection);
+			if (Math.Abs(denom) < 1e-6)
+				return null; // Ray is parallel
+
+			double t = Vector3D.DotProduct(planeNormal, pivotPoint - nearPoint) / denom;
+			if (t < 0)
+				return null; // Intersection behind camera
+
+			return nearPoint + (rayDirection * t);
+		}
+
+		private static Point3D Unproject(Point3D point, PerspectiveCamera camera, double viewportWidth, double viewportHeight)
+		{
+			// Get the view matrix and include the camera's transform
+			Matrix3D viewMatrix = MathUtils.GetViewMatrix(camera);
+
+			if (camera.Transform != null)
+			{
+				Matrix3D transformMatrix = camera.Transform.Value;
+				transformMatrix.Invert();
+				viewMatrix = transformMatrix * viewMatrix;
+			}
+
+			// Get the projection matrix
+			Matrix3D projectionMatrix = MathUtils.GetProjectionMatrix(camera, viewportWidth / viewportHeight);
+
+			// Combine view and projection matrices
+			Matrix3D viewProjectionMatrix = viewMatrix * projectionMatrix;
+
+			if (!viewProjectionMatrix.HasInverse)
+				return new Point3D(double.NaN, double.NaN, double.NaN);
+
+			// Invert the combined matrix
+			viewProjectionMatrix.Invert();
+
+			// Transform the point using the inverted matrix
+			Point3D unprojectedPoint = viewProjectionMatrix.Transform(point);
+			return unprojectedPoint;
+		}
+	}
+
+	public static Matrix3D GetWorldMatrixFor(Visual3D? visual)
+	{
+		Matrix3D worldMatrix = Matrix3D.Identity;
+
+		// Traverse up the visual tree to accumulate transformations
+		while (visual != null)
+		{
+			if (visual.Transform != null)
+				worldMatrix.Append(visual.Transform.Value);
+
+			visual = VisualTreeHelper.GetParent(visual) as Visual3D;
+		}
+
+		return worldMatrix;
+	}
+}
+
+public class PlaneVisual3D : ModelVisual3D
+{
+	private readonly MeshGeometry3D mesh;
+	private readonly GeometryModel3D model;
+
+	public PlaneVisual3D()
+	{
+		this.mesh = new MeshGeometry3D();
+		this.model = new GeometryModel3D
+		{
+			Geometry = this.mesh,
+			Material = new DiffuseMaterial(new SolidColorBrush(Color.FromArgb(128, 255, 255, 255))),
+			BackMaterial = new DiffuseMaterial(new SolidColorBrush(Color.FromArgb(128, 255, 255, 255))),
+		};
+
+		this.Content = this.model;
+	}
+
+	public void UpdatePlane(Point3D point, Vector3D normal)
+	{
+		// Create a plane with a size of 1x1 units
+		double size = 1.0;
+
+		// Calculate the plane's basis vectors
+		Vector3D u = Vector3D.CrossProduct(new Vector3D(0, 1, 0), normal);
+		if (u.LengthSquared < 1e-6)
+			u = Vector3D.CrossProduct(new Vector3D(1, 0, 0), normal);
+
+		u.Normalize();
+		Vector3D v = Vector3D.CrossProduct(normal, u);
+		v.Normalize();
+
+		// Calculate the plane's corners
+		Point3D p0 = point + ((-u - v) * size);
+		Point3D p1 = point + ((u - v) * size);
+		Point3D p2 = point + ((u + v) * size);
+		Point3D p3 = point + ((-u + v) * size);
+
+		// Update the mesh
+		this.mesh.Positions = [p0, p1, p2, p3];
+		this.mesh.TriangleIndices = [0, 1, 2, 0, 2, 3];
+		this.mesh.Normals = [normal, normal, normal, normal];
 	}
 }


### PR DESCRIPTION
Fixes the inconsistent linear mouse dragging behaviour by implementing the following approach:
  1.  On mouse down (drag start), the following are computed:
    - A pivot point that represents the nearest point on the active gizmo axis' circle from the mouse cursor.
    - The plane normal that originates from the pivot point and goes towards the camera origin.
    - A tangent that is perpendicular to the axis circle's radius and part of the axis plane. (i.e., the tangent and the axis circle share the same plane).
      - **Explanation:** The tangent here acts as a "rail" onto which the mouse drag will take place to determine the rotation amount based on the current and previous mouse cursor projections. 
  2. The pivot point and the plane normal are used to create a so-called "tangent plane" onto which the tangent is also projected.
     - **Explanation:** In reality, the plane is perpendicular to the camera's look direction. This allows for consistent dragging behaviour.
  3. The current and previous mouse cursors are raycast onto the plane to get the intersections of the cursor onto the plane.