### PR TITLE
Implemented changes to Item favorites.

### DIFF
--- a/Anamnesis/Actor/Items/ChocoboSkinItem.cs
+++ b/Anamnesis/Actor/Items/ChocoboSkinItem.cs
@@ -17,6 +17,7 @@ public class ChocoboSkinItem : IItem
 		this.Description = mount.Description;
 		this.ModelVariant = variant;
 		this.Icon = mount.Icon;
+		this.RowId = variant;
 	}
 
 	public string Name { get; private set; }
@@ -35,7 +36,7 @@ public class ChocoboSkinItem : IItem
 	public Classes EquipableClasses => Classes.All;
 	public bool IsWeapon => false;
 	public Mod? Mod => null;
-	public uint RowId => 0;
+	public uint RowId { get; private set; }
 	public byte EquipLevel => 0;
 
 	public bool IsFavorite
@@ -48,6 +49,8 @@ public class ChocoboSkinItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.ChocoboSkin;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => slot == ItemSlots.Legs;

--- a/Anamnesis/Actor/Items/DummyItem.cs
+++ b/Anamnesis/Actor/Items/DummyItem.cs
@@ -10,14 +10,15 @@ using System.Runtime.CompilerServices;
 
 public class DummyItem : IItem
 {
-	public DummyItem(ushort modelSet, ushort modelBase, ushort modelVariant)
+	public DummyItem(uint rowId, ushort modelSet, ushort modelBase, ushort modelVariant)
 	{
+		this.RowId = rowId;
 		this.ModelSet = modelSet;
 		this.ModelBase = modelBase;
 		this.ModelVariant = modelVariant;
 	}
 
-	public uint RowId => 0;
+	public uint RowId { get; private set; }
 	public bool IsWeapon => true;
 	public bool HasSubModel => false;
 	public string Name => LocalizationService.GetString("Item_Unknown");
@@ -47,6 +48,7 @@ public class DummyItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.CustomEquipment;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public virtual bool FitsInSlot(ItemSlots slot) => true;

--- a/Anamnesis/Actor/Items/DummyNoneItem.cs
+++ b/Anamnesis/Actor/Items/DummyNoneItem.cs
@@ -39,6 +39,7 @@ public class DummyNoneItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => true;

--- a/Anamnesis/Actor/Items/EmperorsAccessoryItem.cs
+++ b/Anamnesis/Actor/Items/EmperorsAccessoryItem.cs
@@ -19,7 +19,7 @@ public class EmperorsAccessoryItem : IItem
 	public ushort ModelBase => 53;
 	public ushort ModelVariant => 1;
 	public ushort ModelSet => 0;
-	public uint RowId => 0;
+	public uint RowId => 52;
 	public bool IsWeapon => false;
 	public bool HasSubModel => false;
 
@@ -41,6 +41,7 @@ public class EmperorsAccessoryItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => (slot & ItemSlots.Accessories) != 0;

--- a/Anamnesis/Actor/Items/EmperorsEquipItem.cs
+++ b/Anamnesis/Actor/Items/EmperorsEquipItem.cs
@@ -18,7 +18,7 @@ public class EmperorsEquipItem : IItem
 	public ushort ModelBase => 279;
 	public ushort ModelVariant => 1;
 	public ushort ModelSet => 0;
-	public uint RowId => 0;
+	public uint RowId => 279;
 	public bool IsWeapon => false;
 	public bool HasSubModel => false;
 	public ulong SubModel => 0;
@@ -39,6 +39,7 @@ public class EmperorsEquipItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => (slot & ItemSlots.Armor) != 0;

--- a/Anamnesis/Actor/Items/InvisibleBodyItem.cs
+++ b/Anamnesis/Actor/Items/InvisibleBodyItem.cs
@@ -27,7 +27,7 @@ public class InvisibleBodyItem : IItem
 	public Classes EquipableClasses => Classes.All;
 	public bool IsWeapon => false;
 	public Mod? Mod => null;
-	public uint RowId => 0;
+	public uint RowId => 2;
 	public byte EquipLevel => 0;
 
 	public bool IsFavorite
@@ -40,6 +40,7 @@ public class InvisibleBodyItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => slot == ItemSlots.Body;

--- a/Anamnesis/Actor/Items/InvisibleHeadItem.cs
+++ b/Anamnesis/Actor/Items/InvisibleHeadItem.cs
@@ -27,7 +27,7 @@ public class InvisibleHeadItem : IItem
 	public Classes EquipableClasses => Classes.All;
 	public bool IsWeapon => false;
 	public Mod? Mod => null;
-	public uint RowId => 0;
+	public uint RowId => 1;
 	public byte EquipLevel => 0;
 
 	public bool IsFavorite
@@ -40,6 +40,8 @@ public class InvisibleHeadItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => slot == ItemSlots.Head;

--- a/Anamnesis/Actor/Items/NpcBodyItem.cs
+++ b/Anamnesis/Actor/Items/NpcBodyItem.cs
@@ -18,7 +18,7 @@ public class NpcBodyItem : IItem
 	public ushort ModelSet => 0;
 	public ushort ModelBase => 9903;
 	public ushort ModelVariant => 1;
-	public uint RowId => 0;
+	public uint RowId => 9903;
 	public bool IsWeapon => false;
 	public bool HasSubModel => false;
 	public ulong SubModel => 0;
@@ -39,6 +39,8 @@ public class NpcBodyItem : IItem
 	public bool IsOwned { get; set; }
 
 	public ItemCategories Category => ItemCategories.Standard;
+
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.OneOffItem;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot) => (slot & (ItemSlots.Body | ItemSlots.Feet | ItemSlots.Hands | ItemSlots.Legs)) != 0;

