### PR TITLE
Fixed hidden headgear appearing on actor redraw

### DIFF
--- a/RemoteController/Drivers/Modules/RedrawModule.cs
+++ b/RemoteController/Drivers/Modules/RedrawModule.cs
@@ -178,13 +178,26 @@ public sealed class RedrawModule
 		if (drawObjPtr == nint.Zero || drawDataPtr == nint.Zero)
 			return [0];
 
+		DrawDataContainerStruct* drawData = (DrawDataContainerStruct*)drawDataPtr;
+		if (drawData == null)
+			return [0];
+
 		bool success = true;
 
 		if (req.Flags.HasFlag(RedrawFlags.Appearance) && req.DrawData != null)
 		{
+			bool isHeadgearHidden = drawData->IsHeadgearHidden;
+
 			fixed (byte* p = req.DrawData)
 			{
 				success = this.updateDrawData.OriginalFunction(drawObjPtr, p, false);
+			}
+
+			// Re-enforce headgear hidden state after applying new draw data
+			if (success && isHeadgearHidden)
+			{
+				drawData->IsHeadgearHidden = false;
+				this.SetHeadgearHidden(drawDataPtr, 1);
 			}
 		}
 
@@ -198,8 +211,6 @@ public sealed class RedrawModule
 
 			if (req.Flags.HasFlag(RedrawFlags.Facewear))
 			{
-				DrawDataContainerStruct* drawData = (DrawDataContainerStruct*)drawDataPtr;
-
 				if (drawData->FacewearId == req.FacewearId)
 				{
 					Log.Verbose("Facewear ID matches; Manually tripping facewear dirty flag.");

--- a/RemoteController/Interop/Types/DrawDataContainer.cs
+++ b/RemoteController/Interop/Types/DrawDataContainer.cs
@@ -10,8 +10,15 @@ public struct DrawDataContainer
 {
 	public const int FACEWEAR_DIRTY_FLAG = 0x248;
 
+	[FieldOffset(0x23E)] public byte DrawFlags;
 	[FieldOffset(0x240)] public ushort FacewearId;
 	[FieldOffset(FACEWEAR_DIRTY_FLAG)] public byte FacewearDirtyFlag;
+
+	public bool IsHeadgearHidden
+	{
+		readonly get => (this.DrawFlags & 0x01) == 0x01;
+		set => this.DrawFlags = (byte)(value ? this.DrawFlags | 0x01 : this.DrawFlags & ~0x01);
+	}
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 8)]


### PR DESCRIPTION
It seems that the native function for `UpdateDrawData` will make the headgear visible despite its internal memory state. I added a force hide action after updating the draw data to enforce intended headgear visibility.