### PR TITLE
Animation selection and speed control fixups

### DIFF
--- a/Anamnesis/Actor/Pages/ActionPage.xaml.cs
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml.cs
@@ -113,7 +113,7 @@ public partial class ActionPage : UserControl
 
 		animSelector.LocalAnimationSlotFilter = new()
 		{
-			IncludeBlendable = true,
+			IncludeBlendable = false,
 			IncludeFullBody = true,
 			SlotsLocked = false,
 		};


### PR DESCRIPTION
**Changelog:**
- Improved the action page resume button to preserve active animation speeds, preventing the previous behavior of resetting custom values to 1.
- Update the base animation override configuration to exclude blendables from the list by default.
  - **Explanation:** Most blendable (i.e. upper body) animations do not work when theres no full body animation playing. There are niche cases (e.g. facial animations) where it is possible to play them so I opted not to lock the slots outright as it was prior to commit 95f64a821b66f6ab53b462a2cf0e5941473b0150.