### PR TITLE
Validate Anamnesis for Patch 7.45 (Hotfix 1)

### DIFF
--- a/Anamnesis/Actor/Pages/PosePage.xaml.cs
+++ b/Anamnesis/Actor/Pages/PosePage.xaml.cs
@@ -609,22 +609,42 @@ public partial class PosePage : UserControl, INotifyPropertyChanged
 		this.Skeleton = null;
 	}
 
-	private void OnPoseServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
+	private async void OnPoseServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		// Don't refresh the skeleton if the selected bones text changes to prevent a loop
 		if (e.PropertyName == nameof(PoseService.SelectedBonesText))
 			return;
 
-		this.Skeleton?.Reselect();
-		this.Skeleton?.ReadTransforms();
-
 		if (e.PropertyName == nameof(PoseService.IsEnabled))
 		{
+			await WorkQueue.Value.Enqueue(() =>
+			{
+				this.Skeleton?.Actor?.Do(actor =>
+				{
+					var skeleton = actor.ModelObject?.Skeleton;
+					if (skeleton == null || skeleton.Address == IntPtr.Zero)
+						return;
+
+					try
+					{
+						skeleton.Synchronize();
+					}
+					catch (Exception ex)
+					{
+						Log.Verbose(ex, "Failed to sync skeleton on pose service property change.");
+					}
+				});
+
+				this.Skeleton?.ReadTransforms();
+			});
+
 			if (!PoseService.IsEnabled)
 				this.OnClearClicked(null, null);
 
 			Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, BoneViewManager.Instance.Refresh);
 		}
+
+		this.TransformEditor?.InvalidateInternalState();
 	}
 
 	private void OnDataContextChanged(object? sender, DependencyPropertyChangedEventArgs e)

--- a/Anamnesis/Actor/Utilities/ItemUtility.cs
+++ b/Anamnesis/Actor/Utilities/ItemUtility.cs
@@ -8,10 +8,12 @@ using Anamnesis.GameData;
 using Anamnesis.GameData.Excel;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Services;
-using System.Collections.Concurrent;
+using System.Linq;
 
 public static class ItemUtility
 {
+	public const uint EMPERORS_NEW_FISTS_ROWID = 13775;
+
 	public static readonly DummyNoneItem NoneItem = new();
 	public static readonly DummyNoneDye NoneDye = new();
 	public static readonly NpcBodyItem NpcBodyItem = new();
@@ -20,13 +22,13 @@ public static class ItemUtility
 	public static readonly InvisibleBodyItem InvisibileBodyItem = new();
 	public static readonly InvisibleHeadItem InvisibileHeadItem = new();
 
-	private static readonly ConcurrentDictionary<string, IItem> s_itemLookup = new();
-	private static readonly ConcurrentDictionary<string, IItem> s_chocoboItemLookup = new();
+	private static IItem? s_emperorsNewFists;
+	private static ChocoboSkinItem? s_yellowChocoboSkin;
+	private static ChocoboSkinItem? s_blackChocoboSkin;
 
-	public static IItem EmperorsNewFists => GameDataService.Items.GetRow(13775);
-
-	public static ChocoboSkinItem YellowChocoboSkin => new(GameDataService.Mounts.GetRow(1), 1);
-	public static ChocoboSkinItem BlackChocoboSkin => new(GameDataService.Mounts.GetRow(1), 2);
+	public static IItem EmperorsNewFists => s_emperorsNewFists ??= GameDataService.Items.GetRow(EMPERORS_NEW_FISTS_ROWID);
+	public static ChocoboSkinItem YellowChocoboSkin => s_yellowChocoboSkin ??= new(GameDataService.Mounts.GetRow(1), 1);
+	public static ChocoboSkinItem BlackChocoboSkin => s_blackChocoboSkin ??= new(GameDataService.Mounts.GetRow(1), 2);
 
 	/// <summary>
 	/// Searches the gamedata service item list for an item with the given model attributes.
@@ -39,11 +41,9 @@ public static class ItemUtility
 		if (modelBase == NpcBodyItem.ModelBase)
 			return NpcBodyItem;
 
-		string lookupKey = $"{slot}_{modelSet}_{modelBase}_{modelVariant}";
-
 		return isChocobo
-			? s_chocoboItemLookup.GetOrAdd(lookupKey, _ => ChocoboItemSearch(slot, modelSet, modelBase, modelVariant))
-			: s_itemLookup.GetOrAdd(lookupKey, _ => ItemSearch(slot, modelSet, modelBase, modelVariant));
+			? ChocoboItemSearch(slot, modelSet, modelBase, modelVariant)
+			: ItemSearch(slot, modelSet, modelBase, modelVariant);
 	}
 
 	public static IItem GetDummyItem(ushort modelSet, ushort modelBase, ushort modelVariant)
