### PR TITLE
Optimize object handle management to avoid synchronizing multiple internal instances

### DIFF
--- a/Anamnesis/Actor/Converters/MinionGPoseWarningConverter.cs
+++ b/Anamnesis/Actor/Converters/MinionGPoseWarningConverter.cs
@@ -16,9 +16,9 @@ public class MinionGposeWarningConverter : IMultiValueConverter
 		if (values.Length != 2)
 			throw new ArgumentException("The values array must contain exactly two elements.", nameof(values));
 
-		if (values[0] is ActorTypes type && values[1] is int model)
+		if (values[0] is ObjectTypes type && values[1] is int model)
 		{
-			if (type != ActorTypes.Companion)
+			if (type != ObjectTypes.Companion)
 				return Visibility.Collapsed;
 
 			if (model == 0)

--- a/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
+++ b/Anamnesis/Actor/Converters/NpcFaceWarningConverter.cs
@@ -17,11 +17,11 @@ public class NpcFaceWarningConverter : IMultiValueConverter
 		if (values.Length != 4)
 			throw new ArgumentException("The values array must have exactly four elements.", nameof(values));
 
-		if (values[0] is ActorTypes type && values[1] is byte head && values[2] is ActorCustomizeMemory.Races race && values[3] is ActorCustomizeMemory.Genders gender)
+		if (values[0] is ObjectTypes type && values[1] is byte head && values[2] is ActorCustomizeMemory.Races race && values[3] is ActorCustomizeMemory.Genders gender)
 		{
 			bool isHroth = race == ActorCustomizeMemory.Races.Hrothgar;
 
-			if (type == ActorTypes.BattleNpc || type == ActorTypes.EventNpc)
+			if (type == ObjectTypes.BattleNpc || type == ObjectTypes.EventNpc)
 				return Visibility.Collapsed;
 
 			// Hide NPC face warning if the NPC hack is enabled.

--- a/Anamnesis/Actor/Pages/ActionPage.xaml
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml
@@ -255,7 +255,7 @@
 			                Grid.Column="0"
 			                Style="{StaticResource Label}"/>
 
-						<ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding Source={x:Static anaMem:ActorType.AllActorTypes}}" SelectedIndex="{Binding Actor.Unsafe.ObjectKindInt}">
+						<ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding Source={x:Static anaMem:ObjectType.AllActorTypes}}" SelectedIndex="{Binding Actor.Unsafe.ObjectKindInt}">
                             <ComboBox.ItemContainerStyle>
                                 <Style TargetType="{x:Type ComboBoxItem}">
                                     <Setter Property="IsEnabled" Value="{Binding IsSupportedType}"/>

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -39,12 +39,12 @@ public class AnamnesisActorRefresher : IActorRefresher
 			return;
 
 		var isInGpose = GposeService.IsInGpose() ?? GposeService.Instance.IsGpose;
-		if (SettingsService.Current.EnableNpcHack && !isInGpose && actor.ObjectKind == ActorTypes.Player)
+		if (SettingsService.Current.EnableNpcHack && !isInGpose && actor.ObjectKind == ObjectTypes.Player)
 		{
 			// NOTE: This workaround is necessary only when we're in the overworld
-			actor.ObjectKind = ActorTypes.EventNpc;
+			actor.ObjectKind = ObjectTypes.EventNpc;
 			await this.RedrawService.Redraw(handle);
-			actor.ObjectKind = ActorTypes.Player;
+			actor.ObjectKind = ObjectTypes.Player;
 		}
 		else
 		{

--- a/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/BrioActorRefresher.cs
@@ -33,19 +33,19 @@ public class BrioActorRefresher : IActorRefresher
 	{
 		await Dispatch.MainThread();
 
-		bool doNpcHack = SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player;
+		bool doNpcHack = SettingsService.Current.EnableNpcHack && actor.ObjectKind == ObjectTypes.Player;
 
 		try
 		{
 			if (doNpcHack)
-				actor.ObjectKind = ActorTypes.EventNpc;
+				actor.ObjectKind = ObjectTypes.EventNpc;
 
 			await Brio.Redraw(actor.ObjectIndex);
 		}
 		finally
 		{
 			if (doNpcHack)
-				actor.ObjectKind = ActorTypes.Player;
+				actor.ObjectKind = ObjectTypes.Player;
 		}
 	}
 }