--- a/Anamnesis/Actor/Utilities/ItemUtility.cs
+++ b/Anamnesis/Actor/Utilities/ItemUtility.cs
@@ -65,6 +65,14 @@ public static class ItemUtility
 		return new DummyItem(rowId, modelSet, modelBase, modelVariant);
 	}
 
+	/// <summary>
+	/// Attempts to locate an item based on the different properties associated with favoriting items
+	/// It will first use the prefix to decide how to locate the item.
+	/// - For chocobo skins, simply return one or the other based on the rowId.
+	/// - For buddy equipment, get the buddy equip and then use the buddyEquipSlot parameter to decide which slot to return.
+	/// - For one-off items, simply return the right item based on the rowId.
+	/// - For all else, return the item from its GameData list based on its rowId.
+	/// </summary>
 	public static IItem? GetItemByItemFavoriteProperties(uint favoritePrefix, uint rowId, uint buddyEquipSlot)
 	{
 		ItemFavoriteCategory favoriteItemCategory = (ItemFavoriteCategory)favoritePrefix;
@@ -143,6 +151,11 @@ public static class ItemUtility
 			return uint.Parse(favoriteItemCategoryPrefix.ToString() + item.RowId.ToString());
 		}
 	}
+
+	/// <summary>
+	/// Used as a simple method to compare two IItem objects by the properties that make up the
+	/// composite Id for favoriting. This is only used to remove items from the respective favorites array.
+	/// </summary>
 	public static bool CompareItemFavoritesByCompositeId<T>(T x, T y)
 	{
 		if (x == null || y == null)

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -149,6 +149,11 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 		HotkeyService.ClearHotkeyHandler("AppearancePage.ClearEquipment", this);
 	}
 
+	/// <summary>
+	/// Initializes the selector with items.
+	/// 
+	/// Adding items to this method? Be sure to mind FavoriteItemCategories. 
+	/// </summary>
 	protected override Task LoadItems()
 	{
 		if (this.actor?.IsChocobo == true)

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -123,6 +123,12 @@ public partial class ItemView : UserControl
 			if (!isNormalCategory)
 				return false;
 
+			// Invalid if we are not in the None category for favorites.
+			// Previously, the rowId == 0 would catch this, but since we're using non-zero values for 
+			// special items, we don't want the context menu for those.
+			if(!this.Item.FavoriteItemCategory.Equals(ItemFavoriteCategory.None)) 
+				return false;
+
 			return true;
 		}
 	}

