### PR TITLE
Fix camera actor targeting due to object desync

### DIFF
--- a/Anamnesis/Services/PinnedActor.cs
+++ b/Anamnesis/Services/PinnedActor.cs
@@ -154,7 +154,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 
 			try
 			{
-				this.Memory.Do(a => a.Synchronize());
+				this.Memory.Synchronize();
 			}
 			catch (Exception ex)
 			{

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -560,7 +560,7 @@ public class TargetService : ServiceBase<TargetService>
 				if (pinnedActor != null)
 					pinnedActor.Tick();
 				else
-					handle.Do(a => a.Synchronize());
+					handle.Synchronize();
 			}
 			catch
 			{


### PR DESCRIPTION
This a user-reported issue where the camera did not snap to actors after an actor position change. It turns out that the issue was caused by an unsynced player target handle. To fix this issue and avoid such issues in the future, I updated `ObjectHandle<T>` class to expose a generic `Synchronize()` method that will synchronize all objects in the cache with the same base address.