### PR TITLE
Resolve weapon conversion data binding error

### DIFF
--- a/Anamnesis/Actor/Views/EquipmentEditor.xaml
+++ b/Anamnesis/Actor/Views/EquipmentEditor.xaml
@@ -23,7 +23,7 @@
 			<RowDefinition/>
 		</Grid.RowDefinitions>
 
-		<local:ItemView Grid.Row="0" Grid.Column="0" ItemModel="{Binding MainHand}" ExtendedViewModel="{Binding ModelObject.Weapons}"
+		<local:ItemView Grid.Row="0" Grid.Column="0" ItemModel="{Binding MainHand}" ExtendedViewModel="{Binding ModelObject.Weapons, Mode=OneWay}"
 						Slot="MainHand" IsEnabled="{Binding IsChocobo, Converter={StaticResource !B}, Mode=OneWay}"/>
 		<local:ItemView Grid.Row="0" Grid.Column="1" ItemModel="{Binding OffHand}" ExtendedViewModel="{Binding ModelObject.Weapons.SubModel}"
 						Slot="OffHand" IsEnabled="{Binding IsChocobo, Converter={StaticResource !B}, Mode=OneWay}"/>


### PR DESCRIPTION
I previously removed the weapon type converter as part of https://github.com/imchillin/Anamnesis/pull/1529 to resolve an issue which prevented the independent scaling of weapons. Although I resolved the scaling issue in quesiton, I didn't notice that this triggers a false-positive data binding error as .NET complains that it wants to be able to do two-side conversions.

This pull request addresses that error. This has no impact on functionality (bi-directional weapon changes were tested using Anamnesis and Brio).