### PR TITLE
Changes to application versioning

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -37,7 +37,7 @@ jobs:
           echo "BUILD_TIME=$t" >> $env:GITHUB_ENV
 
       # 3. Inject into VersionInfo.cs
-      - name: Replace version info
+      - name: Replace version date
         run: |
           (Get-Content ./Anamnesis/VersionInfo.cs) `
             -replace '2000, 01, 01, 00, 00, 00', "${{ env.BUILD_TIME }}" |
@@ -75,12 +75,33 @@ jobs:
       - name: Create ZIP
         run: Compress-Archive -Path './publish/*' -DestinationPath './Anamnesis.zip'
 
-      # 9. Draft a GitHub release
+      # 9. Extract version from VersionInfo.cs
+      - name: Extract version from application files
+        run: |
+          $content = Get-Content ./Anamnesis/VersionInfo.cs -Raw
+          if ($content -match 'Version\s*\(\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)\s*\)') {
+            $version = "v$($matches[1]).$($matches[2]).$($matches[3]).$($matches[4])"
+            echo "VERSION_TAG=$version" >> $env:GITHUB_ENV
+          } else {
+            Write-Error "Could not extract version from VersionInfo.cs"
+            exit 1
+          }
+
+      # 10. Check if tag already exists
+      - name: Check if tag already exists
+        run: |
+          git fetch --tags
+          if (git tag -l "${{ env.VERSION_TAG }}") {
+            Write-Error "Tag ${{ env.VERSION_TAG }} already exists. Aborting release."
+            exit 1
+          }
+
+      # 11. Draft a GitHub release
       - name: Create draft release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ env.VERSION_DATE }}
-          name: ${{ env.VERSION_DATE }}
+          tag: ${{ env.VERSION_TAG }}
+          name: ${{ env.VERSION_TAG }}
           draft: true
           artifacts: "Anamnesis.zip"
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -25,38 +25,20 @@ jobs:
           submodules: recursive
           persist-credentials: true
 
-      # 2. Capture dates in env vars
-      - name: Set version date
-        run: |
-          $d = Get-Date -Format 'yyyy-MM-dd'
-          echo "VERSION_DATE=$d" >> $env:GITHUB_ENV
-
-      - name: Set build timestamp
-        run: |
-          $t = Get-Date -Format 'yyyy, MM, dd, HH, mm, ss'
-          echo "BUILD_TIME=$t" >> $env:GITHUB_ENV
-
-      # 3. Inject into VersionInfo.cs
-      - name: Replace version date
-        run: |
-          (Get-Content ./Anamnesis/VersionInfo.cs) `
-            -replace '2000, 01, 01, 00, 00, 00', "${{ env.BUILD_TIME }}" |
-          Set-Content ./Anamnesis/VersionInfo.cs
-
-      # 4. Install .NET SDK
+      # 2. Install .NET SDK
       - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v3.4.2
         with:
           dotnet-version: '9.0.x'
 
-      # 5. Publish projects
+      # 3. Publish projects
       - name: Publish Anamnesis
-        run: dotnet publish Anamnesis/Anamnesis.csproj /p:PublishProfile=".\Anamnesis\Properties\PublishProfiles\FolderProfile.pubxml"
+        run: dotnet publish Anamnesis/Anamnesis.csproj /p:PublishProfile=".\Anamnesis\Properties\PublishProfiles\FolderProfile.pubxml" /p:DefineConstants="CI_BUILD"
 
       - name: Publish UpdateExtractor
-        run: dotnet publish UpdateExtractor/UpdateExtractor.csproj /p:PublishProfile=".\UpdateExtractor\Properties\PublishProfiles\FolderProfile.pubxml"
+        run: dotnet publish UpdateExtractor/UpdateExtractor.csproj /p:PublishProfile=".\UpdateExtractor\Properties\PublishProfiles\FolderProfile.pubxml" /p:DefineConstants="CI_BUILD"
 
