### PR TITLE
Optimizations to NPC and Equipment selector load times

### DIFF
--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml
@@ -204,16 +204,16 @@
 						</Grid.RowDefinitions>
 
 						<Border Width="38" Height="38" Background="#444444" Grid.RowSpan="3" CornerRadius="3"
-								Visibility="{Binding Icon, Converter={StaticResource NotNullToVisibilityConverter}}"
+								Visibility="{Binding Icon, Mode=OneTime, Converter={StaticResource NotNullToVisibilityConverter}}"
 								Margin="0, -4">
 							<Grid>
-								<Image Source="{Binding Icon, Converter={StaticResource Img}}" Margin="1"/>
+								<Image Source="{Binding Icon, Mode=OneTime, Converter={StaticResource Img}}" Margin="1"/>
 								<Image Source="/Assets/IconBorderSmall.png" Margin="-2, 0, -2, -4"/>
 							</Grid>
 						</Border>
 
 						<TextBlock Grid.Row="0" Grid.Column="1"
-								   Text="{Binding Name}"
+								   Text="{Binding Name, Mode=OneTime}"
 								   Margin="6, 0, 0, 0"
 								   FontWeight="DemiBold"
 								   Foreground="{DynamicResource MaterialDesignBody}"
@@ -229,18 +229,18 @@
 							</Grid.ColumnDefinitions>
 
 							<TextBlock Grid.Column="0"
-								   Text="{Binding EquipLevel, StringFormat=Lv.{0:D}}"
+								   Text="{Binding EquipLevel, Mode=OneTime, StringFormat=Lv.{0:D}}"
 								   TextTrimming="CharacterEllipsis"
 								   Margin="6,0,0,0"
 								   TextAlignment="Left"
-								   Visibility="{Binding EquipLevel, Converter={StaticResource NotZeroToVisibilityConverter}}"/>
+								   Visibility="{Binding EquipLevel, Mode=OneTime, Converter={StaticResource NotZeroToVisibilityConverter}}"/>
 
 							<TextBlock Grid.Column="1"
-								   Text="{Binding Description}"
+								   Text="{Binding Description, Mode=OneTime}"
 								   TextTrimming="CharacterEllipsis"
 								   Margin="6,0,0,0"
 								   TextAlignment="Left"
-								   Visibility="{Binding Description, Converter={StaticResource NotEmptyToVisibilityConverter}}"/>
+								   Visibility="{Binding Description, Mode=OneTime, Converter={StaticResource NotEmptyToVisibilityConverter}}"/>
 							
 						</Grid>
 						
@@ -250,11 +250,11 @@
 									   Fill="Transparent" >
 							<ToolTipService.ToolTip>
 								<StackPanel Orientation="Vertical">
-									<TextBlock Text="{Binding Name}" FontWeight="DemiBold"/>
-									<TextBlock Text="{Binding Description}"
+									<TextBlock Text="{Binding Name, Mode=OneTime}" FontWeight="DemiBold"/>
+									<TextBlock Text="{Binding Description, Mode=OneTime}"
 											   MaxWidth="200"
 											   TextWrapping="Wrap"
-											   Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+											   Visibility="{Binding Description, Mode=OneTime, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
 									<Grid Grid.Column="1" Grid.Row="2" Margin="0, 3, 0, 0">
 										<Grid.ColumnDefinitions>
@@ -269,19 +269,19 @@
 											<RowDefinition/>
 										</Grid.RowDefinitions>
 
-										<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="EquipmentSelector_ItemId" HorizontalAlignment="Right" Visibility="{Binding RowId, Converter={StaticResource NotZeroToVisibility}}" Margin="0, 0, 6, 0"/>
-										<TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding RowId}" Visibility="{Binding RowId, Converter={StaticResource NotZeroToVisibility}}"/>
+										<XivToolsWpf:TextBlock Grid.Column="0" Grid.Row="0" Key="EquipmentSelector_ItemId" HorizontalAlignment="Right" Visibility="{Binding RowId, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}" Margin="0, 0, 6, 0"/>
+										<TextBlock Grid.Column="1" Grid.Row="0" Text="{Binding RowId, Mode=OneTime}" Visibility="{Binding RowId, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}"/>
 
-										<TextBlock Grid.Column="0" Grid.Row="1" Text="Lv." HorizontalAlignment="Right" Visibility="{Binding EquipLevel, Converter={StaticResource NotZeroToVisibility}}" Margin="0, 0, 6, 0"/>
-										<TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding EquipLevel}" Visibility="{Binding EquipLevel, Converter={StaticResource NotZeroToVisibility}}"/>
+										<TextBlock Grid.Column="0" Grid.Row="1" Text="Lv." HorizontalAlignment="Right" Visibility="{Binding EquipLevel, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}" Margin="0, 0, 6, 0"/>
+										<TextBlock Grid.Column="1" Grid.Row="1" Text="{Binding EquipLevel, Mode=OneTime}" Visibility="{Binding EquipLevel, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}"/>
 										
 										<TextBlock Grid.Column="0" Grid.Row="2" Text="Model:" HorizontalAlignment="Right" Margin="0, 0, 6, 0"/>
 										<StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="2">