@@ -99,8 +99,10 @@ public static class ItemUtility
 	{
 		var model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
 
-		foreach (IItem tItem in GameDataService.Items)
+		foreach (uint rowId in GameDataService.ItemsByModel[model])
 		{
+			var tItem = GameDataService.Items.GetRow(rowId);
+
 			if (slot == ItemSlots.MainHand || slot == ItemSlots.OffHand)
 			{
 				if (!tItem.IsWeapon)
@@ -116,12 +118,16 @@ public static class ItemUtility
 			if (slot == ItemSlots.Wrists && tItem.Name.StartsWith("Promise of"))
 				continue;
 
-			if (tItem.Model == model)
-				return tItem;
+			return tItem;
+		}
 
-			if (slot == ItemSlots.MainHand || slot == ItemSlots.OffHand)
+		if (slot == ItemSlots.MainHand || slot == ItemSlots.OffHand)
+		{
+			foreach (uint rowId in GameDataService.ItemsBySubModel[model])
 			{
-				if (tItem.HasSubModel && tItem.SubModel == model)
+				var tItem = GameDataService.Items.GetRow(rowId);
+
+				if (tItem.IsWeapon)
 					return tItem;
 			}
 		}

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -11,8 +11,9 @@ using Anamnesis.GameData.Sheets;
 using Anamnesis.Keyboard;
 using Anamnesis.Services;
 using Anamnesis.Styles.Drawers;
+using Lumina;
+using Lumina.Text.ReadOnly;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using XivToolsWpf;
@@ -191,20 +192,31 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	protected override int Compare(IItem itemA, IItem itemB)
 	{
-		if (itemA.IsFavorite && !itemB.IsFavorite)
+		bool isItemAFavorite = FavoritesService.IsFavorite(itemA);
+		bool isItemBFavorite = FavoritesService.IsFavorite(itemB);
+
+		if (isItemAFavorite && !isItemBFavorite)
 			return -1;
 
-		if (!itemA.IsFavorite && itemB.IsFavorite)
+		if (!isItemAFavorite && isItemBFavorite)
 			return 1;
 
 		// Push the Emperor's New Fists to the top of the list for weapons.
 		if (this.IsWeaponSlot)
 		{
-			if (itemA == ItemUtility.EmperorsNewFists && itemB != ItemUtility.EmperorsNewFists)
+			if (itemA.RowId == ItemUtility.EMPERORS_NEW_FISTS_ROWID && itemB.RowId != ItemUtility.EMPERORS_NEW_FISTS_ROWID)
 				return -1;
 
-			if (itemA != ItemUtility.EmperorsNewFists && itemB == ItemUtility.EmperorsNewFists)
+			if (itemA.RowId != ItemUtility.EMPERORS_NEW_FISTS_ROWID && itemB.RowId == ItemUtility.EMPERORS_NEW_FISTS_ROWID)
 				return 1;
+		}
+
+		if (this.SortMode == SortModes.Name)
+		{
+			if (itemA.SeName is ReadOnlySeString aSeName && itemB.SeName is ReadOnlySeString bSeName)
+				return aSeName.Data.Span.SequenceCompareTo(bSeName.Data.Span);
+
+			return string.Compare(itemA.Name, itemB.Name, StringComparison.Ordinal);
 		}
 
 		return this.SortMode switch
@@ -218,8 +230,8 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	protected override bool Filter(IItem item, string[]? search)
 	{
-		// skip items without names
-		if (string.IsNullOrEmpty(item.Name))
+		bool hasName = item.SeName.HasValue ? !item.SeName.Value.IsEmpty : !string.IsNullOrEmpty(item.Name);
+		if (!hasName)
 			return false;
 
 		if (this.IsWeaponSlot)
@@ -250,45 +262,51 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	private static bool HasClass(Classes a, Classes b)
 	{
-		foreach (Classes? job in Enum.GetValues<Classes>().Select(v => (Classes?)v))
-		{
-			if (job == null || job == Classes.None)
-				continue;
+		if (a == Classes.None)
+			return b == Classes.All;
 
-			if (a.HasFlagUnsafe(job.Value) && b.HasFlagUnsafe(job.Value))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return (a & b) != Classes.None;
 	}
 
 	private static bool MatchesSearch(IItem item, string[]? search = null)
 	{
-		bool matches = false;
+		if (SearchUtility.Matches(item.Name, search))
+			return true;
 
-		matches |= SearchUtility.Matches(item.Name, search);
-		matches |= SearchUtility.Matches(item.Description, search);
-		matches |= SearchUtility.Matches(item.ModelSet.ToString(), search);
-		matches |= SearchUtility.Matches(item.ModelBase.ToString(), search);
-		matches |= SearchUtility.Matches(item.ModelVariant.ToString(), search);
+		if (SearchUtility.Matches(item.Description, search))
+			return true;
+
+		if (SearchUtility.Matches(item.ModelSet.ToString(), search))
+			return true;
+
+		if (SearchUtility.Matches(item.ModelBase.ToString(), search))
+			return true;
+
+		if (SearchUtility.Matches(item.ModelVariant.ToString(), search))
+			return true;
 
 		if (item.HasSubModel)
 		{
-			matches |= SearchUtility.Matches(item.SubModelSet.ToString(), search);
-			matches |= SearchUtility.Matches(item.SubModelBase.ToString(), search);
-			matches |= SearchUtility.Matches(item.SubModelVariant.ToString(), search);
+			if (SearchUtility.Matches(item.SubModelSet.ToString(), search))
+				return true;
+
+			if (SearchUtility.Matches(item.SubModelBase.ToString(), search))
+				return true;
+
+			if (SearchUtility.Matches(item.SubModelVariant.ToString(), search))
+				return true;
 		}
 
-		matches |= SearchUtility.Matches(item.RowId.ToString(), search);
+		if (SearchUtility.Matches(item.RowId.ToString(), search))
+			return true;
 
 		if (item.Mod != null && item.Mod.ModPack != null)
 		{
-			matches |= SearchUtility.Matches(item.Mod.ModPack.Name, search);
+			if (SearchUtility.Matches(item.Mod.ModPack.Name, search))
+				return true;
 		}
 
-		return matches;
+		return false;
 	}
 
 	private bool ValidCategory(IItem item)
@@ -312,10 +330,11 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 	private bool CanEquip(Item item)
 	{
-		if (!item.EquipRestriction.IsValid || this.actor == null || this.actor.DrawData.Customize == null)
+		var restriction = LuminaExtensions.GetEquipRaceCategory(item.EquipRestrictionId);
+		if (restriction == null || this.actor == null || this.actor.DrawData.Customize == null)
 			return true;
 
-		return item.EquipRestriction.Value.CanEquip(this.actor.DrawData.Customize.Race, this.actor.DrawData.Customize.Gender);
+		return restriction.Value.CanEquip(this.actor.DrawData.Customize.Race, this.actor.DrawData.Customize.Gender);
 	}
 
 	private void ClearSlot()

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -331,9 +331,7 @@ public partial class ItemView : UserControl
 
 			SetModel(this.ItemModel, modelSet, modelBase, modelVariant);
 
-			if (autoOffhand && this.Slot == ItemSlots.MainHand
-				&& item is Item ivm
-				&& ivm.EquipSlotCategory.Value.OffHand == -1)
+			if (autoOffhand && this.Slot == ItemSlots.MainHand && item is Item ivm)
 			{
 				if (ivm.HasSubModel)
 				{

--- a/Anamnesis/Extensions/LuminaExtensions.cs
+++ b/Anamnesis/Extensions/LuminaExtensions.cs
@@ -5,10 +5,108 @@ namespace Lumina;
 
 using Anamnesis.Actor.Utilities;
 using Anamnesis.GameData;
+using Anamnesis.Services;
+using System;
 using System.Runtime.CompilerServices;
 
 public static class LuminaExtensions
 {
+	private static readonly Lazy<ItemSlots[]> s_itemSlotsCache = new(() =>
+	{
+		var sheet = GameDataService.GetExcelSheet<Excel.Sheets.EquipSlotCategory>();
+		if (sheet == null)
+			return [];
+
+		uint maxRowId = 0;
+		foreach (var row in sheet)
+		{
+			if (row.RowId > maxRowId)
+				maxRowId = row.RowId;
+		}
+
+		var cache = new ItemSlots[maxRowId + 1];
+		foreach (var row in sheet)
+		{
+			cache[row.RowId] = row.GetItemSlots();
+		}
+
+		return cache;
+	});
+
+	private static readonly Lazy<Classes[]> s_classJobCache = new(() =>
+	{
+		var sheet = GameDataService.GetExcelSheet<Anamnesis.GameData.Excel.ClassJobCategory>();
+		if (sheet == null)
+			return [];
+
+		uint maxRowId = 0;
+		foreach (var row in sheet)
+		{
+			if (row.RowId > maxRowId)
+				maxRowId = row.RowId;
+		}
+
+		var cache = new Classes[maxRowId + 1];
+		foreach (var row in sheet)
+		{
+			cache[row.RowId] = row.ToFlags();
+		}
+
+		return cache;
+	});
+
+	private static readonly Lazy<Anamnesis.GameData.Excel.EquipRaceCategory?[]> s_equipRaceCache = new(() =>
+	{
+		var sheet = GameDataService.GetExcelSheet<Anamnesis.GameData.Excel.EquipRaceCategory>();
+		if (sheet == null)
+			return [];
+
+		uint maxRowId = 0;
+		foreach (var row in sheet)
+		{
+			if (row.RowId > maxRowId)
+				maxRowId = row.RowId;
+		}
+
+		var cache = new Anamnesis.GameData.Excel.EquipRaceCategory?[maxRowId + 1];
+		foreach (var row in sheet)
+		{
+			cache[row.RowId] = row;
+		}
+
+		return cache;
+	});
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static ItemSlots GetItemSlots(byte equipSlotCategoryId)
+	{
+		var cache = s_itemSlotsCache.Value;
+		if (equipSlotCategoryId < cache.Length)
+			return cache[equipSlotCategoryId];
+
+		return ItemSlots.None;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static Classes GetClassJobs(byte classJobCategoryId)
+	{
+		var cache = s_classJobCache.Value;
+		if (classJobCategoryId < cache.Length)
+			return cache[classJobCategoryId];
+
+		return Classes.None;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static Anamnesis.GameData.Excel.EquipRaceCategory? GetEquipRaceCategory(byte equipRaceCategoryId)
+	{
+		var cache = s_equipRaceCache.Value;
+		if (equipRaceCategoryId < cache.Length)
+			return cache[equipRaceCategoryId];
+
+		return null;
+	}
+
 	public static IItem GetWeaponItem(ItemSlots slot, ulong val)
 	{
 		if (val == 0)

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -860,8 +860,8 @@ public class CharacterFile : JsonFileBase
 
 				if (curItem is Anamnesis.GameData.Excel.Item curExcel && tgtItem is Anamnesis.GameData.Excel.Item tgtExcel)
 				{
-					var curFlags = curExcel.ClassJobCategory.Value.ToFlags();
-					var tgtFlags = tgtExcel.ClassJobCategory.Value.ToFlags();
+					var curFlags = curExcel.EquipableClasses;
+					var tgtFlags = tgtExcel.EquipableClasses;
 
 					// Treat crafters and gatherers as equivalent as they use the paladin battle/idle animation.
 					if (AreBothCraftersOrGatherers(curFlags, tgtFlags))

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -721,6 +721,7 @@ public class CharacterFile : JsonFileBase
 			return c.ModelType != t.ModelType ||
 				   c.Race != t.Race ||
 				   c.Gender != t.Gender ||
+				   c.Age != t.Age ||
 				   c.Tribe != t.Tribe ||
 				   c.Head != t.Head;
 		}

--- a/Anamnesis/GameData/Excel/Item.cs
+++ b/Anamnesis/GameData/Excel/Item.cs
@@ -9,7 +9,7 @@ using Anamnesis.Services;
 using Anamnesis.TexTools;
 using Lumina;
 using Lumina.Excel;
-using Lumina.Excel.Sheets;
+using Lumina.Text.ReadOnly;
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -17,16 +17,28 @@ using System.Runtime.CompilerServices;
 /// <summary>Represents an item in the game data.</summary>
 [Sheet("Item", 0xE9A33C9D)]
 public readonly unsafe struct Item(ExcelPage page, uint offset, uint row)
-	: IExcelRow<Item>, IItem
+	: IExcelRow<Item>, IItem, IEquatable<Item>
 {
 	/// <inheritdoc/>
 	public uint RowId => row;
 
 	/// <inheritdoc/>
-	public readonly string Name => page.ReadString(offset + 12, offset).ToString() ?? string.Empty;
+	/// <remarks>
+	/// Use <see cref="SeName"/> whenever possible to avoid unnecessary string allocations.
+	/// </remarks>
+	public readonly string Name => this.SeName?.ToString() ?? string.Empty;
 
 	/// <inheritdoc/>
-	public string Description => page.ReadString(offset + 8, offset).ToString() ?? string.Empty;
+	public readonly ReadOnlySeString? SeName => page.ReadString(offset + 12, offset);
+
+	/// <inheritdoc/>
+	/// <remarks>
+	/// Use <see cref="SeDescription"/> whenever possible to avoid unnecessary string allocations.
+	/// </remarks>
+	public string Description => this.SeDescription?.ToString() ?? string.Empty;
+
+	/// <inheritdoc/>
+	public readonly ReadOnlySeString? SeDescription => page.ReadString(offset + 8, offset);
 
 	/// <inheritdoc/>
 	public ImgRef Icon => new(page.ReadUInt16(offset + 136));
@@ -62,22 +74,22 @@ public readonly unsafe struct Item(ExcelPage page, uint offset, uint row)
 	public ushort SubModelVariant => this.IsWeapon ? page.ReadWeaponVariant(offset + 32) : page.ReadVariant(offset + 32);
 
 	/// <summary>Gets the classes that can equip the item.</summary>
-	public Classes EquipableClasses => this.ClassJobCategory.Value.ToFlags();
+	public Classes EquipableClasses => LuminaExtensions.GetClassJobs(this.ClassJobCategoryId);
 
 	/// <summary>
-	/// Gets the EquipSlotCategory reference object, representing the the equipment slot data associated with the item.
+	/// Gets the EquipSlotCategory identifier, representing the the equipment slot data associated with the item.
 	/// </summary>
-	public readonly RowRef<EquipSlotCategory> EquipSlotCategory => new(page.Module, (uint)page.ReadUInt8(offset + 154), page.Language);
+	public readonly byte EquipSlotCategoryId => page.ReadUInt8(offset + 154);
 
 	/// <summary>
-	/// Gets the EquipRaceCategory reference object, representing the item's equip restrictions.
+	/// Gets the EquipRaceCategory identifier, representing the item's equip restrictions.
 	/// </summary>
-	public RowRef<EquipRaceCategory> EquipRestriction => new(page.Module, (uint)page.ReadUInt8(offset + 80), page.Language);
+	public readonly byte EquipRestrictionId => page.ReadUInt8(offset + 80);
 
 	/// <summary>
-	/// Gets the ClassJobCategory reference object, representing the class job category the item belongs to.
+	/// Gets the ClassJobCategory identifier, representing the class job category the item belongs to.
 	/// </summary>
-	public readonly RowRef<ClassJobCategory> ClassJobCategory => new(page.Module, (uint)page.ReadUInt8(offset + 81), page.Language);
+	public readonly byte ClassJobCategoryId => page.ReadUInt8(offset + 81);
 
 	/// <inheritdoc/>
 	public bool IsWeapon => (this.GetItemSlots() & ItemSlots.Weapons) != 0;
@@ -105,6 +117,9 @@ public readonly unsafe struct Item(ExcelPage page, uint offset, uint row)
 	/// <summary>Gets the item category.</summary>
 	public ItemCategories Category => GameDataService.GetCategory(this);
 
+	public static bool operator ==(Item left, Item right) => left.Equals(right);
+	public static bool operator !=(Item left, Item right) => !(left == right);
+
 	/// <summary>
 	/// Creates a new instance of the <see cref="Item"/> struct.
 	/// </summary>
@@ -121,13 +136,17 @@ public readonly unsafe struct Item(ExcelPage page, uint offset, uint row)
 	/// <param name="slot">The slot to check.</param>
 	/// <returns>True if the item fits in the slot; otherwise, false.</returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool FitsInSlot(ItemSlots slot) => this.EquipSlotCategory.Value.Contains(slot);
+	public bool FitsInSlot(ItemSlots slot) => (this.GetItemSlots() & slot) != 0;
 
 	/// <summary>
 	/// Gets the item slots that the item can be equipped in.
 	/// </summary>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public ItemSlots GetItemSlots() => this.EquipSlotCategory.Value.GetItemSlots();
+	public ItemSlots GetItemSlots() => LuminaExtensions.GetItemSlots(this.EquipSlotCategoryId);
+
+	public bool Equals(Item other) => this.RowId == other.RowId;
+	public override bool Equals(object? obj) => obj is Item other && this.Equals(other);
+	public override int GetHashCode() => this.RowId.GetHashCode();
 
 	/// <summary>
 	/// Converts the class job category to a <see cref="Classes"/> enum.

--- a/Anamnesis/GameData/Excel/Stain.cs
+++ b/Anamnesis/GameData/Excel/Stain.cs
@@ -16,7 +16,7 @@ using MediaColor = System.Windows.Media.Color;
 /// </summary>
 [Sheet("Stain", 0x97C471BD)]
 public readonly struct Stain(ExcelPage page, uint offset, uint row)
-	: IExcelRow<Stain>, IDye
+	: IExcelRow<Stain>, IDye, IEquatable<Stain>
 {
 	/// <summary>Maps dye IDs to item keys.</summary>
 	/// <remarks>
@@ -122,6 +122,9 @@ public readonly struct Stain(ExcelPage page, uint offset, uint row)
 		set => FavoritesService.SetFavorite<IDye>(this, value);
 	}
 
+	public static bool operator ==(Stain left, Stain right) => left.Equals(right);
+	public static bool operator !=(Stain left, Stain right) => !(left == right);
+
 	/// <summary>
 	/// Creates a new instance of the <see cref="Stain"/> struct.
 	/// </summary>
@@ -131,4 +134,8 @@ public readonly struct Stain(ExcelPage page, uint offset, uint row)
 	/// <returns>A new instance of the <see cref="Stain"/> struct.</returns>
 	static Stain IExcelRow<Stain>.Create(ExcelPage page, uint offset, uint row) =>
 		new(page, offset, row);
+
+	public bool Equals(Stain other) => this.RowId == other.RowId;
+	public override bool Equals(object? obj) => obj is Stain other && this.Equals(other);
+	public override int GetHashCode() => this.RowId.GetHashCode();
 }

--- a/Anamnesis/GameData/GameDataService.cs
+++ b/Anamnesis/GameData/GameDataService.cs
@@ -14,6 +14,7 @@ using Lumina.Excel;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 using LuminaData = global::Lumina.GameData;
@@ -60,6 +61,9 @@ public class GameDataService : ServiceBase<GameDataService>
 	public static ExcelSheet<Glasses> Glasses { get; private set; } = null!;
 
 	public static EquipmentSheet Equipment { get; private set; } = null!;
+
+	public static ILookup<ulong, uint> ItemsByModel { get; private set; } = null!;
+	public static ILookup<ulong, uint> ItemsBySubModel { get; private set; } = null!;
 
 	public static ExcelSheet<T> GetExcelSheet<T>(Language? language = null, string? name = null)
 					where T : struct, IExcelRow<T>
@@ -221,6 +225,9 @@ public class GameDataService : ServiceBase<GameDataService>
 			Ornaments = GetExcelSheet<Ornament>();
 			BuddyEquips = GetExcelSheet<BuddyEquip>();
 			Glasses = GetExcelSheet<Glasses>();
+
+			ItemsByModel = Items.ToLookup(static i => i.Model, static i => i.RowId);
+			ItemsBySubModel = Items.Where(static i => i.HasSubModel).ToLookup(static i => i.SubModel, static i => i.RowId);
 
 			CustomizeOptionsCache.Build();
 		}

--- a/Anamnesis/GameData/Interfaces/IItem.cs
+++ b/Anamnesis/GameData/Interfaces/IItem.cs
@@ -5,6 +5,7 @@ namespace Anamnesis.GameData;
 
 using Anamnesis.GameData.Sheets;
 using Anamnesis.TexTools;
+using Lumina.Text.ReadOnly;
 
 /// <summary>Represents an item in the game data.</summary>
 public interface IItem
@@ -15,8 +16,14 @@ public interface IItem
 	/// <summary>Gets the name of the item.</summary>
 	string Name { get; }
 
+	/// <summary>Gets the raw unallocated SeString payload for the name, if available.</summary>
+	ReadOnlySeString? SeName => null;
+
 	/// <summary>Gets the description of the item.</summary>
 	string? Description { get; }
+
+	/// <summary>Gets the raw unallocated SeString payload for the description, if available.</summary>
+	ReadOnlySeString? SeDescription => null;
 
 	/// <summary>Gets the level required to equip the item.</summary>
 	byte EquipLevel { get; }

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new(7, 45, 1, 1);
+	public static readonly Version ApplicationVersion = new(7, 45, 1, 2);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;
@@ -31,5 +31,5 @@ public static class VersionInfo
 	/// <summary>
 	/// The latest game version that the tool has been validated for.
 	/// </summary>
-	public static readonly string ValidatedGameVersion = "2026.02.20.0000.0000";
+	public static readonly string ValidatedGameVersion = "2026.03.07.0000.0000";
 }

--- a/RemoteController/Drivers/DriverManager.cs
+++ b/RemoteController/Drivers/DriverManager.cs
@@ -14,7 +14,7 @@ using System.Diagnostics.CodeAnalysis;
 public sealed class DriverManager : IDisposable
 {
 	private const int FRAMEWORK_TIMEOUT_TICKS = 60;
-	private const int MANAGER_WAIT_TIMEOUT_MS = 1000;
+	private const int MANAGER_WAIT_TIMEOUT_MS = 5000;
 
 	private static readonly Stopwatch s_timer = new();
 	private readonly List<DriverEntry> drivers = [];
@@ -101,6 +101,7 @@ public sealed class DriverManager : IDisposable
 	}
 
 	private static T InitializeOnFramework<T>(Func<T> factory)
+		where T : IDisposable
 	{
 		if (FrameworkDriver.Instance == null || FrameworkDriver.Instance.IsDisposed)
 			throw new InvalidOperationException("FrameworkDriver instance is null. Cannot initialize on framework thread.");
@@ -108,12 +109,22 @@ public sealed class DriverManager : IDisposable
 		T? instance = default;
 		Exception? capturedException = null;
 		using var signal = new ManualResetEventSlim(false);
+		bool isTimedOut = false;
 
 		FrameworkDriver.Instance.RunOnTickUntil(null, 0, FRAMEWORK_TIMEOUT_TICKS, () =>
 		{
 			try
 			{
-				instance = factory();
+				var createdInstance = factory();
+				if (Volatile.Read(ref isTimedOut))
+				{
+					createdInstance?.Dispose();
+					Log.Warning($"Disposed orphaned instance of {typeof(T).Name} due to framework initialization timeout.");
+				}
+				else
+				{
+					instance = createdInstance;
+				}
 			}
 			catch (Exception ex)
 			{
@@ -126,7 +137,10 @@ public sealed class DriverManager : IDisposable
 		});
 
 		if (!signal.Wait(MANAGER_WAIT_TIMEOUT_MS))
+		{
+			Volatile.Write(ref isTimedOut, true);
 			throw new TimeoutException($"Timed out initializing {typeof(T).Name} on framework thread.");
+		}
 
 		if (capturedException != null)
 			throw capturedException;

--- a/RemoteController/Drivers/FrameworkDriver.cs
+++ b/RemoteController/Drivers/FrameworkDriver.cs
@@ -335,7 +335,6 @@ public class FrameworkDriver : DriverBase<FrameworkDriver>
 				break;
 
 			var task = this.activeCondTasks[i];
-			bool shouldRemove = false;
 
 			if (currentTick >= task.TargetTick)
 			{
@@ -343,27 +342,27 @@ public class FrameworkDriver : DriverBase<FrameworkDriver>
 				{
 					if (task.Condition == null || task.Condition())
 					{
+						this.activeCondTasks.RemoveAt(i);
 						task.Action();
-						shouldRemove = true;
+						continue;
 					}
 					else if (task.TimeoutFrames >= 0 && (currentTick - task.EnqueueTick) >= (ulong)task.TimeoutFrames)
 					{
+						this.activeCondTasks.RemoveAt(i);
 						task.Tcs?.TrySetCanceled();
-						shouldRemove = true;
+						continue;
 					}
 				}
 				catch (Exception ex)
 				{
 					Log.Error(ex, "Error in conditional task.");
 					task.Tcs?.TrySetException(ex);
-					shouldRemove = true;
+					this.activeCondTasks.RemoveAt(i);
+					continue;
 				}
 			}
 
-			if (shouldRemove)
-				this.activeCondTasks.RemoveAt(i);
-			else
-				i++;
+			i++;
 		}
 	}
 


### PR DESCRIPTION
**Changelog:**
- Validated for game patch 7.45 (Hotfix 1).
- Fixed edge case where bones can snap back on to their original positions on pose mode toggle off then on.
- Fixed age change not triggering an actor redraw.
- Fixed bug in driver inititialization leading to improper disposal and re-initialization on initializaiton timeout.
- Performance and memory optimizations to item lookup and equipment selector.
- Fixed edge case where actor model would disappear on weapon change.
  - **Explanation:** This doesn't resolve the overall problem, just addresses a case where the actor model would not appear due to not auto applying offhand models properly.