### PR TITLE
Remove unwanted properties from file data serialization

### DIFF
--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -12,6 +12,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using XivToolsWpf.Math3D.Extensions;
 
@@ -111,6 +112,8 @@ public class CharacterFile : JsonFileBase
 	public float? HeightMultiplier { get; set; }
 
 	// unrelated, used for char diff redraw logic
+
+	[JsonIgnore]
 	public bool? IsWeaponDrawn { get; set; }
 
 	public void WriteToFile(ObjectHandle<ActorMemory> handle, SaveModes mode)

--- a/Anamnesis/Files/PoseFile.cs
+++ b/Anamnesis/Files/PoseFile.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 [Flags]
@@ -395,6 +396,7 @@ public class PoseFile : JsonFileBase
 			this.BoneDepth = Core.Bone.GetBoneDepth(bone);
 		}
 
+		[JsonIgnore]
 		public int BoneDepth { get; }
 		public Vector3? Position { get; set; }
 		public Quaternion? Rotation { get; set; }

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new(7, 45, 1, 5);
+	public static readonly Version ApplicationVersion = new(7, 45, 1, 6);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;


### PR DESCRIPTION
Hotfix to address an issue that was brought up to me regarding Anamnesis serializing data that should not be in the exported files.