### PR TITLE
Tidying up auto-update process to handle edge cases

### DIFF
--- a/Anamnesis/App.xaml.cs
+++ b/Anamnesis/App.xaml.cs
@@ -41,7 +41,7 @@ public partial class App : Application
 
 	private void OnExit(object sender, ExitEventArgs e)
 	{
-		Task.Run(async () => { await Services.ShutdownServices(); });
+		Task.Run(Services.ShutdownServices);
 	}
 
 	private void TaskSchedulerOnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)

--- a/Anamnesis/Core/Memory/Exceptions/UpdateRequiredException.cs
+++ b/Anamnesis/Core/Memory/Exceptions/UpdateRequiredException.cs
@@ -1,0 +1,8 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Memory.Exceptions;
+
+using System;
+
+public class UpdateTriggeredException() : Exception() { }

--- a/Anamnesis/Core/ServiceBase{T}.cs
+++ b/Anamnesis/Core/ServiceBase{T}.cs
@@ -42,6 +42,11 @@ public abstract class ServiceBase<T> : IService, INotifyPropertyChanged
 	}
 
 	/// <summary>
+	/// Gets the singleton instance of the service, or null if it has not been instantiated.
+	/// </summary>
+	public static T? InstanceOrNull => instance;
+
+	/// <summary>
 	/// Gets a value indicating whether the service is initialized.
 	/// </summary>
 	/// <remarks>

--- a/Anamnesis/Keyboard/HotkeyService.cs
+++ b/Anamnesis/Keyboard/HotkeyService.cs
@@ -23,6 +23,14 @@ public class HotkeyService : ServiceBase<HotkeyService>
 
 	private static readonly HashSet<Key> KeyDownSentToGame = new();
 
