### PR TITLE
Bug fixes & Tidying up

### DIFF
--- a/Anamnesis/Actor/Pages/ActionPage.xaml
+++ b/Anamnesis/Actor/Pages/ActionPage.xaml
@@ -447,7 +447,10 @@
                         <Button Style="{StaticResource TransparentButton}" Click="OnResumeAll">
                             <XivToolsWpf:IconBlock Icon="Play"/>
                             <Button.ToolTip>
-                                <ana:HotkeyPrompt Function="ActionPage.ResumeAll" />
+                                <StackPanel>
+                                    <XivToolsWpf:TextBlock Key="Hotkey_ResumeAll" />
+                                    <ana:HotkeyPrompt Function="ActionPage.ResumeAll" />
+                                </StackPanel>
                             </Button.ToolTip>
                         </Button>
 
@@ -456,7 +459,10 @@
                         <Button Style="{StaticResource TransparentButton}" Click="OnPauseAll">
                             <XivToolsWpf:IconBlock Icon="Pause"/>
                             <Button.ToolTip>
-                                <ana:HotkeyPrompt Function="ActionPage.PauseAll" />
+                                <StackPanel>
+                                    <XivToolsWpf:TextBlock Key="Hotkey_PauseAll" />
+                                    <ana:HotkeyPrompt Function="ActionPage.PauseAll" />
+                                </StackPanel>
                             </Button.ToolTip>
                         </Button>
                     </StackPanel>

--- a/Anamnesis/Actor/Pages/CharacterPage.xaml
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml
@@ -81,7 +81,7 @@
 						<Button.ToolTip>
 							<StackPanel>
 								<XivToolsWpf:TextBlock Key="Character_Equipment_Clear"/>
-								<ana:HotkeyPrompt Function="AppearancePage.ClearEquipment"/>
+								<ana:HotkeyPrompt Function="CharacterPage.ClearEquipment"/>
 							</StackPanel>
 						</Button.ToolTip>
 

--- a/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
+++ b/Anamnesis/Actor/Pages/CharacterPage.xaml.cs
@@ -31,7 +31,7 @@ using System.Windows.Navigation;
 using static Anamnesis.Actor.Utilities.DyeUtility;
 
 /// <summary>
-/// Interaction logic for AppearancePage.xaml.
+/// Interaction logic for CharacterPage.xaml.
 /// </summary>
 [AddINotifyPropertyChangedInterface]
 public partial class CharacterPage : UserControl, INotifyPropertyChanged

--- a/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
+++ b/Anamnesis/Actor/Views/CustomizeEditor.xaml.cs
@@ -19,7 +19,7 @@ using System.Windows.Threading;
 using static Anamnesis.Memory.ActorCustomizeMemory;
 
 /// <summary>
-/// Interaction logic for AppearancePage.xaml.
+/// Interaction logic for CustomizeEditor.xaml.
 /// </summary>
 [AddINotifyPropertyChangedInterface]
 public partial class CustomizeEditor : UserControl

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -50,7 +50,7 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 
 		this.JobFilterText.Text = s_classFilter.Describe();
 
-		HotkeyService.RegisterHotkeyHandler("AppearancePage.ClearEquipment", this.ClearSlot);
+		HotkeyService.RegisterHotkeyHandler("CharacterPage.ClearEquipment", this.ClearSlot);
 
 		GposeService.GposeStateChanged += this.OnGposeStateChanged;
 		this.OnGposeStateChanged(GposeService.InstanceOrNull?.IsGpose ?? false);
@@ -160,7 +160,7 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 	{
 		base.OnClosed();
 
-		HotkeyService.ClearHotkeyHandler("AppearancePage.ClearEquipment", this);
+		HotkeyService.ClearHotkeyHandler("CharacterPage.ClearEquipment", this);
 		GposeService.GposeStateChanged -= this.OnGposeStateChanged;
 	}
 

--- a/Anamnesis/Languages/de.json
+++ b/Anamnesis/Languages/de.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "X- schnell drehen",
   "Hotkey_RotateYPlusSlow": "Y+ schnell drehen",
   "Hotkey_RotateYMinusSlow": "Y- schnell drehen",
-  "HotkeyCategory_AppearancePage": "Ausrüstung",
+  "HotkeyCategory_CharacterPage": "Ausrüstung",
   "Hotkey_ClearEquipment": "Ausrüstung entfernen",
   "HotkeyCategory_TargetService": "Charaktere",
   "Hotkey_SelectPinned1": "Charakter 1 auswählen",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -939,7 +939,7 @@
   "Hotkey_RotateYPlusSlow": "Rotate Y+ Slow",
   "Hotkey_RotateYMinusSlow": "Rotate Y- Slow",
 