-											<TextBlock Text="{Binding ModelSet}" Visibility="{Binding ModelSet, Converter={StaticResource NotZeroToVisibility}}"/>
-											<TextBlock Text=", " Visibility="{Binding ModelSet, Converter={StaticResource NotZeroToVisibility}}"/>
-											<TextBlock Text="{Binding ModelBase}"/>
+											<TextBlock Text="{Binding ModelSet, Mode=OneTime}" Visibility="{Binding ModelSet, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}"/>
+											<TextBlock Text=", " Visibility="{Binding ModelSet, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}"/>
+											<TextBlock Text="{Binding ModelBase, Mode=OneTime}"/>
 											<TextBlock Text=", "/>
-											<TextBlock Text="{Binding ModelVariant}"/>
+											<TextBlock Text="{Binding ModelVariant, Mode=OneTime}"/>
 										</StackPanel>
 
 										<TextBlock Grid.Column="0" Grid.Row="2" Text="Modded: " HorizontalAlignment="Left" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}"/>

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -189,35 +189,28 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 	protected override int Compare(IItem itemA, IItem itemB)
 	{
 		if (itemA.IsFavorite && !itemB.IsFavorite)
-		{
 			return -1;
-		}
-		else if (!itemA.IsFavorite && itemB.IsFavorite)
-		{
+
+		if (!itemA.IsFavorite && itemB.IsFavorite)
 			return 1;
-		}
 
 		// Push the Emperor's New Fists to the top of the list for weapons.
 		if (this.IsWeaponSlot)
 		{
 			if (itemA == ItemUtility.EmperorsNewFists && itemB != ItemUtility.EmperorsNewFists)
-			{
 				return -1;
-			}
-			else if (itemA != ItemUtility.EmperorsNewFists && itemB == ItemUtility.EmperorsNewFists)
-			{
+
+			if (itemA != ItemUtility.EmperorsNewFists && itemB == ItemUtility.EmperorsNewFists)
 				return 1;
-			}
 		}
 
-		switch (this.SortMode)
+		return this.SortMode switch
 		{
-			case SortModes.Name: return itemA.Name.CompareTo(itemB.Name);
-			case SortModes.Row: return itemA.RowId.CompareTo(itemB.RowId);
-			case SortModes.Level: return itemA.EquipLevel.CompareTo(itemB.EquipLevel);
-		}
-
-		throw new NotImplementedException($"Sort mode {this.SortMode} not implemented");
+			SortModes.Name => itemA.Name.CompareTo(itemB.Name),
+			SortModes.Row => itemA.RowId.CompareTo(itemB.RowId),
+			SortModes.Level => itemA.EquipLevel.CompareTo(itemB.EquipLevel),
+			_ => throw new NotImplementedException($"Sort mode {this.SortMode} not implemented"),
+		};
 	}
 
 	protected override bool Filter(IItem item, string[]? search)

--- a/Anamnesis/Actor/Views/NpcSelector.xaml
+++ b/Anamnesis/Actor/Views/NpcSelector.xaml
@@ -117,9 +117,9 @@
 								Background="#444444"
 								Grid.RowSpan="2"
 								CornerRadius="3"
-								Visibility="{Binding Icon, Converter={StaticResource NotNullToVisibilityConverter}}">
+								Visibility="{Binding Icon, Mode=OneTime, Converter={StaticResource NotNullToVisibilityConverter}}">
 							<Grid>
-								<Image Source="{Binding Icon, Converter={StaticResource Img}}"
+								<Image Source="{Binding Icon, Mode=OneTime, Converter={StaticResource Img}}"
 									   Margin="1" />
 								<Image Source="/Assets/IconBorderSmall.png"
 									   Margin="-2, 0, -2, -4" />
@@ -132,7 +132,7 @@
 									Grid.Row="1"
 									Grid.Column="1"
 									Margin="3, 0, 0, 0"
-									Visibility="{Binding ModelCharaRow, Converter={StaticResource NotZeroToVisibility}}">
+									Visibility="{Binding ModelCharaRow, Mode=OneTime, Converter={StaticResource NotZeroToVisibility}}">
 
 							<xivToolsWpf:TextBlock Key="Character_Actor_Model"
 												   Style="{StaticResource Label}"
@@ -158,22 +158,22 @@
 								   Fill="Transparent" >
 							<ToolTipService.ToolTip>
 								<StackPanel Orientation="Vertical">
-									<TextBlock Text="{Binding Name}"
+									<TextBlock Text="{Binding Name, Mode=OneTime}"
 											   FontWeight="Bold"
 											   Visibility="{Binding HasName, Converter={StaticResource B2V}}" />
