### PR TITLE
Determine CN region by checking FFXIVBootV3.exe file

### DIFF
--- a/Anamnesis/GameData/GameDataService.cs
+++ b/Anamnesis/GameData/GameDataService.cs
@@ -152,7 +152,7 @@ public class GameDataService : ServiceBase<GameDataService>
 		Language defaultLuminaLaunguage = Language.English;
 		Region = ClientRegion.Global;
 
-		if (File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "rail_files", "rail_game_identify.json")))
+		if (File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot3.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "rail_files", "rail_game_identify.json")))
 		{
 			Region = ClientRegion.Chinese;
 			defaultLuminaLaunguage = Language.ChineseSimplified;

--- a/Anamnesis/GameData/GameDataService.cs
+++ b/Anamnesis/GameData/GameDataService.cs
@@ -152,7 +152,7 @@ public class GameDataService : ServiceBase<GameDataService>
 		Language defaultLuminaLaunguage = Language.English;
 		Region = ClientRegion.Global;
 
-		if (File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot3.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "rail_files", "rail_game_identify.json")))
+		if (File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBoot.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "FFXIVBootV3.exe")) || File.Exists(Path.Combine(MemoryService.GamePath, "rail_files", "rail_game_identify.json")))
 		{
 			Region = ClientRegion.Chinese;
 			defaultLuminaLaunguage = Language.ChineseSimplified;


### PR DESCRIPTION
New launcher creates `FFXIVBootV3.exe`, users who only use the new launcher lack `FFXIVBoot.exe`, which results in the region being detected as Global, leading to Lunima errors.

<img width="1090" height="1223" alt="image" src="https://github.com/user-attachments/assets/e4f35547-0b62-4ba1-aaa9-f4afa4b9571d" />
