### PR TITLE
Fixed issue where skipping available update would crash the application

### DIFF
--- a/Anamnesis/Updater/UpdateService.cs
+++ b/Anamnesis/Updater/UpdateService.cs
@@ -122,6 +122,7 @@ public partial class UpdateService : ServiceBase<UpdateService>
 					Changes = this.currentRelease.Changes,
 				};
 				await ViewService.ShowDialog<UpdateDialog, bool?>("Update", dlg);
+				update = dlg.IsUpdating;
 			}
 
 			SettingsService.Current.LastUpdateCheck = DateTimeOffset.Now;


### PR DESCRIPTION
`UpdateService.CheckForUpdates` was incorrectly returning `true` even when the user has selected "Skip" in the update dialog, triggering an `UpdateTriggeredException`. The exception halts the service manager, preventing it from initializing the rest of the services, causing an application crash when the main window attempts to access `TargetService`, which stayed uninitialized due to the skipped initialization.

The solution is to return `true` only if an update is going to take place.