-									
-									<TextBlock Text="{Binding Description}" Visibility="{Binding Description, Converter={StaticResource NotNullToVisibilityConverter}}"/>
+
+									<TextBlock Text="{Binding Description, Mode=OneTime}" Visibility="{Binding Description, Mode=OneTime, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
 									<StackPanel Orientation="Horizontal">
-										<xivToolsWpf:TextBlock Text="{Binding TypeName}" />
+										<xivToolsWpf:TextBlock Text="{Binding TypeName, Mode=OneTime}" />
 										<xivToolsWpf:TextBlock Text=": #" Margin="0" />
-										<TextBlock Text="{Binding RowId}" />
+										<TextBlock Text="{Binding RowId, Mode=OneTime}" />
 									</StackPanel>
 
 									<StackPanel Orientation="Horizontal">
 										<xivToolsWpf:TextBlock Key="Character_Actor_Model"/>
 										<xivToolsWpf:TextBlock Text=": #" Margin="0" />
-										<TextBlock Text="{Binding ModelCharaRow}" Margin="0" />
+										<TextBlock Text="{Binding ModelCharaRow, Mode=OneTime}" Margin="0" />
 									</StackPanel>
 
 									<Grid Grid.Column="1" Grid.Row="2" Visibility="{Binding Mod, Converter={StaticResource NotNullToVisibilityConverter}}" Margin="3, 0, 0, 0">
@@ -183,7 +183,7 @@
 										</Grid.ColumnDefinitions>
 
 										<TextBlock Grid.Column="0" Text="Modded: " HorizontalAlignment="Left" />
-										<TextBlock Grid.Column="1" Text="{Binding Mod.ModPack.Name}" HorizontalAlignment="Left" />
+										<TextBlock Grid.Column="1" Text="{Binding Mod.ModPack.Name, Mode=OneTime}" HorizontalAlignment="Left" />
 									</Grid>
 								</StackPanel>
 							</ToolTipService.ToolTip>

--- a/Anamnesis/Actor/Views/NpcSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/NpcSelector.xaml.cs
@@ -11,6 +11,7 @@ using Anamnesis.Styles.Drawers;
 using Anamnesis.Utils;
 using PropertyChanged;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
 using XivToolsWpf;
@@ -86,41 +87,13 @@ public partial class NpcSelector : NpcSelectorDrawer
 		if (!itemA.IsFavorite && itemB.IsFavorite)
 			return 1;
 
-		// Then Residents
-		if (itemA is ResidentNpc && itemB is not ResidentNpc)
-			return -1;
+		int priorityA = GetNpcSortPriority(itemA);
+		int priorityB = GetNpcSortPriority(itemB);
 
-		if (itemA is not ResidentNpc && itemB is ResidentNpc)
-			return 1;
+		if (priorityA != priorityB)
+			return priorityA.CompareTo(priorityB);
 
-		// Then Mounts
-		if (itemA is Mount && itemB is not Mount)
-			return -1;
-
-		if (itemA is not Mount && itemB is Mount)
-			return 1;
-
-		// Then Minions
-		if (itemA is Companion && itemB is not Companion)
-			return -1;
-
-		if (itemA is not Companion && itemB is Companion)
-			return 1;
-
-		// Then Battle NPCs
-		if (itemA is BattleNpc && itemB is not BattleNpc)
-			return -1;
-
-		if (itemA is not BattleNpc && itemB is BattleNpc)
-			return 1;
-
-		// Then Ornaments
-		if (itemA is Ornament && itemB is not Ornament)
-			return -1;
-
-		if (itemA is not Ornament && itemB is Ornament)
-			return 1;
-
+		// Fallback to RowId comparison if priorities are equal
 		return -itemB.RowId.CompareTo(itemA.RowId);
 	}
 
@@ -220,6 +193,20 @@ public partial class NpcSelector : NpcSelectorDrawer
 			return;
 
 		await ClipboardUtility.CopyToClipboardAsync(this.Value.ToStringKey());
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static int GetNpcSortPriority(INpcBase npc)
+	{
+		return npc switch
+		{
+			ResidentNpc => 0,
+			Mount => 1,
+			Companion => 2,
+			BattleNpc => 3,
+			Ornament => 4,
+			_ => 5,
+		};
 	}
 
 	[AddINotifyPropertyChangedInterface]


### PR DESCRIPTION
The slowdown was traced to the favorites service, as reported by a user on Discord. For the NPCs selector, the `IsFavourite` method is being invoked approximately 2 million times, with each lookup operating at linear time complexity (O(n)) due to list-based presence checks. To address the issue, I introduced hash sets to leverage their O(1) lookup times, substantially improving the initial load times. Additionally, I optimized certain bindings by setting them to "OneTime" bind mode as these are static entities and will not change name, description, model, etc. during runtime.