--- a/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/PenumbraActorRefresher.cs
@@ -34,19 +34,19 @@ public class PenumbraActorRefresher : IActorRefresher
 	{
 		await Dispatch.MainThread();
 
-		bool doNpcHack = SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player;
+		bool doNpcHack = SettingsService.Current.EnableNpcHack && actor.ObjectKind == ObjectTypes.Player;
 
 		try
 		{
 			if (doNpcHack)
-				actor.ObjectKind = ActorTypes.EventNpc;
+				actor.ObjectKind = ObjectTypes.EventNpc;
 
 			await Penumbra.Penumbra.Redraw(actor.Name, actor.ObjectIndex);
 		}
 		finally
 		{
 			if (doNpcHack)
-				actor.ObjectKind = ActorTypes.Player;
+				actor.ObjectKind = ObjectTypes.Player;
 		}
 	}
 }

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -165,7 +165,7 @@ public partial class CustomizeEditor : UserControl
 		if (dataPath.HasValue && CustomizeOptionsCache.ValidFaceIds.TryGetValue(dataPath.Value, out var validFaces))
 		{
 			// Apply offset logic for specific tribes
-			if (this.Actor != null && this.Actor.ObjectKind != ActorTypes.Player)
+			if (this.Actor != null && this.Actor.ObjectKind != ObjectTypes.Player)
 			{
 				this.ValidFaceOptions = validFaces.ToList();
 			}

--- a/Anamnesis/Core/Memory/Types/ObjectTypes.cs
+++ b/Anamnesis/Core/Memory/Types/ObjectTypes.cs
@@ -6,7 +6,7 @@ using Anamnesis.Styles;
 using System;
 using System.Collections.Generic;
 
-public enum ActorTypes : byte
+public enum ObjectTypes : byte
 {
 	None = 0x00,
 	Player = 0x01,
@@ -27,25 +27,22 @@ public enum ActorTypes : byte
 	CardStand = 0x10,
 }
 
-public class ActorType(string name, ActorTypes value)
+public class ObjectType(string name, ObjectTypes value)
 {
-	public static IEnumerable<ActorType> AllActorTypes
+	private static readonly List<ObjectType> s_allActorTypes;
+
+	static ObjectType()
 	{
-		get
+		s_allActorTypes = new List<ObjectType>();
+		foreach (ObjectTypes value in Enum.GetValues<ObjectTypes>())
 		{
-			List<ActorType> actorTypes = [];
-
-			foreach (ActorTypes value in Enum.GetValues<ActorTypes>())
-			{
-				var name = Enum.GetName(value);
-				actorTypes.Add(new ActorType(name!, value));
-			}
-
-			return actorTypes;
+			var name = Enum.GetName(value);
+			s_allActorTypes.Add(new ObjectType(name!, value));
 		}
 	}
 
+	public static IEnumerable<ObjectType> AllActorTypes => s_allActorTypes;
 	public string Name { get; private set; } = name;
-	public ActorTypes Value { get; private set; } = value;
+	public ObjectTypes Value { get; private set; } = value;
 	public bool IsSupportedType { get; private set; } = value.IsSupportedType();
 }

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -42,7 +42,7 @@ public class CharacterFile : JsonFileBase
 
 	public string? Nickname { get; set; } = null;
 	public uint ModelType { get; set; } = 0;
-	public ActorTypes ObjectKind { get; set; } = ActorTypes.None;
+	public ObjectTypes ObjectKind { get; set; } = ObjectTypes.None;
 
 	// appearance
 	public ActorCustomizeMemory.Races? Race { get; set; }

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -76,11 +76,25 @@ public class ActorMemory : GameObjectMemory, IDisposable
 		HeadgearEarsHidden = 1 << 5,
 	}
 
-	[Bind(0x0100, BindFlags.Pointer)] public new ActorModelMemory? ModelObject { get; set; }
+	[Bind(0x0100, BindFlags.Pointer)]
+	public new ActorModelMemory? ModelObject
+	{
+		get => base.ModelObject as ActorModelMemory;
+		set
+		{
+			if (base.ModelObject == value)
+				return;
+
+			base.ModelObject = value;
+			this.OnPropertyChanged(nameof(base.ModelObject));
+			this.OnPropertyChanged(nameof(this.ModelObject));
+		}
+	}
+
 	[Bind(0x01CA)] public byte ClassJob { get; set; } // Source: CharacterData; Calculated using GameObject size + ClassJob offset
 	[Bind(0x0680, BindFlags.Pointer)] public ActorMemory? Mount { get; set; } // Targets object within MountContainer
 	[Bind(0x0688)] public ushort MountId { get; set; }
-	[Bind(0x06E8, BindFlags.Pointer)] public ActorMemory? Companion { get; set; } // Targets object within CompanionContainer
+	[Bind(0x06E8, BindFlags.Pointer)] public CompanionMemory? Companion { get; set; } // Targets object within CompanionContainer
 	[Bind(0x0708)] public WeaponMemory? MainHand { get; set; }
 	[Bind(0x0778)] public WeaponMemory? OffHand { get; set; }
 	[Bind(0x08C8)] public ActorEquipmentMemory? Equipment { get; set; }
