### PR TITLE
Adjustments to pose import checkbox data bindings and notification events

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml
+++ b/Anamnesis/Actor/Pages/PosePage.xaml
@@ -1,5 +1,6 @@
 ﻿<UserControl
 	x:Class="Anamnesis.Actor.Pages.PosePage"
+	x:Name="RootControl"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:anaUtils="clr-namespace:Anamnesis"
@@ -191,21 +192,21 @@
 								<ContentControl>
 									<StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Background="Transparent">
 										<CheckBox Margin="3" VerticalContentAlignment="Center"
-												   IsChecked="{Binding ImportPoseRotation, Mode=TwoWay}">
+												   IsChecked="{Binding ImportPoseRotation, ElementName=RootControl, Mode=TwoWay}">
 											<XivToolsWpf:TextBlock Key="Pose_EnableRotation" Margin="0,-2,0,2" />
 											<CheckBox.ToolTip>
 												<XivToolsWpf:TextBlock Key="Pose_ImportRotationImportTooltip" />
 											</CheckBox.ToolTip>
 										</CheckBox>
 										<CheckBox Margin="3" VerticalContentAlignment="Center"
-												  IsChecked="{Binding ImportPosePosition, Mode=TwoWay}">
+												  IsChecked="{Binding ImportPosePosition, ElementName=RootControl, Mode=TwoWay}">
 											<XivToolsWpf:TextBlock Key="Pose_EnablePosition" Margin="0,-2,0,2" />
 											<CheckBox.ToolTip>
 												<XivToolsWpf:TextBlock Key="Pose_ImportPositionImportTooltip" />
 											</CheckBox.ToolTip>
 										</CheckBox>
 										<CheckBox Margin="3" VerticalContentAlignment="Center"
-												  IsChecked="{Binding ImportPoseScale, Mode=TwoWay}">
+												  IsChecked="{Binding ImportPoseScale, ElementName=RootControl, Mode=TwoWay}">
 											<XivToolsWpf:TextBlock Key="Pose_EnableScale" Margin="0,-2,0,2" />
 											<CheckBox.ToolTip>
 												<XivToolsWpf:TextBlock Key="Pose_ImportScaleImportTooltip" />

--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -148,9 +148,13 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			// Don't disable if it's the only one enabled
 			// We want to have at least one option enabled at all times
 			if (!value && !this.importPosePosition && !this.importPoseScale)
+			{
+				this.RaisePropertyChanged(nameof(this.ImportPoseRotation));
 				return;
+			}
 
 			this.importPoseRotation = value;
+			this.RaisePropertyChanged(nameof(this.ImportPoseRotation));
 		}
 	}
 
@@ -162,9 +166,13 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			// Don't disable if it's the only one enabled
 			// We want to have at least one option enabled at all times
 			if (!value && !this.importPoseRotation && !this.importPoseScale)
+			{
+				this.RaisePropertyChanged(nameof(this.ImportPosePosition));
 				return;
+			}
 
 			this.importPosePosition = value;
+			this.RaisePropertyChanged(nameof(this.ImportPosePosition));
 		}
 	}
 
@@ -176,9 +184,13 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 			// Don't disable if it's the only one enabled
 			// We want to have at least one option enabled at all times
 			if (!value && !this.importPoseRotation && !this.importPosePosition)
+			{
+				this.RaisePropertyChanged(nameof(this.ImportPoseScale));
 				return;
+			}
 
 			this.importPoseScale = value;
+			this.RaisePropertyChanged(nameof(this.ImportPoseScale));
 		}
 	}
 


### PR DESCRIPTION
Some users have run into an issue where toggling the pose import checkboxes has no effect on the import behavior. I suspect this is caused by a breaking data binding. While I haven't been able to reproduce the issue locally, I hope that by explicitly targetting the user control instead of using data context inheritence, this issue disappears.