-      # 6. Attest Build Artifacts
+      # 4. Attest Build Artifacts
       - name: Generate artifact attestation Ana
         uses: actions/attest-build-provenance@v2
         with:
@@ -67,15 +49,15 @@ jobs:
         with:
           subject-path: './publish/Updater/UpdateExtractor.exe'
 
-      # 7. Delete redundant files
+      # 5. Delete redundant files
       - name: Delete pdb and xml
         run: Get-ChildItem -Path './publish/*' -Recurse -Include *.pdb,*.xml -File | Remove-Item -Force
 
-      # 8. Zip up the entire publish folder
+      # 6. Zip up the entire publish folder
       - name: Create ZIP
         run: Compress-Archive -Path './publish/*' -DestinationPath './Anamnesis.zip'
 
-      # 9. Extract version from VersionInfo.cs
+      # 7. Extract version from VersionInfo.cs
       - name: Extract version from application files
         run: |
           $content = Get-Content ./Anamnesis/VersionInfo.cs -Raw
@@ -87,7 +69,7 @@ jobs:
             exit 1
           }
 
-      # 10. Check if tag already exists
+      # 8. Check if tag already exists
       - name: Check if tag already exists
         run: |
           git fetch --tags
@@ -96,7 +78,7 @@ jobs:
             exit 1
           }
 
-      # 11. Draft a GitHub release
+      # 9. Draft a GitHub release
       - name: Create draft release
         uses: ncipollo/release-action@v1
         with:

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -860,6 +860,8 @@
 
   "Update_Title": "Update",
   "Update_NoUpdate": "No updates found",
+  "Update_Check_Fail_Title": "Failed to check for updates",
+  "Update_RateLimit": "Unable to check for updates at this time. Please try again later.",
 
   "DevBuild_Title": "Development Build",
   "DevBuild_Body": "This is an experimental development build of Anamnesis and is not officially supported. These builds are likely to contain serious issues and should be avoided unless you know what you are doing.\n\nWould you like to continue using this build?\nSelecting no will offer you an update to the latest supported build.",

--- a/Anamnesis/Services/LogService.cs
+++ b/Anamnesis/Services/LogService.cs
@@ -107,7 +107,7 @@ public class LogService : ServiceBase<LogService>
 		Log.Information("Framework: " + RuntimeInformation.FrameworkDescription, "Info");
 		Log.Information("OS Architecture: " + RuntimeInformation.OSArchitecture.ToString(), "Info");
 		Log.Information("Process Architecture: " + RuntimeInformation.ProcessArchitecture.ToString(), "Info");
-		Log.Information("Anamnesis Version: " + VersionInfo.Date.ToString(@"yyyy-MM-dd HH:mm"), "Info");
+		Log.Information($"Anamnesis Version: v{VersionInfo.ApplicationVersion}", "Info");
 	}
 
 	/// <inheritdoc/>

--- a/Anamnesis/Services/PoseService.cs
+++ b/Anamnesis/Services/PoseService.cs
@@ -258,12 +258,20 @@ public class PoseService : ServiceBase<PoseService>
 					try
 					{
 						string verText = await File.ReadAllTextAsync(verFile);
-						DateTime standardPoseVersion = DateTime.Parse(verText, CultureInfo.InvariantCulture);
 
-						if (standardPoseVersion == VersionInfo.Date)
+						if (!DateTime.TryParse(verText, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime _))
 						{
-							Log.Information($"Standard pose library up to date");
-							return;
+							if (!Version.TryParse(verText, out Version? standardPoseVer))
+							{
+								Log.Error($"Failed to parse standard pose library version: {verText}");
+								return;
+							}
+
+							if (standardPoseVer == VersionInfo.ApplicationVersion)
+							{
+								Log.Information($"Standard pose library up to date");
+								return;
+							}
 						}
 					}
 					catch (Exception ex)
