### PR TITLE
Fixed regression to prior multi-bone scaling fix

### DIFF
--- a/Anamnesis/Styles/Controls/VectorEditorNew.xaml
+++ b/Anamnesis/Styles/Controls/VectorEditorNew.xaml
@@ -179,7 +179,7 @@
 
 				<!-- Input control (Z) -->
 				<Label Grid.Column="4"  Content="Z:" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="{StaticResource MaterialDesignBodyLight}" FontSize="10" Margin="0, 0, -4, 2"/>
-				<local:SliderInputBox Grid.Column="5" Value="{Binding Z, Mode=TwoWay}" Minimum="{Binding Minimum}" Maximum="{Binding Maximum}" DefaultValue="{Binding DefaultValue}" TickFrequency="{Binding TickFrequency}"
+				<local:SliderInputBox Grid.Column="5" Value="{Binding Z, Mode=TwoWay}" Minimum="{Binding Minimum, Mode=OneWay}" Maximum="{Binding Maximum, Mode=OneWay}" DefaultValue="{Binding DefaultValue}" TickFrequency="{Binding TickFrequency}"
 									  Suffix="{Binding Suffix, Mode=OneWay}" EnableStepButtons="False" DecimalPlaces="{Binding DecimalPlaces, Mode=OneWay}" Margin="2, 0, 2, 2" BorderColor="{Binding ZColor, Mode=OneWay}"
 									  OverflowBehavior="{Binding OverflowBehavior, Mode=OneWay}" ShowSliderThumb="{Binding ShowSliderThumb, Mode=OneWay}" SliderMode="{Binding SliderMode, Mode=OneWay}" SliderType="{Binding SliderType, Mode=OneWay}"/>
 			</Grid>

--- a/Anamnesis/Views/TransformEditor.xaml.cs
+++ b/Anamnesis/Views/TransformEditor.xaml.cs
@@ -431,7 +431,7 @@ public partial class TransformEditor : UserControl, INotifyPropertyChanged
 			Application.Current?.Dispatcher.Invoke(() =>
 			{
 				this.SetInitialValues();
-				this.ScaleVectorEditor.Minimum = this.Skeleton != null && this.Skeleton.SelectedBones.Count() > 1 ? null : "0";
+				this.ScaleVectorEditor.Minimum = this.Skeleton != null && this.Skeleton.SelectedBones.Count() > 1 ? "" : "0";
 				this.RaisePropertyChanged(string.Empty);
 			});
 		}


### PR DESCRIPTION
_Note: The changes to `SliderInputBox.xaml.cs` and `VectorEditorNew.xaml` are not related to the regression. The ones in SliderInputBox were done as a precaution to ensure the correct Min/Max values are used everywhere._

Regression was caused as a result of changing Min/Max property type from `decimal?` to `string?`. The Binder class' Register method will not invoke the callback as `null` fails the `e.NewValue is TValue value` check. Changing `null` to `""` in `TransformEditor.xaml.cs` fixes the regression.