--- a/Anamnesis/GameData/Excel/Equipment.cs
+++ b/Anamnesis/GameData/Excel/Equipment.cs
@@ -97,6 +97,9 @@ public class Equipment : IItem, IRow
 	[JsonIgnore] public ItemCategories Category => ItemCategories.CustomEquipment;
 
 	/// <inheritdoc/>
+	[JsonIgnore] public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.CustomEquipment;
+
+	/// <inheritdoc/>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public bool FitsInSlot(ItemSlots slot)
 	{

--- a/Anamnesis/GameData/Excel/Item.cs
+++ b/Anamnesis/GameData/Excel/Item.cs
@@ -105,6 +105,9 @@ public readonly unsafe struct Item(ExcelPage page, uint offset, uint row)
 	/// <summary>Gets the item category.</summary>
 	public ItemCategories Category => GameDataService.GetCategory(this);
 
+	/// <inheritdoc/>
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.None;
+
 	/// <summary>
 	/// Creates a new instance of the <see cref="Item"/> struct.
 	/// </summary>

--- a/Anamnesis/GameData/Excel/Perform.cs
+++ b/Anamnesis/GameData/Excel/Perform.cs
@@ -85,6 +85,9 @@ public readonly struct Perform(ExcelPage page, uint offset, uint row)
 	/// <inheritdoc/>
 	public readonly ItemCategories Category => ItemCategories.Performance;
 
+	/// <inheritdoc/>
+	public ItemFavoriteCategory FavoriteItemCategory => ItemFavoriteCategory.Perform;
+
 	/// <summary>
 	/// Creates a new instance of the <see cref="Perform"/> struct.
 	/// </summary>

--- a/Anamnesis/GameData/Interfaces/IItem.cs
+++ b/Anamnesis/GameData/Interfaces/IItem.cs
@@ -72,6 +72,9 @@ public interface IItem
 	/// <summary>Gets the item's category.</summary>
 	ItemCategories Category { get; }
 
+	/// <summary>Get the item's favorite category and favorite prefix.</summary>
+	ItemFavoriteCategory FavoriteItemCategory { get; }
+
 	/// <summary>Gets the TexTools mod associated with the item.</summary>
 	Mod? Mod { get; }
 

--- a/Anamnesis/GameData/ItemFavoriteCategory.cs
+++ b/Anamnesis/GameData/ItemFavoriteCategory.cs
@@ -1,0 +1,22 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.GameData;
+
+/// <summary>
+/// Associates item groupings with ID prefixes for easy identification of favorites in the general "items" array.
+/// These groupings are loosely associated with items added to the EquipmentSelector via its LoadItems() method.
+/// 
+/// Use a 5 digit prefix to prevent collisions with existing game item data, which currently has rowIds up to ID ~48800.
+/// Using prefixes that start with 42000, since max uint is 4,294,967,295. This should allow for 99,999 prefixed items.
+/// There is no prefix for None, which is used for normal items.
+/// </summary>
+public enum ItemFavoriteCategory
+{
+	None,
+	ChocoboSkin = 42000,
+	BuddyEquipment = 42001,
+	OneOffItem = 42002,
+	CustomEquipment = 42003,
+	Perform = 42004
+}

--- a/Anamnesis/GameData/Sheets/EquipmentSheet.cs
+++ b/Anamnesis/GameData/Sheets/EquipmentSheet.cs
@@ -30,7 +30,9 @@ public class EquipmentSheet : ISheet<Equipment>
 
 			foreach (Equipment equipment in rows)
 			{
-				this.rows.Add(index, equipment);
+				// Give a RowId for this custom equipment.
+				equipment.RowId = index;
+				this.rows.Add(equipment.RowId, equipment);
 				index++;
 			}
 		}

--- a/Anamnesis/Serialization/Converters/IItemConverter.cs
+++ b/Anamnesis/Serialization/Converters/IItemConverter.cs
@@ -35,15 +35,56 @@ public class IItemConverter : JsonConverter<IItem>
 		return (modelSet, modelBase, modelVariant);
 	}
 