-  "HotkeyCategory_AppearancePage": "Appearance",
+  "HotkeyCategory_CharacterPage": "Appearance",
   "Hotkey_ClearEquipment": "Clear Equipment",
 
   "HotkeyCategory_TargetService": "Actors",

--- a/Anamnesis/Languages/es.json
+++ b/Anamnesis/Languages/es.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Rotate X- Slow",
   "Hotkey_RotateYPlusSlow": "Rotate Y+ Slow",
   "Hotkey_RotateYMinusSlow": "Rotate Y- Slow",
-  "HotkeyCategory_AppearancePage": "Appearance",
+  "HotkeyCategory_CharacterPage": "Appearance",
   "Hotkey_ClearEquipment": "Clear Equipment",
   "HotkeyCategory_TargetService": "Actors",
   "Hotkey_SelectPinned1": "Select Actor 1",

--- a/Anamnesis/Languages/fr.json
+++ b/Anamnesis/Languages/fr.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Rotation X- Slow",
   "Hotkey_RotateYPlusSlow": "Rotation Y+ Slow",
   "Hotkey_RotateYMinusSlow": "Rotation Y- Slow",
-  "HotkeyCategory_AppearancePage": "Apparence",
+  "HotkeyCategory_CharacterPage": "Apparence",
   "Hotkey_ClearEquipment": "Retirer Equipment",
   "HotkeyCategory_TargetService": "Acteurs",
   "Hotkey_SelectPinned1": "Selectioner acteur 1",

--- a/Anamnesis/Languages/id.json
+++ b/Anamnesis/Languages/id.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Rotate X- Slow",
   "Hotkey_RotateYPlusSlow": "Rotate Y+ Slow",
   "Hotkey_RotateYMinusSlow": "Rotate Y- Slow",
-  "HotkeyCategory_AppearancePage": "Appearance",
+  "HotkeyCategory_CharacterPage": "Appearance",
   "Hotkey_ClearEquipment": "Clear Equipment",
   "HotkeyCategory_TargetService": "Actors",
   "Hotkey_SelectPinned1": "Select Actor 1",

--- a/Anamnesis/Languages/it.json
+++ b/Anamnesis/Languages/it.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Ruota X- Lentamente",
   "Hotkey_RotateYPlusSlow": "Ruota Y+ Lentamente",
   "Hotkey_RotateYMinusSlow": "Ruota Y- Lentamente",
-  "HotkeyCategory_AppearancePage": "Aspetto",
+  "HotkeyCategory_CharacterPage": "Aspetto",
   "Hotkey_ClearEquipment": "Rimuovi Equipaggiamento",
   "HotkeyCategory_TargetService": "Attori",
   "Hotkey_SelectPinned1": "Seleziona Attore 1",

--- a/Anamnesis/Languages/ko.json
+++ b/Anamnesis/Languages/ko.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "X- 느리게 회전",
   "Hotkey_RotateYPlusSlow": "Y+ 느리게 회전",
   "Hotkey_RotateYMinusSlow": "Y- 느리게 회전",
-  "HotkeyCategory_AppearancePage": "외형",
+  "HotkeyCategory_CharacterPage": "외형",
   "Hotkey_ClearEquipment": "장비 비우기",
   "HotkeyCategory_TargetService": "액터",
   "Hotkey_SelectPinned1": "액터 1 선택",

--- a/Anamnesis/Languages/pt.json
+++ b/Anamnesis/Languages/pt.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Rotate X- Slow",
   "Hotkey_RotateYPlusSlow": "Rotate Y+ Slow",
   "Hotkey_RotateYMinusSlow": "Rotate Y- Slow",
-  "HotkeyCategory_AppearancePage": "Appearance",
+  "HotkeyCategory_CharacterPage": "Appearance",
   "Hotkey_ClearEquipment": "Clear Equipment",
   "HotkeyCategory_TargetService": "Actors",
   "Hotkey_SelectPinned1": "Select Actor 1",

--- a/Anamnesis/Languages/ru.json
+++ b/Anamnesis/Languages/ru.json
@@ -850,7 +850,7 @@
   "Hotkey_RotateXMinusSlow": "Вращение оси X- медленно",
   "Hotkey_RotateYPlusSlow": "Вращение оси Y+ медленно",
   "Hotkey_RotateYMinusSlow": "Вращение оси Y- медленно",