+	/// <inheritdoc/>
+	protected override IEnumerable<IService> Dependencies =>
+	[
+		SettingsService.Instance,
+		MemoryService.Instance,
+		GposeService.Instance
+	];
+
 	public static void RegisterHotkeyHandler(string function, Action callback)
 	{
 		RegisterHotkeyHandler(function, new Handler(callback));

--- a/Anamnesis/Memory/ActorBasicMemory.cs
+++ b/Anamnesis/Memory/ActorBasicMemory.cs
@@ -89,7 +89,7 @@ public class ActorBasicMemory : MemoryBase
 	[DependsOn(nameof(ObjectIndex), nameof(Address))]
 	public bool IsValid
 	{
-		get => this.Address != IntPtr.Zero && ActorService.Instance.GetActorTableIndex(this.Address) == this.ObjectIndex;
+		get => this.Address != IntPtr.Zero && ActorService.InstanceOrNull?.GetActorTableIndex(this.Address) == this.ObjectIndex;
 	}
 
 	/// <summary>

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -89,7 +89,7 @@ public class ActorMemory : ActorBasicMemory
 	public bool IsWeaponDirty { get; set; } = false;
 
 	[DependsOn(nameof(IsValid), nameof(IsOverworldActor), nameof(Name), nameof(RenderMode))]
-	public bool CanRefresh => ActorService.Instance.CanRefreshActor(this);
+	public bool CanRefresh => ActorService.InstanceOrNull?.CanRefreshActor(this) == true;
 
 	public bool IsHuman => this.ModelObject != null && this.ModelObject.IsHuman;
 
@@ -232,7 +232,7 @@ public class ActorMemory : ActorBasicMemory
 			return;
 
 		// Only record changes that originate from the user
-		if (!change.OriginBind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && !HistoryService.Instance.IsRestoring)
+		if (!change.OriginBind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && !HistoryService.InstanceOrNull?.IsRestoring == true)
 		{
 			if (change.Origin == PropertyChange.Origins.User)
 			{

--- a/Anamnesis/Memory/MemoryBase.cs
+++ b/Anamnesis/Memory/MemoryBase.cs
@@ -493,7 +493,7 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 
 		// Propagate the property changed event to the rest of the application after write to memory
 		var origin = PropertyChange.Origins.User;
-		if (!bind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && HistoryService.Instance.IsRestoring)
+		if (!bind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && HistoryService.InstanceOrNull?.IsRestoring == true)
 		{
 			origin = PropertyChange.Origins.History;
 		}
@@ -574,7 +574,7 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 		if (bind.IsWriting)
 			throw new Exception("Cannot read memory while we're writing to it");
 
-		if (bind.Flags.HasFlagUnsafe(BindFlags.OnlyInGPose) && !GposeService.Instance.IsGpose)
+		if (bind.Flags.HasFlagUnsafe(BindFlags.OnlyInGPose) && GposeService.InstanceOrNull?.IsGpose != true)
 			return;
 
 		bind.IsReading = true;
@@ -776,7 +776,7 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 						continue;
 
 					// If the child is a bind but only applies in gpose and we are not in gpose, then skip it.
-					if (child.parentBind.Flags.HasFlagUnsafe(BindFlags.OnlyInGPose) && !GposeService.Instance.IsGpose)
+					if (child.parentBind.Flags.HasFlagUnsafe(BindFlags.OnlyInGPose) && GposeService.InstanceOrNull?.IsGpose != true)
 						continue;
 
 					stack.Push(child);
@@ -828,7 +828,7 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 
 					// Propagate property changed event to the rest of the application after writing to memory
 					var origin = PropertyChange.Origins.User;
-					if (!propertyBind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && HistoryService.Instance.IsRestoring)
+					if (!propertyBind.Flags.HasFlagUnsafe(BindFlags.DontRecordHistory) && HistoryService.InstanceOrNull?.IsRestoring == true)
 					{
 						origin = PropertyChange.Origins.History;
 					}

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -3,9 +3,9 @@
 
 namespace Anamnesis.Services;
 
-using Anamnesis.Core.Memory;
 using Anamnesis.Files;
 using Anamnesis.Memory;
+using Anamnesis.Memory.Exceptions;
 using Anamnesis.Serialization;
 using Anamnesis.TexTools;
 using Serilog;
@@ -36,6 +36,10 @@ public class ServiceManager
 			Services.Add(service);
 			await InitializeService(service);
 		}
+		catch (UpdateTriggeredException)
+		{
+			throw; // Do not log as fatal, just rethrow so its handled gracefully
+		}
 		catch (Exception ex)
 		{
 			Log.Fatal(ex, $"{typeof(T).Name} Error: {ex.Message}");
@@ -46,32 +50,40 @@ public class ServiceManager
 	{
 		StartupTimer.Start();
 
-		await Add<LogService>();
-		await Add<SerializerService>();
-		await Add<SettingsService>();
-		await Add<LocalizationService>();
-		await Add<Updater.UpdateService>();
-		await Add<ViewService>();
-		await Add<MemoryService>();
-		await Add<AddressService>();
-		await Add<ActorService>();
-		await Add<GameDataService>();
-		await Add<GameService>();
-		await Add<FileService>();
-		await Add<TimeService>();
-		await Add<GposeService>();
-		await Add<TerritoryService>();
-		await Add<TargetService>();
-		await Add<CameraService>();
-		await Add<PoseService>();
-		await Add<TipService>();
-		await Add<TexToolsService>();
-		await Add<FavoritesService>();
-		await Add<AnimationService>();
-		await Add<Keyboard.HotkeyService>();
-		await Add<HistoryService>();
-		await Add<CustomBoneNameService>();
-		await Add<AutoSaveService>();
+		try
+		{
+			await Add<LogService>();
+			await Add<SerializerService>();
+			await Add<SettingsService>();
+			await Add<LocalizationService>();
+			await Add<Updater.UpdateService>();
+			await Add<ViewService>();
+			await Add<MemoryService>();
+			await Add<AddressService>();
+			await Add<ActorService>();
+			await Add<GameDataService>();
+			await Add<GameService>();
+			await Add<FileService>();
+			await Add<TimeService>();
+			await Add<GposeService>();
+			await Add<TerritoryService>();
+			await Add<TargetService>();
+			await Add<CameraService>();
+			await Add<PoseService>();
+			await Add<TipService>();
+			await Add<TexToolsService>();
+			await Add<FavoritesService>();
+			await Add<AnimationService>();
+			await Add<Keyboard.HotkeyService>();
+			await Add<HistoryService>();
+			await Add<CustomBoneNameService>();
+			await Add<AutoSaveService>();
+		}
+		catch (UpdateTriggeredException)
+		{
+			Log.Information("Application update has been triggered, halting further service initialization...");
+			return;
+		}
 
 		IsInitialized = true;
 
@@ -84,7 +96,7 @@ public class ServiceManager
 		CheckWindowsVersion();
 
 		StartupTimer.Stop();
-		Log.Information($"took {StartupTimer.ElapsedMilliseconds}ms to check windows version");
+		Log.Information($"Took {StartupTimer.ElapsedMilliseconds}ms to check windows version");
 	}
 
 	public async Task StartServices()

--- a/Anamnesis/Services/AnimationService.cs
+++ b/Anamnesis/Services/AnimationService.cs
@@ -4,7 +4,6 @@
 namespace Anamnesis.Services;
 
 using Anamnesis.Core;
-using Anamnesis.Core.Memory;
 using Anamnesis.Memory;
 using PropertyChanged;
 using System;
@@ -32,6 +31,7 @@ public class AnimationService : ServiceBase<AnimationService>
 	/// <inheritdoc/>
 	protected override IEnumerable<IService> Dependencies =>
 	[
+		ActorService.Instance,
 		TargetService.Instance,
 		GposeService.Instance,
 		GameDataService.Instance

--- a/Anamnesis/Services/HistoryService.cs
+++ b/Anamnesis/Services/HistoryService.cs
@@ -6,6 +6,7 @@ namespace Anamnesis.Services;
 using Anamnesis.Core;
 using Anamnesis.Keyboard;
 using Anamnesis.Memory;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +16,9 @@ using System.Threading.Tasks;
 public class HistoryService : ServiceBase<HistoryService>
 {
 	private int isRestoring = 0;
+
+	/// <inheritdoc/>
+	protected override IEnumerable<IService> Dependencies => [TargetService.Instance];
 
 	/// <summary>Lock object for thread synchronization.</summary>
 	/// <remarks>
@@ -57,7 +61,7 @@ public class HistoryService : ServiceBase<HistoryService>
 	/// <param name="context">The new history context.</param>
 	public static void SetContext(HistoryContext context)
 	{
-		ActorMemory? actor = TargetService.Instance?.SelectedActor;
+		ActorMemory? actor = TargetService.Instance.SelectedActor;
 		if (actor is null)
 			return;
 
@@ -88,7 +92,7 @@ public class HistoryService : ServiceBase<HistoryService>
 	/// </summary>
 	public void Clear()
 	{
-		ActorMemory? actor = TargetService.Instance?.SelectedActor;
+		ActorMemory? actor = TargetService.Instance.SelectedActor;
 
 		if (actor is null)
 			return;
@@ -101,7 +105,7 @@ public class HistoryService : ServiceBase<HistoryService>
 
 	private void Step(bool forward)
 	{
-		ActorMemory? actor = TargetService.Instance?.SelectedActor;
+		ActorMemory? actor = TargetService.Instance.SelectedActor;
 
 		if (actor is null)
 			return;

--- a/Anamnesis/Services/Settings.cs
+++ b/Anamnesis/Services/Settings.cs
@@ -96,7 +96,7 @@ public class Settings : INotifyPropertyChanged
 			}
 			catch (ServiceNotFoundException)
 			{
-				// Silently ignore
+				// Service not instantiated yet, nothing to restart
 			}
 		}
 	}
@@ -116,8 +116,15 @@ public class Settings : INotifyPropertyChanged
 
 			this.autoSaveIntervalMinutes = value;
 
-			if (AutoSaveService.Instance != null && AutoSaveService.Instance.IsAlive)
-				AutoSaveService.Instance.RestartUpdateTask();
+			try
+			{
+				if (AutoSaveService.Instance != null && AutoSaveService.Instance.IsAlive)
+					AutoSaveService.Instance.RestartUpdateTask();
+			}
+			catch (ServiceNotFoundException)
+			{
+				// Service not instantiated yet, nothing to restart
+			}
 		}
 	}
 	public bool AutoSaveOnlyInGpose { get; set; } = true;

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -6,6 +6,7 @@ namespace Anamnesis.Updater;
 using Anamnesis.Core;
 using Anamnesis.Files;
 using Anamnesis.GUI.Dialogs;
+using Anamnesis.Memory.Exceptions;
 using Anamnesis.Services;
 using System;
 using System.Collections.Generic;
@@ -67,7 +68,9 @@ public class UpdateService : ServiceBase<UpdateService>
 			return;
 		}
 
-		await this.CheckForUpdates();
+		bool updateTriggered = await this.CheckForUpdates();
+		if (updateTriggered)
+			throw new UpdateTriggeredException();
 	}
 
 	public async Task<bool> CheckForUpdates()

--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -17,6 +17,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Windows;
 using XivToolsWpf;
 
 public class UpdateService : ServiceBase<UpdateService>
@@ -27,6 +28,8 @@ public class UpdateService : ServiceBase<UpdateService>
 	// The requests are associated with the originating IP address.
 	// Choose a reasonable update interval to avoid hitting the limit.
 	private const int UpdateIntervalMinutes = 10;
+
+	private const int ForceShutdownTimeout = 10000; // ms (10 seconds)
 
 	private readonly HttpClient httpClient = new HttpClient();
 	private Release? currentRelease;
@@ -243,7 +246,27 @@ public class UpdateService : ServiceBase<UpdateService>
 			Process.Start(start);
 
 			// Shutdown anamnesis
-			App.Current.Shutdown();
+			// Note: Ensure shutdown call takes place on the UI thread
+			App.Current.Dispatcher.Invoke(() =>
+			{
+				// Application may not exit if any windows are still open
+				foreach (Window window in App.Current.Windows)
+				{
+					window.Close();
+				}
+
+				Log.Information("Attempting graceful shutdown after update.");
+				App.Current.Shutdown();
+
+				// Force shutdown if application doesn't shutdown gracefully within the timeout.
+				_ = Task.Run(async () =>
+				{
+					await Task.Delay(ForceShutdownTimeout);
+					Log.Warning("Forceful shutdown triggered after update (timeout reached).");
+					Environment.Exit(0);
+				});
+			});
+
 			return;
 		}
 		catch (Exception ex)

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new Version(7, 30, 0, 0);
+	public static readonly Version ApplicationVersion = new Version(7, 20, 0, 0);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new Version(7, 20, 0, 0);
+	public static readonly Version ApplicationVersion = new Version(7, 30, 0, 1);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;

