### PR TITLE
Hotfix: Resolve issue with incorrect import of non-player battle NPCs

### DIFF
--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -289,7 +289,6 @@ public class CharacterFile : JsonFileBase
 		var existingHead = drawData.Customize.Head;
 
 		bool needsRedraw = false;
-		bool isStructuralChange = false;
 		bool prevAutoRefresh = actor.AutomaticRefreshEnabled;
 
 		try
@@ -304,11 +303,7 @@ public class CharacterFile : JsonFileBase
 
 			// Model type change always requires a full redraw
 			actor.ModelType = (int)this.ModelType;
-			if (actor.ModelType != existingModelType)
-			{
-				needsRedraw = true;
-				isStructuralChange = true;
-			}
+			needsRedraw |= actor.ModelType != existingModelType;
 
 			if (this.IncludeSection(SaveModes.EquipmentWeapons, mode) && GposeService.InstanceOrNull?.IsGpose == true)
 			{
@@ -491,13 +486,6 @@ public class CharacterFile : JsonFileBase
 
 				needsRedraw = true;
 			}
-
-			// Determine if the actor needs to be redrawn based on structural changes
-			isStructuralChange |=
-				drawData.Customize.Race != existingRace ||
-				drawData.Customize.Gender != existingGender ||
-				drawData.Customize.Tribe != existingTribe ||
-				drawData.Customize.Head != existingHead;
 
 			// Resume synchronization and read back from game memory.
 			// This is required so that the ConstantBufferMemory (extended appearance)

--- a/Anamnesis/GameData/Excel/BattleNpc.cs
+++ b/Anamnesis/GameData/Excel/BattleNpc.cs
@@ -37,13 +37,13 @@ public readonly struct BattleNpc(ExcelPage page, uint offset, uint row)
 	public uint ModelCharaRow => this.ModelChara.RowId;
 
 	/// <summary>Gets the ModelChara object reference of the battle non-player entity.</summary>
-	public readonly RowRef<ModelChara> ModelChara => new(page.Module, (uint)page.ReadUInt16(offset + 10), page.Language);
+	public readonly RowRef<ModelChara> ModelChara => new(page.Module, (uint)page.ReadUInt16(offset + 14), page.Language);
 
 	/// <summary>Gets the <c>BNpcCustomize</c> object reference of the battle non-player entity.</summary>
-	public readonly RowRef<BNpcCustomize> BNpcCustomize => new(page.Module, (uint)page.ReadUInt16(offset + 12), page.Language);
+	public readonly RowRef<BNpcCustomize> BNpcCustomize => new(page.Module, (uint)page.ReadUInt16(offset + 16), page.Language);
 
 	/// <summary>Gets the <c>NpcEquip</c> object reference of the battle non-player entity.</summary>
-	public readonly RowRef<NpcEquip> NpcEquip => new(page.Module, (uint)page.ReadUInt16(offset + 14), page.Language);
+	public readonly RowRef<NpcEquip> NpcEquip => new(page.Module, (uint)page.ReadUInt16(offset + 18), page.Language);
 
 	/// <inheritdoc/>
 	public ImgRef? Icon => null;

--- a/Anamnesis/VersionInfo.cs
+++ b/Anamnesis/VersionInfo.cs
@@ -20,7 +20,7 @@ public static class VersionInfo
 	/// - Revision: The revision of the tool. This should reset to 0 on every build.
 	///   - Bump the revision number for hotfixes and urgent patches.
 	/// </remarks>
-	public static readonly Version ApplicationVersion = new(7, 51, 0, 2);
+	public static readonly Version ApplicationVersion = new(7, 51, 0, 3);
 
 #if CI_BUILD
 	public static readonly bool IsDevelopmentBuild = false;


### PR DESCRIPTION
*Note: This pull request targets the `master` branch as I intend to make a hotfix release.*

The root cause of the issue users recently reported with regards to the NPC import feature appears to be due to outdated offsets of a few of the fields in the `BNpcBase` excel sheet.