-  "HotkeyCategory_AppearancePage": "Внешний вид",
+  "HotkeyCategory_CharacterPage": "Внешний вид",
   "Hotkey_ClearEquipment": "Очистить экипировку",
   "HotkeyCategory_TargetService": "Актёры",
   "Hotkey_SelectPinned1": "Выбрать актёра 1",

--- a/Anamnesis/Languages/zh.json
+++ b/Anamnesis/Languages/zh.json
@@ -888,7 +888,7 @@
   "Hotkey_RotateXMinusSlow": "慢速旋转 X-",
   "Hotkey_RotateYPlusSlow": "慢速旋转 Y+",
   "Hotkey_RotateYMinusSlow": "慢速旋转 Y-",
-  "HotkeyCategory_AppearancePage": "外貌",
+  "HotkeyCategory_CharacterPage": "外貌",
   "Hotkey_ClearEquipment": "清除装备",
   "HotkeyCategory_TargetService": "角色",
   "Hotkey_SelectPinned1": "选择角色1",

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -29,9 +29,6 @@ public class ActorMemory : GameObjectMemory, IDisposable
 		new AnamnesisActorRefresher(),
 	];
 
-	private static readonly Lock s_hookLock = new();
-	private static HookHandle? s_isWandererHook = null;
-
 	private readonly System.Timers.Timer refreshDebounceTimer;
 	private readonly FuncQueue backupQueue;
 	private readonly SemaphoreSlim snapshotSemaphore = new(1, 1);