--- a/Anamnesis/Views/HotkeyPrompt.xaml.cs
+++ b/Anamnesis/Views/HotkeyPrompt.xaml.cs
@@ -5,6 +5,8 @@ namespace Anamnesis.Views;
 
 using Anamnesis.Core.Extensions;
 using Anamnesis.Keyboard;
+using Anamnesis.Memory.Exceptions;
+using Serilog;
 using System.Text;
 using System.Windows.Input;
 using XivToolsWpf.DependencyProperties;
@@ -37,34 +39,41 @@ public partial class HotkeyPrompt : System.Windows.Controls.TextBlock
 		if (string.IsNullOrEmpty(this.Function))
 			return;
 
-		if (!HotkeyService.Instance.IsInitialized)
-			return;
-
-		KeyCombination? keys = HotkeyService.GetBind(this.Function);
-		if (keys == null)
-			return;
-
-		StringBuilder str = new StringBuilder();
-
-		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Control))
+		try
 		{
-			str.Append("[CTRL] +");
-		}
+			if (!HotkeyService.Instance.IsInitialized)
+				return;
 
-		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Alt))
+			KeyCombination? keys = HotkeyService.GetBind(this.Function);
+			if (keys == null)
+				return;
+
+			StringBuilder str = new StringBuilder();
+
+			if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Control))
+			{
+				str.Append("[CTRL] +");
+			}
+
+			if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Alt))
+			{
+				str.Append("[ALT] +");
+			}
+
+			if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Shift))
+			{
+				str.Append("[SHIFT] +");
+			}
+
+			str.Append('[');
+			str.Append(keys.Key);
+			str.Append(']');
+
+			this.Text = str.ToString();
+		}
+		catch (ServiceNotFoundException)
 		{
-			str.Append("[ALT] +");
+			Log.Warning("Attempted to load hotkey prompt string before hotkey service was available.");
 		}