@@ -88,7 +102,7 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	[Bind(0x0936, BindFlags.ActorRefresh)] public bool HatHidden { get; set; }
 	[Bind(0x0937, BindFlags.ActorRefresh)] public CharacterFlagDefs CharacterFlags { get; set; }
 	[Bind(0x0938)] public GlassesMemory? Glasses { get; set; }
-	[Bind(0x0970, BindFlags.Pointer)] public ActorMemory? Ornament { get; set; } // Targets object within OrnamentContainer
+	[Bind(0x0970, BindFlags.Pointer)] public OrnamentMemory? Ornament { get; set; } // Targets object within OrnamentContainer
 	[Bind(0x0978)] public ushort OrnamentId { get; set; }
 	[Bind(0x0A30)] public AnimationMemory? Animation { get; set; }
 	[Bind(0x1A58)] public byte Voice { get; set; }
@@ -97,7 +111,6 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	[Bind(0x22E8)] public float Transparency { get; set; }
 	[Bind(0x2364)] public byte CharacterModeRaw { get; set; }
 	[Bind(0x2365)] public byte CharacterModeInput { get; set; }
-	[Bind(0x2384)] public byte AttachmentPoint { get; set; } // Part of Ornament
 
 	public PinnedActor? Pinned { get; set; }
 

--- a/Anamnesis/Memory/ActorModelMemory.cs
+++ b/Anamnesis/Memory/ActorModelMemory.cs
@@ -12,7 +12,20 @@ public class ActorModelMemory : DrawObjectMemory
 	/// <summary>
 	/// Gets or sets the main-hand weapon memory object.
 	/// </summary>
-	[Bind(0x030, BindFlags.Pointer)] public new ExtendedWeaponMemory? ChildObject { get; set; }
+	[Bind(0x030, BindFlags.Pointer)] public new ExtendedWeaponMemory? ChildObject
+	{
+		get => base.ChildObject as ExtendedWeaponMemory;
+		set
+		{
+			if (base.ChildObject == value)
+				return;
+
+			base.ChildObject = value;
+			this.OnPropertyChanged(nameof(base.ChildObject));
+			this.OnPropertyChanged(nameof(this.ChildObject));
+		}
+	}
+
 	[Bind(0x0A0, BindFlags.Pointer | BindFlags.OnlyInGPose | BindFlags.DontCacheOffsets, SyncGroup = "Skeleton")] public SkeletonMemory? Skeleton { get; set; }
 	[Bind(0x150, BindFlags.Pointer)] public BustMemory? Bust { get; set; }
 	[Bind(0x290)] public Color Tint { get; set; }

--- a/Anamnesis/Memory/CompanionMemory.cs
+++ b/Anamnesis/Memory/CompanionMemory.cs
@@ -1,0 +1,8 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Memory;
+
+public class CompanionMemory : ActorMemory
+{
+}

--- a/Anamnesis/Memory/DrawObjectMemory.cs
+++ b/Anamnesis/Memory/DrawObjectMemory.cs
@@ -3,6 +3,8 @@
 
 namespace Anamnesis.Memory;
 
+using PropertyChanged;
+
 /// <summary>
 /// Represents a drawable scene object in memory.
 /// </summary>
@@ -16,6 +18,7 @@ public class DrawObjectMemory : SceneObjectMemory
 	/// <summary>
 	/// Gets or sets a value indicating whether the object is visible.
 	/// </summary>