@@ -42,11 +39,6 @@ public class ActorMemory : GameObjectMemory, IDisposable
 
 	public ActorMemory()
 	{
-		lock (s_hookLock)
-		{
-			s_isWandererHook ??= ControllerService.Instance.RegisterWrapper<Character.IsWanderer>();
-		}
-
 		this.backupQueue = new(this.BackupAsync, 250);
 
 		this.PropertyChanged += this.HandlePropertyChanged;
@@ -318,19 +310,6 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	{
 		this.OnPropertyChanged(nameof(this.CanRefresh));
 		this.OnPropertyChanged(nameof(this.RefreshBlockReason));
-	}
-
-	public bool IsWanderer()
-	{
-		try
-		{
-			return ControllerService.Instance.InvokeHook<bool>(s_isWandererHook!, args: this.Address) ?? false;
-		}
-		catch
-		{
-			Log.Verbose($"Failed to invoke 'IsWanderer' hook for actor at address 0x{this.Address:X}");
-			return false;
-		}
 	}
 
 	internal HumanDrawData BuildDrawData()

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -6,6 +6,7 @@ namespace Anamnesis.Memory;
 using Anamnesis.Actor.Utilities;
 using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
+using Anamnesis.Services;
 using PropertyChanged;
 using RemoteController.Interop.Types;
 using System;
@@ -178,6 +179,9 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 
 	public void Clear(bool isPlayer)
 	{
+		if (GposeService.InstanceOrNull?.IsGpose != true)
+			return;
+
 		bool useEmperorsFists = true;
 
 		if (this.Parent is ActorMemory actor)

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new(7, 50, 0, 0);
+	public static readonly Version ApplicationVersion = new(7, 50, 0, 1);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;

--- a/Anamnesis/Views/HotkeyPrompt.xaml
+++ b/Anamnesis/Views/HotkeyPrompt.xaml
@@ -1,12 +1,9 @@
 ﻿<TextBlock x:Class="Anamnesis.Views.HotkeyPrompt"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Anamnesis.Views"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
-    <Grid>
-            
-    </Grid>
-</TextBlock>
+		   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+		   xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+		   xmlns:local="clr-namespace:Anamnesis.Views"
+		   mc:Ignorable="d"
+		   Loaded="OnLoaded"
+		   d:DesignHeight="450" d:DesignWidth="800"/>

--- a/Anamnesis/Views/HotkeyPrompt.xaml.cs
+++ b/Anamnesis/Views/HotkeyPrompt.xaml.cs
@@ -8,6 +8,7 @@ using Anamnesis.Keyboard;
 using Anamnesis.Memory.Exceptions;
 using Serilog;
 using System.Text;
+using System.Windows;
 using System.Windows.Input;
 using XivToolsWpf.DependencyProperties;
 
@@ -18,18 +19,40 @@ public partial class HotkeyPrompt : System.Windows.Controls.TextBlock
 {
 	public static readonly IBind<string> FunctionDp = Binder.Register<string, HotkeyPrompt>(nameof(Function), OnKeyChanged, BindMode.OneWay);
 
+	private bool isInternalSet = false;
+
 	public HotkeyPrompt()
 	{
 		this.InitializeComponent();
 		this.LoadString();
 	}
 
-	public string? Function { get; set; }
+	public string Function
+	{
+		get => FunctionDp.Get(this);
+		set
+		{
+			if (FunctionDp.Get(this) == value)
+				return;
+
+			this.isInternalSet = true;
+			FunctionDp.Set(this, value);
+			this.isInternalSet = false;
+		}
+	}
 
 	public static void OnKeyChanged(HotkeyPrompt sender, string val)
 	{
+		if (sender.isInternalSet)
+			return;
+
 		sender.Function = val;
 		sender.LoadString();
+	}
+
+	private void OnLoaded(object sender, RoutedEventArgs e)
+	{
+		this.LoadString();
 	}
 
 	private void LoadString()

--- a/RemoteController/Controller.cs
+++ b/RemoteController/Controller.cs
@@ -12,7 +12,6 @@ using Serilog;
 using SharedMemoryIPC;
 using System.Buffers;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -30,6 +29,7 @@ public class Controller
 	private const int IPC_FAST_FAIL_TIMEOUT_MS = 16;
 	private const int BATCH_INVOKE_BUFFER_STARTSIZE = 1024;
 	private const int STACKALLOC_THRESHOLD = 256;
+	private const int MAX_PATH_LENGTH = 32768; // Windows maximum path length
 
 	private const string FASM_RESOURCE_NAME = "FASMX64";
 	private const string FASM_RESOURCE_FILENAME = $"{FASM_RESOURCE_NAME}.dll";
@@ -293,13 +293,43 @@ public class Controller
 				s_dllImportResolverSet = true;
 			}
 
-			Process currentProcess = Process.GetCurrentProcess();
-			if (currentProcess.MainModule == null)
+			if (!NativeFunctions.GetModuleHandleEx(
+				(uint)NativeFunctions.GetModuleFlag.GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+				IntPtr.Zero,
+				out IntPtr hMainModule))
 			{
-				Log.Error("Failed to get main module of the current process.");
+				Log.Error("Failed to get main module handle of the current process.");
 				return;
 			}
-			Scanner = new SignatureScanner(currentProcess.MainModule, MemoryReader);
+
+			string? mainModulePath = null;
+			unsafe
+			{
+				char[] buffer = ArrayPool<char>.Shared.Rent(MAX_PATH_LENGTH);
+				try
+				{
+					fixed (char* pBuffer = buffer)
+					{
+						uint length = NativeFunctions.GetModuleFileName(hMainModule, pBuffer, (uint)MAX_PATH_LENGTH);
+						if (length > 0)
+						{
+							mainModulePath = new string(buffer.AsSpan(0, (int)length));
+						}
+					}
+				}
+				finally
+				{
+					ArrayPool<char>.Shared.Return(buffer);
+				}
+			}
+
+			if (string.IsNullOrEmpty(mainModulePath))
+			{
+				Log.Error("Failed to get main module path.");
+				return;
+			}
+
+			Scanner = new SignatureScanner(hMainModule, mainModulePath, MemoryReader);
 			SigResolver = new SignatureResolver(Scanner, MemoryReader);
 
 			Log.Debug("Creating IPC endpoints...");

--- a/RemoteController/Interop/HookDelegates.cs
+++ b/RemoteController/Interop/HookDelegates.cs
@@ -30,10 +30,6 @@ public static class Character
 	[FunctionBind("E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 85 C9 74 33 45 33 C0")]
 	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
 	public delegate byte EnableDraw(nint objPtr);
-
-	[FunctionBind("E8 ?? ?? ?? ?? 84 C0 8B CF")]
-	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-	public delegate bool IsWanderer(nint charPtr);
 }
 
 public static class GameConfigEntry

--- a/RemoteController/Memory/SignatureScanner.cs
+++ b/RemoteController/Memory/SignatureScanner.cs
@@ -42,28 +42,40 @@ public sealed unsafe class SignatureScanner
 	/// </summary>
 	/// <param name="module">The process to be used for scanning.</param>
 	public SignatureScanner(ProcessModule module, IProcessMemoryReader memoryReader)
+		: this(module?.BaseAddress ?? 0, module?.FileName ?? string.Empty, memoryReader)
 	{
-		Debug.Assert(module != null, "Process module cannot be null.");
 		this.Module = module;
-		this.moduleBaseAddress = module.BaseAddress;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SignatureScanner"/> class.
+	/// </summary>
+	/// <param name="moduleBaseAddress">The base address of the module.</param>
+	/// <param name="moduleFilePath">The full path on disk to the module executable.</param>
+	/// <param name="memoryReader">The process memory reader.</param>
+	public SignatureScanner(nint moduleBaseAddress, string moduleFilePath, IProcessMemoryReader memoryReader)
+	{
+		Debug.Assert(moduleBaseAddress != 0, "A valid module base address must be provided");
+		Debug.Assert(!string.IsNullOrEmpty(moduleFilePath), "A valid module file path must be provided");
+
+		this.moduleBaseAddress = moduleBaseAddress;
 		this.memoryReader = memoryReader;
 
-		string? fileName = module.FileName;
-		if (string.IsNullOrEmpty(fileName))
+		if (string.IsNullOrEmpty(moduleFilePath))
 			throw new ArgumentException("Unable to obtain module path.");
 
 		// Open the file on disk to map it
-		this.file = MemoryMappedFile.CreateFromFile(fileName, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+		this.file = MemoryMappedFile.CreateFromFile(moduleFilePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
 
 		// Limit the search space to .text section.
-		this.SetupSearchSpace(module, out SectionInfo textSection, out SectionInfo dataSection);
+		this.SetupSearchSpace(moduleBaseAddress, out SectionInfo textSection, out SectionInfo dataSection);
 		this.textSectionVirtualAddress = textSection.VirtualAddress;
 		this.dataSectionVirtualAddress = dataSection.VirtualAddress;
 
 		this.textSectionAccessor = this.file.CreateViewAccessor(textSection.Offset, textSection.Size, MemoryMappedFileAccess.Read);
 		this.dataSectionAccessor = this.file.CreateViewAccessor(dataSection.Offset, dataSection.Size, MemoryMappedFileAccess.Read);
 
-		Log.Information($"Signature Scanner (MMF) Created: {module.ModuleName}");
+		Log.Information($"Signature Scanner (MMF) Created: {Path.GetFileName(moduleFilePath)}");
 		Log.Information($"Text Section: Offset=0x{textSection.Offset:X}, Virtual Address=0x{textSection.VirtualAddress:X}, Size=0x{textSection.Size:X}");
 		Log.Information($"Data Section: Offset=0x{dataSection.Offset:X}, Virtual Address=0x{dataSection.VirtualAddress:X}, Size=0x{dataSection.Size:X}");
 
@@ -74,7 +86,10 @@ public sealed unsafe class SignatureScanner
 	}
 
 	/// <summary>Gets the process module the scanner is attached to.</summary>
-	public ProcessModule Module { get; }
+	/// <remarks>
+	/// Note that using the <see cref="SignatureScanner(nint, string, IProcessMemoryReader)"/> constructor will result in this property being null.
+	/// </remarks>
+	public ProcessModule? Module { get; }
 
 	/// <summary>
 	/// Resolve a RVA address.
@@ -318,12 +333,10 @@ public sealed unsafe class SignatureScanner
 		return -1;
 	}
 
-	private void SetupSearchSpace(ProcessModule module, out SectionInfo textSection, out SectionInfo dataSection)
+	private void SetupSearchSpace(IntPtr baseAddress, out SectionInfo textSection, out SectionInfo dataSection)
 	{
 		textSection = default;
 		dataSection = default;
-
-		IntPtr baseAddress = module.BaseAddress;
 
 		// We don't want to read all of IMAGE_DOS_HEADER or IMAGE_NT_HEADER stuff so we cheat here.
 		int ntNewOffset = this.memoryReader.ReadInt32(baseAddress, 0x3C);


### PR DESCRIPTION
**Changelog:**
- Addressed user-reported error that prevented them from using the application due to access denied error in remote controller.
  - **Explanation:** After analyzing the stack trace with IDA, I've deduced that `ProcessModule.MainModule` (System.Diagnostics.ProcessModule) is the cause for the exception "Access denied". While I'm not entirely certain, my belief is that .NET's getter for the main module property attempts to open the process via the Win32 API `OpenProcess(...)` using rights, which the game process does not have, leading to `ERROR_ACCESS_DENIED` internally, which in turn causes the remote controller to shutdown during initialization.
- Removed unused `IsWanderer` hook, which was added during initial development of the hook system but was left unused.
- Added a check to the weapon memory object to prevent wrongful switching outside of gpose.
  - **Explanation:** The clear/set equipment buttons in the character page use .Clear() to set the weapon to either an empty item or Emperor's New Fists", both of which trigger a weapon model change.
- Fixed missing tooltips for the "Resume All" and "Pause All" buttons in the action page.
- Fixed hotkey visual hints not showing up in tooltips.