-
-		if (keys.Modifiers.HasFlagUnsafe(ModifierKeys.Shift))
-		{
-			str.Append("[SHIFT] +");
-		}
-
-		str.Append('[');
-		str.Append(keys.Key);
-		str.Append(']');
-
-		this.Text = str.ToString();
 	}
 }


### PR DESCRIPTION
_Note: I'm planning to make a hotfix release so this pull request targets `master` branch directly._

**Changelog:**
- Added a safety guard to prevent further service initialization if an update has been triggered.
  - **Explanation:** This falls into one of the edge cases that were identified. What seems to happen is that while the update service's update check and perform tasks are executed synchronously, `DoUpdate` will return once the method `App.Current.Shutdown()` is called. However, it appears that this method call is non-blocking, so the service manager will attempt to continue service initialization while WPF is shutting down the application in the background. I added an explicit exception raised in `UpdateService` that is handled in the service manager to prevent this from occuring.
- Added missing dependencies to `HotkeyService`, `AnimationService`, and `HistoryService`.
  - **Explanation:** This doesn't adress any present issues, just adds some extra safe guards to prevent wrongful server initialization order if/when someone updates the init order in the service manager in the future.
- Added precautions to memory classes in which we cannot guarantee a service's availability.
  - **Explanation:** This also doesn't address any present issues and is meant to be a precaution if any service attempts to read from game memory during service initialization in the future (memory reads currently take place on service start-up).
- Added missing `ServiceNotFoundException` try/catch exception handling in the settings class, error dialog class, and hotkey prompt load method.
- Updated `DoUpdate` to do a graceful and then forceful shutdown if the graceful shutdown takes too long (10s).
  - **Explanation:** `Application.Shutdown()` won't stop the process if there are any foreground threads running or window instances that were created but not shown. While I couldn't identify any threads or windows that would trigger this behavior, I added a forceful shutdown as a catch-all in case the the normal shutdown fails/takes too long. I now also explicitly call the shutdown in a dispatcher. Ref: https://stackoverflow.com/q/5071137.

Big thanks to a friend who was unfortunate enough to run into some of these issues.