+	[DependsOn(nameof(Flags))]
 	public bool IsVisible
 	{
 		get => (this.Flags & 0x09) == 0x09;

--- a/Anamnesis/Memory/DummyActor.cs
+++ b/Anamnesis/Memory/DummyActor.cs
@@ -11,7 +11,7 @@ public class DummyActor : ActorMemory
 	public DummyActor(int id)
 	{
 		this.Address = (IntPtr)id;
-		this.ObjectKind = ActorTypes.Player;
+		this.ObjectKind = ObjectTypes.Player;
 		this.Nickname = "Dummy Actor " + id;
 	}
 

--- a/Anamnesis/Memory/GameObjectMemory.cs
+++ b/Anamnesis/Memory/GameObjectMemory.cs
@@ -23,7 +23,7 @@ public class GameObjectMemory : MemoryBase
 	[Bind(0x084)] public uint DataId { get; set; }
 	[Bind(0x088)] public uint OwnerId { get; set; }
 	[Bind(0x08C)] public ushort ObjectIndex { get; set; }
-	[Bind(0x090, BindFlags.ActorRefresh)] public ActorTypes ObjectKind { get; set; }
+	[Bind(0x090, BindFlags.ActorRefresh)] public ObjectTypes ObjectKind { get; set; }
 	[Bind(0x091)] public byte SubKind { get; set; }
 	[Bind(0x094)] public byte DistanceFromPlayerX { get; set; }
 	[Bind(0x096)] public byte DistanceFromPlayerY { get; set; }
@@ -65,11 +65,11 @@ public class GameObjectMemory : MemoryBase
 	public int ObjectKindInt
 	{
 		get => (int)this.ObjectKind;
-		set => this.ObjectKind = (ActorTypes)value;
+		set => this.ObjectKind = (ObjectTypes)value;
 	}
 
 	[DependsOn(nameof(ObjectKind))]
-	public bool IsPlayer => this.ObjectKind == ActorTypes.Player;
+	public bool IsPlayer => this.ObjectKind == ObjectTypes.Player;
 
 	[DependsOn(nameof(ObjectIndex), nameof(Address))]
 	public bool IsValid
@@ -99,9 +99,9 @@ public class GameObjectMemory : MemoryBase
 				if (actor.IsDisposed)
 					return false;
 
-				if (actor.ObjectKind != ActorTypes.Player &&
-					actor.ObjectKind != ActorTypes.BattleNpc &&
-					actor.ObjectKind != ActorTypes.EventNpc)
+				if (actor.ObjectKind != ObjectTypes.Player &&
+					actor.ObjectKind != ObjectTypes.BattleNpc &&
+					actor.ObjectKind != ObjectTypes.EventNpc)
 					return false;
 
 				return actor.ObjectId == this.OwnerId;

--- a/Anamnesis/Memory/MemoryBase.cs
+++ b/Anamnesis/Memory/MemoryBase.cs
@@ -100,20 +100,28 @@ public abstract class MemoryBase : INotifyPropertyChanged, IDisposable
 	public MemoryBase()
 	{
 		var processedNames = new HashSet<string>();
+		Type? currentType = this.GetType();
 
 		// Enumerate through the class' properties to retrieve memory offsets.
-		foreach (PropertyInfo property in this.GetType().GetProperties())
+		while (currentType != null && currentType != typeof(MemoryBase) && currentType != typeof(object))
 		{
-			// As some classes re-declare properties from their base classes, we need to
-			// filter out duplicates. Add only the first occurrence, which is the most-derived one.
-			if (!processedNames.Add(property.Name))
-				continue;
+			// Fetch only properties declared at the current inheritance level
+			var properties = currentType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-			BindAttribute? attribute = property.GetCustomAttribute<BindAttribute>();
-			if (attribute == null)
-				continue;
+			foreach (PropertyInfo property in properties)
+			{
+				if (!processedNames.Add(property.Name))
+					continue;
 
-			this.Binds.Add(property.Name, new PropertyBindInfo(this, property, attribute));
+				BindAttribute? attribute = property.GetCustomAttribute<BindAttribute>();
+				if (attribute == null)
+					continue;
+
+				this.Binds.Add(property.Name, new PropertyBindInfo(this, property, attribute));
+			}
+
+			// Move up to the base class
+			currentType = currentType.BaseType;
 		}
 	}
 

--- a/Anamnesis/Memory/OrnamentMemory.cs
+++ b/Anamnesis/Memory/OrnamentMemory.cs
@@ -1,0 +1,9 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace Anamnesis.Memory;
+
+public class OrnamentMemory : ActorMemory
+{
+	[Bind(0x2384)] public byte AttachmentPoint { get; set; }
+}

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -6,7 +6,6 @@ namespace Anamnesis;
 using Anamnesis.Core;
 using Anamnesis.Memory;
 using Anamnesis.Services;
-using Microsoft.Extensions.ObjectPool;
 using PropertyChanged;
 using Serilog;
 using System;
@@ -15,12 +14,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Remoting;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Threading;
 
 /// <summary>
 /// A representation of the game's object table in memory.
@@ -126,7 +125,14 @@ public class ObjectTable : INotifyPropertyChanged, IDisposable
 		if (!this.Contains(address))
 			return null;
 
-		return new ObjectHandle<T>(address, this);
+		var handle = new ObjectHandle<T>(address, this);
+		if (!handle.IsValid) // Handle creation succeeded but internal object type does not match requested type
+		{
+			handle.Dispose();
+			return null;
+		}
+
+		return handle;
 	}
 
 	/// <summary>
@@ -238,7 +244,7 @@ public class ObjectTable : INotifyPropertyChanged, IDisposable
 /// </typeparam>
 [AddINotifyPropertyChangedInterface]
 public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