+	/// <summary>
+	/// Splits a string based on the colon (:) character. Return a tuple such that:
+	/// - The first part represents our favorite item prefix.
+	/// - The second part represents the item's rowId, however it's derived.
+	/// - The third (optional) part is for buddy equipment, representing the slot that was favorited in the set.
+	/// </summary>
+	public static (uint prefix, uint rowId, uint buddySlot) SplitPrefixedString(string str)
+	{
+		string[] parts = str.Split(":", StringSplitOptions.RemoveEmptyEntries);
+
+		uint prefix = uint.Parse(parts[0].Trim());
+		uint rowId = uint.Parse(parts[1].Trim());
+		uint buddySlot = 0;
+
+		if (parts.Length == 3)
+		{
+			buddySlot = ushort.Parse(parts[2].Trim());
+		}
+
+		return (prefix, rowId, buddySlot);
+	}
+
+	/// <summary>
+	/// Reads a string and attempts to lookup the item it represents. There are three schemes:
+	/// - #, #, # - Items which are favorited using their base, variant, set notation.
+	/// - #:#:# - Items which are favorited using their prefix:rowId:buddySlot notation.
+	/// - # - Items which are favorited using just their rowId, in the case of regular equipment.
+	/// </summary>
 	public static IItem FromString(string str)
 	{
 		if (str.Contains(","))
 		{
+			// For favorite items stored as #,#,#.
 			(ushort modelSet, ushort modelBase, ushort modelVariant) = SplitString(str);
-			return ItemUtility.GetDummyItem(modelSet, modelBase, modelVariant);
+			return ItemUtility.GetDummyItem(0, modelSet, modelBase, modelVariant);
+		}
+		else if(str.Contains(":"))
+		{
+			// For favorite items stored as prefix:rowId:buddySlot.
+			(uint prefix, uint rowId, uint buddySlot) = SplitPrefixedString(str);
+			IItem? item = ItemUtility.GetItemByItemFavoriteProperties(prefix, rowId, buddySlot);
+
+			if (item == null)
+				throw new Exception("Error retrieving favorited item from game data.");
+
+			return item;
 		}
 		else
 		{
+			// For favorite items stored as just a rowId.
 			if (GameDataService.Items == null)
 				throw new Exception("No items in game data service");
 
@@ -63,9 +104,25 @@ public class IItemConverter : JsonConverter<IItem>
 
 	public override void Write(Utf8JsonWriter writer, IItem value, JsonSerializerOptions options)
 	{
-		if (value.RowId != 0)
+		// For items with a non-zero rowId OR are in a non-none Favorite Item Category.
+		// Otherwise, write out the value in #, #, # notation.
+		if (value.RowId != 0 || !value.FavoriteItemCategory.Equals(ItemFavoriteCategory.None))
 		{
-			writer.WriteStringValue($"{value.RowId}");
+			uint favoriteItemCategoryPrefix = (uint)value.FavoriteItemCategory;
+
+			switch(value.FavoriteItemCategory)
+			{
+				case ItemFavoriteCategory.None:
+					writer.WriteStringValue($"{value.RowId}");
+					break;
+				case ItemFavoriteCategory.BuddyEquipment:
+					uint buddyEquipSlotNum = ((GameData.Excel.BuddyEquip.BuddyItem)value).GetBuddyEquipSlotIntAlias();
+					writer.WriteStringValue($"{favoriteItemCategoryPrefix}:{value.RowId}:{buddyEquipSlotNum}");
+					break;
+				default:
+					writer.WriteStringValue($"{favoriteItemCategoryPrefix}:{value.RowId}");
+					break;
+			}
 		}
 		else
 		{

--- a/Anamnesis/Services/FavoritesService.cs
+++ b/Anamnesis/Services/FavoritesService.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.Services;
 
+using Anamnesis.Actor.Utilities;
 using Anamnesis.Files;
 using Anamnesis.GameData;
 using Anamnesis.GameData.Excel;
@@ -78,7 +79,7 @@ public class FavoritesService : ServiceBase<FavoritesService>
 			return lookupTable.Contains(iNpcBase.RowId);
 
 		if (item is IItem iItem)
-			return lookupTable.Contains(iItem.RowId);
+			return lookupTable.Contains(ItemUtility.GetCompositeIdForItemFavorite(iItem));
 
 		return false;
 	}
@@ -101,7 +102,15 @@ public class FavoritesService : ServiceBase<FavoritesService>
 		}
 		else
 		{
-			curInstCollection.Remove(item);
+			
+			if(item is IItem)
+			{
+				curInstCollection.RemoveAll(entry => ItemUtility.CompareItemFavoritesByCompositeId(entry, item));
+			}
+			else
+			{
+				curInstCollection.Remove(item);
+			}
 			RemoveFromLookupTable(item, lookupTable);
 		}
 
@@ -146,7 +155,7 @@ public class FavoritesService : ServiceBase<FavoritesService>
 			}
 		}
 
