### PR TITLE
Validate Anamnesis for Patch 7.51 (Hotfix 1)

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Delete pdb and xml
         run: |
           Get-ChildItem -Path './publish/*' -Recurse -Include *.pdb,*.xml -File | Remove-Item -Force
-          Get-ChildItem -Path './publish/*' -Recurse -Include FASM*,Reloaded.* -File | Remove-Item -Force
+          Get-ChildItem -Path './publish/*' -Recurse -Include FASM*,Reloaded.*,AetherTools.Anamnesis.Reloaded.* -File | Remove-Item -Force
 
       # 6. Zip up the entire publish folder
       - name: Create ZIP

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new(7, 51, 0, 1);
+	public static readonly Version ApplicationVersion = new(7, 51, 0, 2);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;
@@ -31,5 +31,5 @@ public static class VersionInfo
 	/// <summary>
 	/// The latest game version that the tool has been validated for.
 	/// </summary>
-	public static readonly string ValidatedGameVersion = "2026.05.25.0000.0000";
+	public static readonly string ValidatedGameVersion = "2026.06.10.0000.0000";
 }


### PR DESCRIPTION
No changes necessary, just a version bump.

I also updated the publish GitHub action to filter out the  `AetherTools.Anamnesis.Reloaded.Assembler.target` build file that incorrectly made its way into the release archive with `v7.51.0.1`.