-	where T : GameObjectMemory, new()
+	where T : GameObjectMemory
 {
 	private readonly ObjectTable table;
 	private IntPtr ptr;
@@ -262,20 +268,19 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 		if (ptr == IntPtr.Zero || !this.table.Contains(ptr))
 			throw new InvalidOperationException("Cannot create a handle for an object not part of the object table.");
 
-		var cacheKey = (ptr, typeof(T));
 		lock (ObjectHandleCache.Lock)
 		{
-			if (!ObjectHandleCache.Cache.TryGetValue(cacheKey, out var entry))
+			if (!ObjectHandleCache.Cache.TryGetValue(ptr, out var entry))
 			{
 				try
 				{
-					var obj = new T();
-					obj.SetAddress(ptr);
-					ObjectHandleCache.Cache.TryAdd(cacheKey, new ObjectHandleCache.CacheEntry(obj));
+					var obj = MemoryObjectFactory.Create(ptr);
+					entry = new ObjectHandleCache.CacheEntry(obj);
+					ObjectHandleCache.Cache.TryAdd(ptr, entry);
 				}
 				catch (Exception ex)
 				{
-					Log.Warning(ex, $"Failed to create memory object from address: {ptr}");
+					Log.Warning(ex, $"Failed to create memory object from address: 0x{ptr:X}");
 				}
 			}
 			else
@@ -307,7 +312,7 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	/// <summary>
 	/// Gets a value indicating whether this handle is still valid.
 	/// </summary>
-	public bool IsValid => !this.disposed && this.ptr != IntPtr.Zero && this.table.Contains(this.ptr);
+	public bool IsValid => !this.disposed && this.ptr != IntPtr.Zero && this.table.Contains(this.ptr) && this.Unsafe != null;
 
 	/// <summary>
 	/// An unsafe reference to the underlying object.
@@ -315,7 +320,7 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	/// <remarks>
 	/// This is intended only for UI data bindings and should not be used outside of that context.
 	/// </remarks>
-	public T? Unsafe => ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry) ? (T)entry.Object : null;
+	public T? Unsafe => ObjectHandleCache.Cache.TryGetValue(this.ptr, out var entry) ? entry.Object as T : null;
 
 	/// <summary>
 	/// Synchronizes all cached objects with the same base address.
@@ -326,33 +331,16 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	/// </remarks>
 	public void Synchronize(IReadOnlySet<string>? inclGroups = null, IReadOnlySet<string>? exclGroups = null)
 	{
-		var targets = ObjectHandleCache.ListPool.Get();
 		try
 		{
-			lock (ObjectHandleCache.Lock)
-			{
-				foreach (var (key, entry) in ObjectHandleCache.Cache)
-				{
-					if (key.Item1 == this.Address)
-						targets.Add(entry.Object);
-				}
-			}
+			if (!ObjectHandleCache.Cache.TryGetValue(this.Address, out var entry) || entry.Object.IsDisposed)
+				return;
 
-			int count = targets.Count;
-			for (int i = 0; i < count; i++)
-			{
-				var obj = targets[i];
-				if (!obj.IsDisposed)
-					obj.Synchronize(inclGroups, exclGroups);
-			}
+			entry.Object.Synchronize(inclGroups, exclGroups);
 		}
 		catch (Exception ex)
 		{
 			Log.Warning(ex, $"Failed to synchronize object handle at address: 0x{this.Address:X}");
-		}
-		finally
-		{
-			ObjectHandleCache.ListPool.Return(targets);
 		}
 	}
 
@@ -365,9 +353,9 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 			return;
 
 		this.disposed = true;
-		var cacheKey = (this.ptr, typeof(T));
-		this.ptr = IntPtr.Zero;
 		this.table.TableChanged -= this.OnTableChanged;
+		var cacheKey = this.ptr;
+		this.ptr = IntPtr.Zero;
 
 		lock (ObjectHandleCache.Lock)
 		{
@@ -399,11 +387,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Do(Action<T> action)
 	{
-		if (!this.IsValid)
-			return;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			action((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			action(obj);
 	}
 
 	/// <summary>
@@ -419,11 +404,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	public TResult? Do<TResult>(Func<T, TResult> func)
 		where TResult : struct
 	{
-		if (!this.IsValid)
-			return null;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			return func((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			return func(obj);
 
 		return null;
 	}
@@ -441,11 +423,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	public TResult? DoRef<TResult>(Func<T, TResult> func)
 		where TResult : class?
 	{
-		if (!this.IsValid)
-			return null;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			return func((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			return func(obj);
 
 		return null;
 	}
@@ -458,11 +437,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public async Task DoAsync(Func<T, Task> action)
 	{
-		if (!this.IsValid)
-			return;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			await action((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			await action(obj);
 	}
 
 	/// <summary>
@@ -478,11 +454,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	public async Task<TResult?> DoAsync<TResult>(Func<T, Task<TResult>> func)
 		where TResult : struct
 	{
-		if (!this.IsValid)
-			return null;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			return await func((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			return await func(obj);
 
 		return null;
 	}
@@ -500,11 +473,8 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	public async Task<TResult?> DoRefAsync<TResult>(Func<T, Task<TResult>> func)
 		where TResult : class
 	{
-		if (!this.IsValid)
-			return null;
-
-		if (ObjectHandleCache.Cache.TryGetValue((this.ptr, typeof(T)), out var entry))
-			return await func((T)entry.Object);
+		if (this.IsValid && this.Unsafe is T obj)
+			return await func(obj);
 
 		return null;
 	}
@@ -516,7 +486,7 @@ public class ObjectHandle<T> : INotifyPropertyChanged, IDisposable
 	{
 		if (!this.IsValid)
 		{
-			if (ObjectHandleCache.Cache.TryRemove((this.ptr, typeof(T)), out var entry))
+			if (ObjectHandleCache.Cache.TryRemove(this.ptr, out var entry))
 			{
 				if (!entry.Object.IsDisposed)
 					entry.Object.Dispose();
@@ -717,8 +687,7 @@ public class ActorService : ServiceBase<ActorService>
 internal static class ObjectHandleCache
 {
 	public static readonly Lock Lock = new();
-	public static readonly ConcurrentDictionary<(IntPtr, Type), CacheEntry> Cache = new();
-	public static readonly ObjectPool<List<GameObjectMemory>> ListPool = ObjectPool.Create<List<GameObjectMemory>>();
+	public static readonly ConcurrentDictionary<IntPtr, CacheEntry> Cache = new();
 
 	public sealed record class CacheEntry
 	{
@@ -731,5 +700,53 @@ internal static class ObjectHandleCache
 		}
 
 		public GameObjectMemory Object { get; init; }
+	}
+}
+
+internal static class MemoryObjectFactory
+{
+	private static readonly int s_objectKindOffset;
+	private static readonly Type s_objectKindType;
+
+	static MemoryObjectFactory()
+	{
+		var property = typeof(GameObjectMemory).GetProperty(nameof(GameObjectMemory.ObjectKind))
+			?? throw new InvalidOperationException($"Property '{nameof(GameObjectMemory.ObjectKind)}' not found in type '{nameof(GameObjectMemory)}'.");
+
+		var attr = property.GetCustomAttribute<BindAttribute>()
+			?? throw new InvalidOperationException($"Property '{property.Name}' does not have a bind attribute.");
+
+		if (attr.Offsets == null || attr.Offsets.Length != 1)
+			throw new InvalidOperationException($"Property '{property.Name}' must have exactly one offset defined in its bind attribute.");
+
+		s_objectKindOffset = attr.Offsets[0];
+		s_objectKindType = Enum.GetUnderlyingType(typeof(ObjectTypes));
+	}
+
+	public static GameObjectMemory Create(IntPtr address)
+	{
+		if (address == IntPtr.Zero)
+			throw new ArgumentException("Invalid address provided for memory object creation.", nameof(address));
+
+		var objKind = (ObjectTypes)MemoryService.Read(address + s_objectKindOffset, s_objectKindType);
+		GameObjectMemory obj = objKind switch
+		{
+			// NOTE(S):
+			// - Object type "Mount" is type "ActorMemory".
+			// - Object types "BattleNpc" and "EventNpc" are derived types of "ActorMemory" but Anamnesis is
+			//   not interested in their fields so we can treat them as a generic "ActorMemory".
+			// - Object types "Treasure", "Aetheryte", "GatheringPoint", "EventObject", "Area", "HousingObject",
+			//   and "ReactionEvent" are all derived types of "GameObjectMemory" but Anamnesis is not interested
+			//   in their fields so we can treat them as a generic "GameObjectMemory".
+			// - Object type "Retainer" shares the same object structure as "ActorMemory" but has a different
+			//   object type value, so we can safely treat it as "ActorMemory".
+			ObjectTypes.Player or ObjectTypes.BattleNpc or ObjectTypes.EventNpc or ObjectTypes.Mount or ObjectTypes.Retainer => new ActorMemory(),
+			ObjectTypes.Companion => new CompanionMemory(),
+			ObjectTypes.Ornament => new OrnamentMemory(),
+			_ => new GameObjectMemory(),
+		};
+
+		obj.SetAddress(address);
+		return obj;
 	}
 }

--- a/Anamnesis/Services/PinnedActor.cs
+++ b/Anamnesis/Services/PinnedActor.cs
@@ -57,7 +57,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 	public bool IsValid { get; private set; }
 
 	[DependsOn(nameof(Memory))]
-	public ActorTypes Kind => this.Memory?.Do(a => a.ObjectKind) ?? ActorTypes.None;
+	public ObjectTypes Kind => this.Memory?.Do(a => a.ObjectKind) ?? ObjectTypes.None;
 
 	[DependsOn(nameof(Memory))]
 	public bool IsGPoseActor => this.Memory?.Do(a => a.IsGPoseActor) ?? false;
@@ -213,7 +213,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 		backup.Apply(this.Memory, slot == null ? CharacterFile.SaveModes.All : CharacterFile.SaveModes.EquipmentSlot, slot);
 
 		// If we were a player, really make sure we are again.
-		if (backup.ObjectKind == ActorTypes.Player)
+		if (backup.ObjectKind == ObjectTypes.Player)
 		{
 			this.Memory.Do(a => a.ObjectKind = backup.ObjectKind);
 		}
@@ -382,7 +382,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 		var objectKind = this.Memory.Do(a => a.ObjectKind);
 		if (objectKind != null)
 		{
-			this.Icon = ((ActorTypes)objectKind).GetIcon();
+			this.Icon = ((ObjectTypes)objectKind).GetIcon();
 		}
 
 		this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Kind)));
@@ -412,7 +412,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 			var objectKind = this.Memory.Do(a => a.ObjectKind);
 			if (objectKind != null)
 			{
-				this.Icon = ((ActorTypes)objectKind).GetIcon();
+				this.Icon = ((ObjectTypes)objectKind).GetIcon();
 			}
 
 			return;

--- a/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
+++ b/Anamnesis/Styles/Extensions/ActorTypesExtensions.cs
@@ -8,29 +8,29 @@ using FontAwesome.Sharp;
 
 public static class ActorTypesExtensions
 {
-	public static bool IsSupportedType(this ActorTypes actorType)
+	public static bool IsSupportedType(this ObjectTypes actorType)
 	{
 		return actorType switch
 		{
-			ActorTypes.Player or ActorTypes.BattleNpc or ActorTypes.EventNpc or ActorTypes.Companion or ActorTypes.Mount or ActorTypes.Ornament or ActorTypes.Retainer => true,
+			ObjectTypes.Player or ObjectTypes.BattleNpc or ObjectTypes.EventNpc or ObjectTypes.Companion or ObjectTypes.Mount or ObjectTypes.Ornament or ObjectTypes.Retainer => true,
 			_ => false,
 		};
 	}
 
-	public static IconChar GetIcon(this ActorTypes type)
+	public static IconChar GetIcon(this ObjectTypes type)
 	{
 		return type switch
 		{
-			ActorTypes.Player => IconChar.UserAlt,
-			ActorTypes.BattleNpc => IconChar.UserShield,
-			ActorTypes.EventNpc => IconChar.UserNinja,
-			ActorTypes.Treasure => IconChar.Coins,
-			ActorTypes.Aetheryte => IconChar.Gem,
-			ActorTypes.Companion => IconChar.Cat,
-			ActorTypes.Retainer => IconChar.ConciergeBell,
-			ActorTypes.Housing => IconChar.Chair,
-			ActorTypes.Mount => IconChar.Horse,
-			ActorTypes.Ornament => IconChar.HatCowboy,
+			ObjectTypes.Player => IconChar.UserAlt,
+			ObjectTypes.BattleNpc => IconChar.UserShield,
+			ObjectTypes.EventNpc => IconChar.UserNinja,
+			ObjectTypes.Treasure => IconChar.Coins,
+			ObjectTypes.Aetheryte => IconChar.Gem,
+			ObjectTypes.Companion => IconChar.Cat,
+			ObjectTypes.Retainer => IconChar.ConciergeBell,
+			ObjectTypes.Housing => IconChar.Chair,
+			ObjectTypes.Mount => IconChar.Horse,
+			ObjectTypes.Ornament => IconChar.HatCowboy,
 			_ => IconChar.Question,
 		};
 	}

--- a/Anamnesis/Tabs/DeveloperTab.xaml
+++ b/Anamnesis/Tabs/DeveloperTab.xaml
@@ -48,7 +48,7 @@
 			<StackPanel>
 				<XivToolsWpf:TextBlock Text="{Binding TargetService.PlayerTargetHandle.Unsafe.Index, StringFormat=Index: {0:D}, Mode=OneWay}"/>
 
-				<ComboBox ItemsSource="{Binding Source={x:Static anaMem:ActorType.AllActorTypes}}" SelectedIndex="{Binding TargetService.PlayerTargetHandle.Unsafe.ObjectKindInt}">
+				<ComboBox ItemsSource="{Binding Source={x:Static anaMem:ObjectType.AllActorTypes}}" SelectedIndex="{Binding TargetService.PlayerTargetHandle.Unsafe.ObjectKindInt}">
 					<ComboBox.ItemContainerStyle>
 						<Style TargetType="{x:Type ComboBoxItem}">
 							<Setter Property="IsEnabled" Value="{Binding IsSupportedType}"/>

--- a/Anamnesis/Views/TargetSelectorView.xaml.cs
+++ b/Anamnesis/Views/TargetSelectorView.xaml.cs
@@ -174,28 +174,28 @@ public partial class TargetSelectorView : TargetSelectorDrawer
 			if (!s_includeHidden && actor.IsHidden)
 				return false;
 
-			if (!s_includePlayers && actor.ObjectKind == Memory.ActorTypes.Player)
+			if (!s_includePlayers && actor.ObjectKind == Memory.ObjectTypes.Player)
 				return false;
 
-			if (!s_includeCompanions && actor.ObjectKind == Memory.ActorTypes.Companion)
+			if (!s_includeCompanions && actor.ObjectKind == Memory.ObjectTypes.Companion)
 				return false;
 
-			if (!s_includeMounts && actor.ObjectKind == Memory.ActorTypes.Mount)
+			if (!s_includeMounts && actor.ObjectKind == Memory.ObjectTypes.Mount)
 				return false;
 
-			if (!s_includeOrnaments && actor.ObjectKind == Memory.ActorTypes.Ornament)
+			if (!s_includeOrnaments && actor.ObjectKind == Memory.ObjectTypes.Ornament)
 				return false;
 
-			if (!s_includeNPCs && (actor.ObjectKind == Memory.ActorTypes.BattleNpc || actor.ObjectKind == Memory.ActorTypes.EventNpc))
+			if (!s_includeNPCs && (actor.ObjectKind == Memory.ObjectTypes.BattleNpc || actor.ObjectKind == Memory.ObjectTypes.EventNpc))
 				return false;
 
 			if (!s_includeOther
-				&& actor.ObjectKind != Memory.ActorTypes.Player
-				&& actor.ObjectKind != Memory.ActorTypes.Companion
-				&& actor.ObjectKind != Memory.ActorTypes.BattleNpc
-				&& actor.ObjectKind != Memory.ActorTypes.EventNpc
-				&& actor.ObjectKind != Memory.ActorTypes.Mount
-				&& actor.ObjectKind != Memory.ActorTypes.Ornament)
+				&& actor.ObjectKind != Memory.ObjectTypes.Player
+				&& actor.ObjectKind != Memory.ObjectTypes.Companion
+				&& actor.ObjectKind != Memory.ObjectTypes.BattleNpc
+				&& actor.ObjectKind != Memory.ObjectTypes.EventNpc
+				&& actor.ObjectKind != Memory.ObjectTypes.Mount
+				&& actor.ObjectKind != Memory.ObjectTypes.Ornament)
 			{
 				return false;
 			}


### PR DESCRIPTION
Reopened pull request to target upstream.
Original: https://github.com/ergoxiv/Anamnesis/pull/12.

---

This pull request aims to optimize the object table/object handle system I introduced to Anamnesis with https://github.com/imchillin/Anamnesis/pull/1557.

**Changelog:**
- Object handles were updated to use one internal object instance internally that's determined based on the object's `ObjectType` value.
  - **Explanation:** As a result of this change, the target service no longer needs to synchronize multiple internal object instances for the derived class and its inherited classes (e.g. `GameObjectMemory` & `ActorMemory`). This significantly reduces CPU usage.
- Created new memory classes `OrnamentMemory` and `CompanionMemory` to differentiate between object types whenever possible (and desired).
- Fixed issue with hidden member fields (the properties with the `new` modifier) not synchronizing properly as they used different backing fields. This includes a patch in the constructions of the binds list in `MemoryBase` to guarantee that we use the inner-most bind for synchronizations, which was not guaranteed in the old implementation.
  - **Explanation:** These changes surfaced once I transitioned to using a single internal object instance within the object handles cache, so they were not caught in the original object handle system's implementation.
- Updated object type list to construct once on initialization instead of every property retrieval.
- Renamed enum `ActorTypes` to `ObjectTypes` and class `ActorType` to `ObjectType.

---

## Before

<img width="375" height="344" alt="image" src="https://github.com/user-attachments/assets/334aadf8-6f37-4985-b8ed-4a9cd6629583" />

<img width="1101" height="591" alt="image" src="https://github.com/user-attachments/assets/ccc12aac-aad7-4e77-967b-47a25cbd2c69" />

## After

<img width="381" height="272" alt="image" src="https://github.com/user-attachments/assets/c90f74a1-d9cb-4890-88ba-5785b86c691a" />

<img width="1091" height="853" alt="image" src="https://github.com/user-attachments/assets/04de22cf-5421-4911-881d-985ac2a9a7d2" />