-		this.itemIds = [.. this.Current.Items.Select(i => i.RowId)];
+		this.itemIds = [.. this.Current.Items.Select(i => ItemUtility.GetCompositeIdForItemFavorite(i))];
 		this.dyeIds = [.. this.Current.Dyes.Select(d => d.RowId)];
 		this.modelIds = [.. this.Current.Models.Select(m => m.RowId)];
 		this.glassesIds = [.. this.Current.Glasses.Select(g => g.RowId)];
@@ -188,7 +197,7 @@ public class FavoritesService : ServiceBase<FavoritesService>
 		switch (item)
 		{
 			case IItem iItem:
-				lookupTable.Add(iItem.RowId);
+				lookupTable.Add(ItemUtility.GetCompositeIdForItemFavorite(iItem));
 				break;
 			case IDye iDye:
 				lookupTable.Add(iDye.RowId);
@@ -209,7 +218,7 @@ public class FavoritesService : ServiceBase<FavoritesService>
 		switch (item)
 		{
 			case IItem iItem:
-				lookupTable.Remove(iItem.RowId);
+				lookupTable.Remove(ItemUtility.GetCompositeIdForItemFavorite(iItem));
 				break;
 			case IDye iDye:
 				lookupTable.Remove(iDye.RowId);


### PR DESCRIPTION
This pull requests aims to resolve the issue brought up on Discord the other day.

User-facing changes
- Fixed issue with favoriting special items causing all special items to show as favorited.
- Added the ability to favorite individual chocobo barding pieces.
- Changed the way item-type favorites are stored and retrieved to allow items of different sub-types (like gear, performance items, and props), and the same internal ID, to not interfere with each other.


# Change Log
## Resolved issue where when favoriting one special item, ALL of the special and one-off items would show marked as being a favorite.
The issue here was that the object used for the Equipment.json items had the rowId hardcoded to 0. The FavoritesService uses rowId to determine if something is favorited or not, therefore would show all of the items of any sub-type with rowId 0 as being favoriteded.

## Allow BuddyEquip BuddyItems to be favorited.
The get and set for its IsFavorited property weren't populated, so I did it!

## Created a system for composite Ids for favoriting IItem based items to allow for  uniqueness across different item types.
Because ALL items are stored in the same favorites bucket, and because rowIds are non-unique between different sheets, there had to be a way to differentiate them. For example, in the current system, favoriting a Perform item with rowId 1 would make it so rowId 1 in other sheets would also appear to be favorited.

I decided to add a prefix to these rowIds only for the FavoriteService lookup sets. I decided on a prefix that started with a 5 digit number, 42000. I picked this because max uint is 4,294,967,295, so we would be able to prefix 100,000 items. Normal items would not get prefixed, as they have the greater quantity. Items like special equipment, perform items, chocobo skins, buddy equips, and one-off items would get prefixed.

(There are currently ~1312 special items.)

## Added an arbitrary rowId to one-off items like None, Emperor's and NPC.
This is to accommodate the change above.
