### PR TITLE
Fixed property changed notifications not propagating due to static keyword use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -67,6 +67,7 @@ dotnet_diagnostic.IDE1006.severity = warning
 dotnet_diagnostic.IDE0044.severity = warning
 dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0073.severity = warning
+dotnet_diagnostic.IDE0079.severity = none
 dotnet_diagnostic.IDE0025.severity = none
 dotnet_diagnostic.IDE0027.severity = none
 dotnet_diagnostic.IDE0059.severity = none

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -57,17 +57,20 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 		Level,
 	}
 
-	public static bool ShowFilters
+	// Suppress CA1822: The properties are used in WPF bindings. Do not set them to static.
+#pragma warning disable CA1822
+	public bool ShowFilters
 	{
 		get => s_showFilters;
 		set => s_showFilters = value;
 	}
 
-	public static bool AutoOffhand
+	public bool AutoOffhand
 	{
 		get => s_autoOffhand;
 		set => s_autoOffhand = value;
 	}
+#pragma warning restore CA1822
 
 	public ItemSlots Slot { get; set; }
 	public bool IsMainHandSlot => this.Slot == ItemSlots.MainHand;

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -254,7 +254,7 @@ public partial class ItemView : UserControl
 			return;
 
 		var selector = new EquipmentSelector(this.Slot, this.Actor);
-		SelectorDrawer.Show(selector, this.Item, (i) => this.SetItem(i, EquipmentSelector.AutoOffhand, selector.ForceMainModel, selector.ForceOffModel));
+		SelectorDrawer.Show(selector, this.Item, (i) => this.SetItem(i, selector.AutoOffhand, selector.ForceMainModel, selector.ForceOffModel));
 	}
 
 	private void OnSlotMouseUp(object sender, MouseButtonEventArgs e)

--- a/Anamnesis/Styles/Controls/QuaternionEditor.xaml.cs
+++ b/Anamnesis/Styles/Controls/QuaternionEditor.xaml.cs
@@ -167,7 +167,9 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 
 	public static Settings Settings => SettingsService.Current;
 
-	public static OverflowModes RotationOverflowBehavior => Settings.WrapRotationSliders ? OverflowModes.Loop : OverflowModes.Clamp;
+#pragma warning disable CA1822
+	public OverflowModes RotationOverflowBehavior => Settings.WrapRotationSliders ? OverflowModes.Loop : OverflowModes.Clamp;
+#pragma warning restore CA1822
 
 	public decimal TickFrequency
 	{
@@ -521,7 +523,7 @@ public partial class QuaternionEditor : UserControl, INotifyPropertyChanged
 	/// <param name="e">The event arguments.</param>
 	private void OnSettingsChanged(object? sender, EventArgs e)
 	{
-		this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RotationOverflowBehavior)));
+		this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.RotationOverflowBehavior)));
 	}
 
 	private class RotationGizmo : ModelVisual3D

--- a/Anamnesis/Views/CameraEditor.xaml.cs
+++ b/Anamnesis/Views/CameraEditor.xaml.cs
@@ -40,7 +40,11 @@ public partial class CameraEditor : UserControl
 	public static CameraService CameraService => CameraService.Instance;
 	public static SettingsService SettingsService => SettingsService.Instance;
 	public static Settings Settings => SettingsService.Current;
-	public static OverflowModes RotationOverflowBehavior => Settings.WrapRotationSliders ? OverflowModes.Loop : OverflowModes.Clamp;
+
+#pragma warning disable CA1822
+	public OverflowModes RotationOverflowBehavior => Settings.WrapRotationSliders ? OverflowModes.Loop : OverflowModes.Clamp;
+#pragma warning restore CA1822
+
 	private static ILogger Log => Serilog.Log.ForContext<CameraEditor>();
 
 	private async void OnImportCamera(object sender, RoutedEventArgs e)
@@ -116,6 +120,6 @@ public partial class CameraEditor : UserControl
 
 	private void OnSettingsChanged(object? sender, EventArgs e)
 	{
-		this.OnPropertyChanged(nameof(RotationOverflowBehavior));
+		this.OnPropertyChanged(nameof(this.RotationOverflowBehavior));
 	}
 }

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -48,47 +48,49 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 	public static GposeService GPoseService => GposeService.Instance;
 	public static SettingsService SettingsService => SettingsService.Instance;
 
-	public static bool IncludePlayers
+#pragma warning disable CA1822
+	public bool IncludePlayers
 	{
 		get => s_includePlayers;
 		set => s_includePlayers = value;
 	}
 
-	public static bool IncludeCompanions
+	public bool IncludeCompanions
 	{
 		get => s_includeCompanions;
 		set => s_includeCompanions = value;
 	}
 
-	public static bool IncludeNPCs
+	public bool IncludeNPCs
 	{
 		get => s_includeNPCs;
 		set => s_includeNPCs = value;
 	}
 
-	public static bool IncludeMounts
+	public bool IncludeMounts
 	{
 		get => s_includeMounts;
 		set => s_includeMounts = value;
 	}
 
-	public static bool IncludeOrnaments
+	public bool IncludeOrnaments
 	{
 		get => s_includeOrnaments;
 		set => s_includeOrnaments = value;
 	}
 
-	public static bool IncludeOther
+	public bool IncludeOther
 	{
 		get => s_includeOther;
 		set => s_includeOther = value;
 	}
 
-	public static bool IncludeHidden
+	public bool IncludeHidden
 	{
 		get => s_includeHidden;
 		set => s_includeHidden = value;
 	}
+#pragma warning restore CA1822
 
 	public static void Show(Action<ActorBasicMemory> sectionChanged)
 	{


### PR DESCRIPTION
The use of static introduced regression in a few locations, which this pull request addresses. As the properties/expressions did not belong to an instance, notification changes are never propagated to the data bindings.

Affected components:
* Equipment filter button toggle did not open on button toggle until selector is re-opened.
* Auto-offhand state changes did not apply until selector is re-opened.
* The setting "Wrap rotation sliders" did not apply immediately on change to quaternion editor nor the camera editor.
* Filters in the target selector did not apply until selector is re-opened.