### PR TITLE
Fixed scale slider preventing value decrease on multi-bone selection

### DIFF
--- a/Anamnesis/Views/TransformEditor.xaml
+++ b/Anamnesis/Views/TransformEditor.xaml
@@ -34,7 +34,7 @@
 				<XivToolsWpf:TextBlock Key="Pose_Scale"/>
 			</GroupBox.Header>
 
-			<controls:VectorEditorNew Value="{Binding Scale}" LayoutStyle="Compact" Minimum="0" Maximum="10" DefaultValue="1" TickFrequency="0.01" DecimalPlaces="{Binding Settings.SliderPrecision, Mode=OneWay}" EnableStepButtons="True" SliderMode="Relative"
+			<controls:VectorEditorNew x:Name="ScaleVectorEditor" Value="{Binding Scale}" LayoutStyle="Compact" Minimum="0" Maximum="10" DefaultValue="1" TickFrequency="0.01" DecimalPlaces="{Binding Settings.SliderPrecision, Mode=OneWay}" EnableStepButtons="True" SliderMode="Relative"
 									  CanLink="{Binding CanLinkScale, Mode=OneWay}" Linked="{Binding ScaleLinked, Mode=OneWay}" SliderType="{Binding Settings.BoneScaleSliderType, Mode=OneWay}" Margin="-3, 3, -2, 0"
 									  ShowSliderThumb="{Binding Settings.ShowSliderThumb, Mode=OneWay}"/>
 		</GroupBox>

--- a/Anamnesis/Views/TransformEditor.xaml.cs
+++ b/Anamnesis/Views/TransformEditor.xaml.cs
@@ -431,6 +431,7 @@ public partial class TransformEditor : UserControl, INotifyPropertyChanged
 			Application.Current.Dispatcher.Invoke(() =>
 			{
 				this.SetInitialValues();
+				this.ScaleVectorEditor.Minimum = this.Skeleton != null && this.Skeleton.SelectedBones.Count() > 1 ? null : 0;
 				this.RaisePropertyChanged(string.Empty);
 			});
 		}


### PR DESCRIPTION
This pull request fixes the issue that was brought up on Discord where you can't decrease scaling when you have multiple bone selected. Now, on multi-bone selection, the slider control's minimum value restricton is reset to null to allow users to decrease scaling.