@@ -276,7 +284,7 @@ public class PoseService : ServiceBase<PoseService>
 			}
 
 			standardPoseDir.Create();
-			await File.WriteAllTextAsync(verFile, VersionInfo.Date.ToString(CultureInfo.InvariantCulture));
+			await File.WriteAllTextAsync(verFile, VersionInfo.ApplicationVersion.ToString());
 
 			string[] poses = EmbeddedFileUtility.GetAllFilesInDirectory("\\Data\\StandardPoses\\");
 			foreach (string posePath in poses)

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -91,10 +91,22 @@ public class UpdateService : ServiceBase<UpdateService>
 			if (this.currentRelease.TagName == null)
 				throw new Exception("No tag name in GitHub API JSON response");
 
-			if (!Version.TryParse(this.currentRelease.TagName.TrimStart('v'), out Version? latestReleaseVer))
-				throw new Exception("Failed to parse version from tag name");
+			bool update = false;
 
-			bool update = latestReleaseVer > VersionInfo.ApplicationVersion;
+			// Check for old date-based tag format: yyyy-MM-dd(-h#)
+			if (System.Text.RegularExpressions.Regex.IsMatch(this.currentRelease.TagName, @"^\d{4}-\d{2}-\d{2}(-h\d+)?$"))
+			{
+				// Trigger an update if the tag is using the old date format.
+				update = true;
+			}
+			else
+			{
+				if (!Version.TryParse(this.currentRelease.TagName.TrimStart('v'), out Version? latestReleaseVer))
+					throw new Exception("Failed to parse version from tag name");
+
+				update = latestReleaseVer > VersionInfo.ApplicationVersion;
+			}
+
 			if (update)
 			{
 				await Dispatch.MainThread();

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -40,7 +40,7 @@ public class UpdateService : ServiceBase<UpdateService>
 		bool skipTimeCheck = false;
 
 		// Determine if this is a dev build
-		if (VersionInfo.Date.Year <= 2000)
+		if (VersionInfo.IsDevelopmentBuild)
 		{
 			// Don't show if there is a debugger attached
 			if (Debugger.IsAttached)

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -4,6 +4,7 @@
 namespace Anamnesis.Updater;
 
 using Anamnesis.Core;
+using Anamnesis.Files;
 using Anamnesis.GUI.Dialogs;
 using Anamnesis.Services;
 using System;
@@ -22,10 +23,15 @@ public class UpdateService : ServiceBase<UpdateService>
 {
 	private const string Repository = "imchillin/Anamnesis";
 
+	// GitHub API rate limits requests to 60/h for unauthenticated users.
+	// The requests are associated with the originating IP address.
+	// Choose a reasonable update interval to avoid hitting the limit.
+	private const int UpdateIntervalMinutes = 10;
+
 	private readonly HttpClient httpClient = new HttpClient();
 	private Release? currentRelease;
 
-	private static string UpdateTempDir => Path.GetTempPath() + "/AnamnesisUpdateLatest/";
+	private static string UpdateTempDir => Path.Combine(Path.GetTempPath(), "AnamnesisUpdateLatest");
 
 	public override async Task Initialize()
 	{
@@ -51,9 +57,10 @@ public class UpdateService : ServiceBase<UpdateService>
 
 		DateTimeOffset lastCheck = SettingsService.Current.LastUpdateCheck;
 		TimeSpan elapsed = DateTimeOffset.Now - lastCheck;
-		if (elapsed.TotalHours < 6 && !skipTimeCheck)
+
+		if (elapsed.TotalMinutes < UpdateIntervalMinutes && !skipTimeCheck)
 		{
-			Log.Information("Last update check was less than 6 hours ago. Skipping.");
+			Log.Information($"Last update check was less than {UpdateIntervalMinutes} minutes ago. Skipping.");
 			return;
 		}
 
@@ -63,7 +70,11 @@ public class UpdateService : ServiceBase<UpdateService>
 	public async Task<bool> CheckForUpdates()
 	{
 		if (Directory.Exists(UpdateTempDir))
+		{
+			var dirInfo = new DirectoryInfo(UpdateTempDir);
+			FileService.SetAttributesNormal(dirInfo);
 			Directory.Delete(UpdateTempDir, true);
+		}
 
 		if (!this.httpClient.DefaultRequestHeaders.Contains("User-Agent"))
 			this.httpClient.DefaultRequestHeaders.Add("User-Agent", "AutoUpdater");
@@ -75,19 +86,15 @@ public class UpdateService : ServiceBase<UpdateService>
 			this.currentRelease = JsonSerializer.Deserialize<Release>(result);
 
 			if (this.currentRelease == null)
-				throw new Exception("Failed to deserialize json response");
+				throw new Exception("Failed to deserialize GitHub API JSON response");
 
-			if (this.currentRelease.Published == null)
-				throw new Exception("No published timestamp in update json");
+			if (this.currentRelease.TagName == null)
+				throw new Exception("No tag name in GitHub API JSON response");
 
-			DateTimeOffset published = (DateTimeOffset)this.currentRelease.Published;
-			published = published.ToUniversalTime();
+			if (!Version.TryParse(this.currentRelease.TagName.TrimStart('v'), out Version? latestReleaseVer))
+				throw new Exception("Failed to parse version from tag name");
 
-			// Bump the published time down by a few hours to account for release upload times.
-			published = published.AddHours(-4);
-
-			bool update = published > VersionInfo.Date;
-
+			bool update = latestReleaseVer > VersionInfo.ApplicationVersion;
 			if (update)
 			{
 				await Dispatch.MainThread();
@@ -108,6 +115,12 @@ public class UpdateService : ServiceBase<UpdateService>
 			{
 				SettingsService.Current.LastUpdateCheck = DateTimeOffset.Now;
 				SettingsService.Save();
+				return false;
+			}
+
+			if (ex.StatusCode == HttpStatusCode.Forbidden || ex.StatusCode == HttpStatusCode.TooManyRequests)
+			{
+				await GenericDialog.ShowLocalizedAsync("Update_RateLimit", "Update_Check_Fail_Title", System.Windows.MessageBoxButton.OK);
 				return false;
 			}
 
@@ -161,10 +174,9 @@ public class UpdateService : ServiceBase<UpdateService>
 			// Download asset to temp file
 			string zipFilePath = Path.GetTempFileName();
 			{
-				using HttpClient client = new HttpClient();
-				using HttpResponseMessage response = await client.GetAsync(asset.Url);
-				using Stream streamToReadFrom = await response.Content.ReadAsStreamAsync();
-				using FileStream fileStream = new FileStream(zipFilePath, FileMode.OpenOrCreate, FileAccess.Write);
+				using HttpResponseMessage response = await this.httpClient.GetAsync(asset.Url);
+				await using Stream streamToReadFrom = await response.Content.ReadAsStreamAsync();
+				await using FileStream fileStream = new(zipFilePath, FileMode.OpenOrCreate, FileAccess.Write);
 				await streamToReadFrom.CopyToAsync(fileStream);
 			}
 
@@ -187,13 +199,18 @@ public class UpdateService : ServiceBase<UpdateService>
 			if (File.Exists(zipFilePath))
 			{
 				// Remove temp file
+				var fileInfo = new FileInfo(zipFilePath);
+				fileInfo.Attributes = FileAttributes.Normal;
 				File.Delete(zipFilePath);
 			}
 
 			// While testing, do not copy the update files over our working files.
 			if (Debugger.IsAttached)
 			{
+				var dirInfo = new DirectoryInfo(UpdateTempDir);
+				FileService.SetAttributesNormal(dirInfo);
 				Directory.Delete(UpdateTempDir, true);
+
 				string[] paths = Directory.GetFiles(".", "*.*", SearchOption.AllDirectories);
 				foreach (string path in paths)
 				{
@@ -210,7 +227,7 @@ public class UpdateService : ServiceBase<UpdateService>
 			// Start the update extractor
 			string currentDir = Directory.GetCurrentDirectory();
 			string procName = Process.GetCurrentProcess().ProcessName;
-			ProcessStartInfo start = new(UpdateTempDir + "/Updater/UpdateExtractor.exe", $"\"{currentDir}\" {procName}");
+			ProcessStartInfo start = new(Path.Combine(UpdateTempDir, "Updater", "UpdateExtractor.exe"), $"\"{currentDir}\" {procName}");
 			Process.Start(start);
 
 			// Shutdown anamnesis
@@ -227,9 +244,6 @@ public class UpdateService : ServiceBase<UpdateService>
 	{
 		[JsonPropertyName("tag_name")]
 		public string? TagName { get; set; }
-
-		[JsonPropertyName("published_at")]
-		public DateTimeOffset? Published { get; set; }
 
 		[JsonPropertyName("body")]
 		public string? Changes { get; set; }

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -8,12 +8,6 @@ using System;
 public static class VersionInfo
 {
 	/// <summary>
-	/// The time this version was published.
-	/// </summary>
-	// This is written to by the build server. do not change.
-	public static readonly DateTime Date = new DateTime(2000, 01, 01, 00, 00, 00, DateTimeKind.Utc);
-
-	/// <summary>
 	/// Application version.
 	/// </summary>
 	/// <remarks>
@@ -27,6 +21,12 @@ public static class VersionInfo
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
 	public static readonly Version ApplicationVersion = new Version(7, 30, 0, 0);
+
+#if CI_BUILD
+	public static readonly bool IsDevelopmentBuild = false;
+#else
+	public static readonly bool IsDevelopmentBuild = true;
+#endif
 
 	/// <summary>
 	/// The latest game version that the tool has been validated for.

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -14,6 +14,21 @@ public static class VersionInfo
 	public static readonly DateTime Date = new DateTime(2000, 01, 01, 00, 00, 00, DateTimeKind.Utc);
 
 	/// <summary>
+	/// Application version.
+	/// </summary>
+	/// <remarks>
+	/// [!] Be sure to update this before making a new release.
+	/// Format: [Major].[Minor].[Build].[Revision]
+	/// - Major: Reflects the major version of the game.
+	/// - Minor: Reflects the minor version of the game, padded to 2 digits.
+	/// - Build: The version of the tool. This should reset to 0 on every minor or major release.
+	///   - Bump the build number after feature releases, improvements, or bug fixes.
+	/// - Revision: The revision of the tool. This should reset to 0 on every build.
+	///   - Bump the revision number for hotfixes and urgent patches.
+	/// </remarks>
+	public static readonly Version ApplicationVersion = new Version(7, 30, 0, 0);
+
+	/// <summary>
 	/// The latest game version that the tool has been validated for.
 	/// </summary>
 	public static readonly string ValidatedGameVersion = "2025.08.07.0000.0000";

--- a/Anamnesis/Views/AboutView.xaml.cs
+++ b/Anamnesis/Views/AboutView.xaml.cs
@@ -16,7 +16,7 @@ public partial class AboutView : UserControl
 	{
 		this.InitializeComponent();
 
-		if (VersionInfo.Date.Year <= 2000)
+		if (VersionInfo.IsDevelopmentBuild)
 		{
 			this.VersionLabel.Text = "Developer";
 		}

--- a/Anamnesis/Views/AboutView.xaml.cs
+++ b/Anamnesis/Views/AboutView.xaml.cs
@@ -3,12 +3,12 @@
 
 namespace Anamnesis.GUI.Views;
 
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Navigation;
 using Anamnesis.GUI.Dialogs;
 using Anamnesis.Services;
 using Anamnesis.Updater;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Navigation;
 
 public partial class AboutView : UserControl
 {
@@ -22,7 +22,7 @@ public partial class AboutView : UserControl
 		}
 		else
 		{
-			this.VersionLabel.Text = VersionInfo.Date.ToString("yyyy-MM-dd HH:mm");
+			this.VersionLabel.Text = $"v{VersionInfo.ApplicationVersion}";
 		}
 	}
 

--- a/Anamnesis/Windows/ErrorDialog.cs
+++ b/Anamnesis/Windows/ErrorDialog.cs
@@ -31,7 +31,7 @@ public static class ErrorDialog
 			SplashWindow.HideWindow();
 
 			Dialog dlg = new Dialog();
-			dlg.TitleText.Text = "Anamnesis v" + VersionInfo.Date.ToString("yyyy-MM-dd HH:mm");
+			dlg.TitleText.Text = $"Anamnesis v{VersionInfo.ApplicationVersion}";
 			XivToolsErrorDialog errorDialog = new XivToolsErrorDialog(dlg, ex, isCriticial);
 			errorDialog.OnQuitRequested = HandleFatalErrorShutdown;
 

--- a/UpdateExtractor/Program.cs
+++ b/UpdateExtractor/Program.cs
@@ -6,7 +6,6 @@ namespace UpdateExtractor
 	using System;
 	using System.Diagnostics;
 	using System.IO;
-	using System.Reflection;
 	using System.Threading;
 
 	public class Program
@@ -124,6 +123,11 @@ namespace UpdateExtractor
 			if (!File.Exists(path))
 				return;
 
+			var fileInfo = new FileInfo(path)
+			{
+				Attributes = FileAttributes.Normal,
+			};
+
 			File.Delete(path);
 		}
 
@@ -132,7 +136,23 @@ namespace UpdateExtractor
 			if (!Directory.Exists(path))
 				return;
 
+			SetAttributesNormal(new DirectoryInfo(path));
 			Directory.Delete(path, true);
+		}
+
+		private static void SetAttributesNormal(DirectoryInfo directory)
+		{
+			directory.Attributes = FileAttributes.Normal;
+
+			foreach (var subDirectory in directory.GetDirectories())
+			{
+				SetAttributesNormal(subDirectory);
+			}
+
+			foreach (var file in directory.GetFiles())
+			{
+				file.Attributes = FileAttributes.Normal;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Changelog:
- Changed from timestamp-based update checking to version-based checking.
  - *Explanation: The old system would prevent users from updating if multiple releases were made too close to each other, as the `published` (-4h) timestamp would not exceed the internal version date of the application. Furthermore, due to a mismatch in timezones, the update check led to flaky behavior for users depending on the local time of their system. While aligning timezones is trivial, tuning the `published` timestamp to match the version date, which reflects the timestamp of the build, is finicky and prone to issues if a draft release is not published at the right time. The new approach comes with additional responsibility as contributors need to bump the version before a release can be made. I updated the publish workflow action to check for existing tags to aid with that process.*
- Increased the time interval at which we check for updates (6h -> 10m).
  - *Explanation: Unauthenticated users can do 60 requests per hour from a given origin IP. I updated the threshold to a reasonable value that accounts for the possibility of having multiple Anamnesis instances being ran from a single network.*
- Replaced obsolete `VersionInfo.Date` with a read-only boolean, whose value is determined by the presence of a constant symbol provided with the `dotnet publish` command.

## Updated versioning:

New version format, as agreed upon with a few other project contributors: `<Major>`.`<Minor>`.`<Build>`.`<Revision>`
  - **Major:** Reflects the major version of the game.
  - **Minor:** Reflects the minor version of the game, padded to 2 digits.
  - **Build:** The version of the tool. This should reset to 0 on every minor or major release.
    - Bump the build number after feature releases, improvements, or bug fixes (i.e. planned changes for a release).
  - **Revision:** The revision of the tool. This should reset to 0 on every build.
    - Bump the revision number for hotfixes and urgent patches. This should be used only for making changes outside of the normal release cycle.