### PR TITLE
Fix NPC face resolution causing unintended appearance changes

### DIFF
--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -165,7 +165,11 @@ public partial class CustomizeEditor : UserControl
 		if (dataPath.HasValue && CustomizeOptionsCache.ValidFaceIds.TryGetValue(dataPath.Value, out var validFaces))
 		{
 			// Apply offset logic for specific tribes
-			if (s_offsetTargets.Contains(tribe))
+			if (this.Actor != null && this.Actor.ObjectKind != ActorTypes.Player)
+			{
+				this.ValidFaceOptions = validFaces.ToList();
+			}
+			else if (s_offsetTargets.Contains(tribe))
 			{
 				this.ValidFaceOptions = validFaces
 					.Where(v => v > 100)

--- a/Anamnesis/GameData/DataPathResolver.cs
+++ b/Anamnesis/GameData/DataPathResolver.cs
@@ -146,7 +146,7 @@ public static class DataPathResolver
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static string ResolveFacePath(DataPaths raceSexId, ushort faceId)
-		 => $"chara/human/c{(short)raceSexId:D4}/obj/face/f{faceId:D4}/model/c{(short)raceSexId:D4}f{faceId:D4}_fac.mdl";
+		 => $"chara/human/c{(short)raceSexId:D4}/obj/face/f{faceId:D4}/material/mt_c{(short)raceSexId:D4}f{faceId:D4}_etc_a.mtrl";
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static string ResolveHairPath(DataPaths raceSexId, ushort hairId)


### PR DESCRIPTION
This pull request aims to fix a user-reported issue where pinning NPCs causes their face to change. The issue is caused by failing data path resolution of valid face options and the subsequent filtering that takes place in the customize editor.

To resolve the issue, I changed the data path to target one of the face materials that seems to be present for all valid face options. Some face options (like Veena, Face 102) do not have a model. I also updated the customize editor not to filter out face options for non-player actor types based on the per-tribe face offsets.