### PR TITLE
Weapon-related redraw improvements and bug fixes

### DIFF
--- a/Anamnesis/Actor/Items/DummyItem.cs
+++ b/Anamnesis/Actor/Items/DummyItem.cs
@@ -6,12 +6,32 @@ using Anamnesis.GameData;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Services;
 using Anamnesis.TexTools;
+using Lumina;
 using System.Runtime.CompilerServices;
 
-public class DummyItem(ushort modelSet, ushort modelBase, ushort modelVariant) : IItem
+public class DummyItem : IItem
 {
+	public DummyItem(ushort modelSet, ushort modelBase, ushort modelVariant)
+	{
+		this.ModelSet = modelSet;
+		this.ModelBase = modelBase;
+		this.ModelVariant = modelVariant;
+		this.Model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
+		this.IsWeapon = modelSet != 0;
+	}
+
+	public DummyItem(ulong model, bool isWeapon = false)
+	{
+		this.Model = model;
+		this.IsWeapon = isWeapon;
+		LuminaExtensions.GetModel(model, isWeapon, out ushort modelSet, out ushort modelBase, out ushort modelVariant);
+		this.ModelSet = modelSet;
+		this.ModelBase = modelBase;
+		this.ModelVariant = modelVariant;
+	}
+
 	public uint RowId => 0;
-	public bool IsWeapon => true;
+	public bool IsWeapon { get; private set; }
 	public bool HasSubModel => false;
 	public string Name => LocalizationService.GetString("Item_Unknown");
 	public string Description => string.Empty;
@@ -20,10 +40,10 @@ public class DummyItem(ushort modelSet, ushort modelBase, ushort modelVariant) :
 	public Mod? Mod => null;
 	public byte EquipLevel => 0;
 
-	public ulong Model => ExcelPageExtensions.ConvertToModel(this.ModelSet, this.ModelBase, this.ModelVariant);
-	public ushort ModelBase { get; private set; } = modelBase;
-	public ushort ModelVariant { get; private set; } = modelVariant;
-	public ushort ModelSet { get; private set; } = modelSet;
+	public ulong Model { get; private set; }
+	public ushort ModelBase { get; private set; }
+	public ushort ModelVariant { get; private set; }
+	public ushort ModelSet { get; private set; }
 
 	public ulong SubModel => ExcelPageExtensions.ConvertToModel(this.SubModelSet, this.SubModelBase, this.SubModelVariant);
 	public ushort SubModelBase { get; }

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -154,7 +154,7 @@ public class AnamnesisActorRefresher : IActorRefresher
 
 			writer.WriteByte((byte)flags);
 
-			if (flags.HasFlag(RedrawFlags.Weapons))
+			if (flags.HasFlag(RedrawFlags.Weapons) || flags.HasFlag(RedrawFlags.Appearance))
 			{
 				writer.Write(actor.DrawData.MainHand?.WeaponModelId ?? default);
 				writer.Write(actor.DrawData.OffHand?.WeaponModelId ?? default);

--- a/Anamnesis/Actor/Utilities/ItemUtility.cs
+++ b/Anamnesis/Actor/Utilities/ItemUtility.cs
@@ -4,10 +4,12 @@
 namespace Anamnesis.Actor.Utilities;
 
 using Anamnesis.Actor.Items;
+using Anamnesis.Core.Extensions;
 using Anamnesis.GameData;
 using Anamnesis.GameData.Excel;
 using Anamnesis.GameData.Sheets;
 using Anamnesis.Services;
+using System;
 using System.Linq;
 
 public static class ItemUtility
@@ -33,42 +35,30 @@ public static class ItemUtility
 	/// <summary>
 	/// Searches the gamedata service item list for an item with the given model attributes.
 	/// </summary>
-	public static IItem GetItem(ItemSlots slot, ushort modelSet, ushort modelBase, ushort modelVariant, bool isChocobo)
+	public static IItem GetItem(ItemSlots slot, ushort modelSet, ushort modelBase, ushort modelVariant, bool isChocobo = false)
 	{
-		if ((modelBase == 0 || modelBase == 1) && modelVariant == 0)
+		bool isWeaponSlot = (slot & ItemSlots.Weapons) != 0;
+		if ((isWeaponSlot && modelSet == 0) || modelBase == 0)
 			return NoneItem;
 
-		if (modelBase == NpcBodyItem.ModelBase)
+		ulong model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
+
+		if (model == NpcBodyItem.Model)
 			return NpcBodyItem;
 
-		return isChocobo
-			? ChocoboItemSearch(slot, modelSet, modelBase, modelVariant)
-			: ItemSearch(slot, modelSet, modelBase, modelVariant);
-	}
-
-	public static IItem GetDummyItem(ushort modelSet, ushort modelBase, ushort modelVariant)
-	{
-		var model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
-
-		if (NoneItem.Model == model)
-			return NoneItem;
-
-		if (NpcBodyItem.Model == model)
-			return NpcBodyItem;
-
-		if (InvisibileBodyItem.Model == model)
+		if (model == InvisibileBodyItem.Model)
 			return InvisibileBodyItem;
 
-		if (InvisibileHeadItem.Model == model)
+		if (model == InvisibileHeadItem.Model)
 			return InvisibileHeadItem;
 
-		return new DummyItem(modelSet, modelBase, modelVariant);
+		return isChocobo
+			? ChocoboItemSearch(slot, model)
+			: ItemSearch(slot, model, isWeaponSlot);
 	}
 
-	private static IItem ChocoboItemSearch(ItemSlots slot, ushort modelSet, ushort modelBase, ushort modelVariant)
+	private static IItem ChocoboItemSearch(ItemSlots slot, ulong model)
 	{
-		var model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
-
 		if (slot == ItemSlots.Legs)
 		{
 			if (YellowChocoboSkin.Model == model)
@@ -81,52 +71,43 @@ public static class ItemUtility
 		{
 			foreach (BuddyEquip equip in GameDataService.BuddyEquips)
 			{
-				if (equip.Head != null && equip.Head.Slot == slot && equip.Head.Model == model)
-					return equip.Head;
+				BuddyEquip.BuddyItem? item = slot switch
+				{
+					ItemSlots.Head => equip.Head,
+					ItemSlots.Body => equip.Body,
+					ItemSlots.Legs => equip.Feet,
+					_ => null,
+				};
 
-				if (equip.Body != null && equip.Body.Slot == slot && equip.Body.Model == model)
-					return equip.Body;
-
-				if (equip.Feet != null && equip.Feet.Slot == slot && equip.Feet.Model == model)
-					return equip.Feet;
+				if (item != null && item.Model == model)
+					return item;
 			}
 		}
 
-		return new DummyItem(modelSet, modelBase, modelVariant);
+		return new DummyItem(model, isWeapon: false);
 	}
 
-	private static IItem ItemSearch(ItemSlots slot, ushort modelSet, ushort modelBase, ushort modelVariant)
+	private static IItem ItemSearch(ItemSlots slot, ulong model, bool isWeaponSlot)
 	{
-		var model = ExcelPageExtensions.ConvertToModel(modelSet, modelBase, modelVariant);
-
 		foreach (uint rowId in GameDataService.ItemsByModel[model])
 		{
 			var tItem = GameDataService.Items.GetRow(rowId);
 
-			if (slot == ItemSlots.MainHand || slot == ItemSlots.OffHand)
-			{
-				if (!tItem.IsWeapon)
-					continue;
-			}
-			else
-			{
-				if (!tItem.FitsInSlot(slot))
-					continue;
-			}
+			if (isWeaponSlot ? !tItem.IsWeapon : !tItem.FitsInSlot(slot))
+				continue;
 
 			// Big old hack, but we prefer the emperors bracelets to the promise bracelets (even though they are the same model)
-			if (slot == ItemSlots.Wrists && tItem.Name.StartsWith("Promise of"))
+			if (slot == ItemSlots.Wrists && tItem.Name.StartsWith("Promise of", StringComparison.Ordinal))
 				continue;
 
 			return tItem;
 		}
 
-		if (slot == ItemSlots.MainHand || slot == ItemSlots.OffHand)
+		if (isWeaponSlot)
 		{
 			foreach (uint rowId in GameDataService.ItemsBySubModel[model])
 			{
 				var tItem = GameDataService.Items.GetRow(rowId);
-
 				if (tItem.IsWeapon)
 					return tItem;
 			}
@@ -144,6 +125,6 @@ public static class ItemUtility
 				return tItem;
 		}
 
-		return new DummyItem(modelSet, modelBase, modelVariant);
+		return new DummyItem(model, isWeapon: isWeaponSlot);
 	}
 }

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml
@@ -1,15 +1,15 @@
-﻿<local:EquipmentSelectorDrawer x:Class="Anamnesis.Actor.Views.EquipmentSelector"
+<local:EquipmentSelectorDrawer x:Class="Anamnesis.Actor.Views.EquipmentSelector"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:controls="clr-namespace:Anamnesis.Styles.Controls"
 			 xmlns:drawers="clr-namespace:Anamnesis.Styles.Drawers"
 			 xmlns:fa="http://schemas.awesome.incremented/wpf/xaml/fontawesome.sharp"
 			 xmlns:XivToolsWpf="clr-namespace:XivToolsWpf.Controls;assembly=XivToolsWpf"
-			 xmlns:xivToolsWpfSelectors="clr-namespace:XivToolsWpf.Selectors;assembly=XivToolsWpf" 
-			 xmlns:local="clr-namespace:Anamnesis.Actor.Views" 
-			 mc:Ignorable="d" 
+			 xmlns:xivToolsWpfSelectors="clr-namespace:XivToolsWpf.Selectors;assembly=XivToolsWpf"
+			 xmlns:local="clr-namespace:Anamnesis.Actor.Views"
+			 mc:Ignorable="d"
 			 d:DesignHeight="450">
 
 	<UserControl.Resources>
@@ -163,21 +163,28 @@
 					Margin="6, 0, 0, 0"
 					Visibility="{Binding IsWeaponSlot, Converter={StaticResource B2V}}">
 
-			<CheckBox Padding="3" IsChecked="{Binding AutoOffhand}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
+			<CheckBox Padding="2, 1" IsChecked="{Binding AutoOffhand}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
 				<CheckBox.ToolTip>
 					<XivToolsWpf:TextBlock Key="EquipmentSelector_AutoOffhandTip"/>
 				</CheckBox.ToolTip>
 				<XivToolsWpf:TextBlock Key="EquipmentSelector_AutoOffhand"/>
 			</CheckBox>
 
-			<CheckBox Padding="3" IsChecked="{Binding ForceMainModel}" Visibility="{Binding IsOffHandSlot, Converter={StaticResource B2V}}">
+			<CheckBox Padding="2, 1" IsChecked="{Binding LinkDyes}">
+				<CheckBox.ToolTip>
+					<XivToolsWpf:TextBlock Key="EquipmentSelector_LinkDyesTip"/>
+				</CheckBox.ToolTip>
+				<XivToolsWpf:TextBlock Key="EquipmentSelector_LinkDyes"/>
+			</CheckBox>
+
+			<CheckBox Padding="2, 1" IsChecked="{Binding ForceMainModel}" Visibility="{Binding IsOffHandSlot, Converter={StaticResource B2V}}">
 				<CheckBox.ToolTip>
 					<XivToolsWpf:TextBlock Key="EquipmentSelector_ForceMainModelTooltip"/>
 				</CheckBox.ToolTip>
 				<XivToolsWpf:TextBlock Key="EquipmentSelector_ForceMainModel"/>
 			</CheckBox>
 
-			<CheckBox Padding="3" IsChecked="{Binding ForceOffModel}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
+			<CheckBox Padding="2, 1" IsChecked="{Binding ForceOffModel}" Visibility="{Binding IsMainHandSlot, Converter={StaticResource B2V}}">
 				<CheckBox.ToolTip>
 					<XivToolsWpf:TextBlock Key="EquipmentSelector_ForceOffModelTooltip"/>
 				</CheckBox.ToolTip>

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -64,7 +64,11 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 		Level,
 	}
 
-	public static bool LinkWeaponDyes => s_linkDyes;
+	public static bool LinkWeaponDyes
+	{
+		get => s_linkDyes;
+		set => s_linkDyes = value;
+	}
 
 	// Suppress CA1822: The properties are used in WPF bindings. Do not set them to static.
 #pragma warning disable CA1822

--- a/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
+++ b/Anamnesis/Actor/Views/EquipmentSelector.xaml.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace Anamnesis.Actor.Views;
@@ -36,6 +36,7 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 	private static bool s_showFilters = false;
 	private static bool s_forceMainModel = false;
 	private static bool s_forceOffModel = false;
+	private static bool s_linkDyes = true;
 	private static SortModes s_sortMode = SortModes.Row;
 
 	private readonly Memory.ActorMemory? actor;
@@ -63,6 +64,8 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 		Level,
 	}
 
+	public static bool LinkWeaponDyes => s_linkDyes;
+
 	// Suppress CA1822: The properties are used in WPF bindings. Do not set them to static.
 #pragma warning disable CA1822
 	public bool ShowFilters
@@ -75,6 +78,12 @@ public partial class EquipmentSelector : EquipmentSelectorDrawer
 	{
 		get => s_autoOffhand;
 		set => s_autoOffhand = value;
+	}
+
+	public bool LinkDyes
+	{
+		get => s_linkDyes;
+		set => s_linkDyes = value;
 	}
 #pragma warning restore CA1822
 

--- a/Anamnesis/Actor/Views/ItemView.xaml
+++ b/Anamnesis/Actor/Views/ItemView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Anamnesis.Actor.Views.ItemView"
+<UserControl x:Class="Anamnesis.Actor.Views.ItemView"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:fa="http://schemas.awesome.incremented/wpf/xaml/fontawesome.sharp"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -258,6 +258,20 @@
 									<fa:IconImage Icon="ArrowRightArrowLeft" Foreground="{StaticResource PrimaryHueMidBrush}"/>
 								</MenuItem.Icon>
 							</MenuItem>
+							<MenuItem Click="OnToggleLinkDyes" Visibility="{Binding IsWeapon, Converter={StaticResource B2V}, Mode=OneWay}">
+								<MenuItem.Header>
+									<Grid>
+										<XivToolsWpf:TextBlock Key="EquipmentSelector_UnlinkDyes" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource B2V}}"/>
+										<XivToolsWpf:TextBlock Key="EquipmentSelector_LinkDyes" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource !B2V}}"/>
+									</Grid>
+								</MenuItem.Header>
+								<MenuItem.Icon>
+									<Grid>
+										<fa:IconImage Icon="Unlink" Foreground="{StaticResource PrimaryHueMidBrush}" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource B2V}}"/>
+										<fa:IconImage Icon="Link" Foreground="{StaticResource PrimaryHueMidBrush}" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource !B2V}}"/>
+									</Grid>
+								</MenuItem.Icon>
+							</MenuItem>
 						</ContextMenu>
 					</Button.ContextMenu>
 				</Button>
@@ -291,6 +305,20 @@
 								</MenuItem.Header>
 								<MenuItem.Icon>
 									<fa:IconImage Icon="ArrowRightArrowLeft" Foreground="{StaticResource PrimaryHueMidBrush}"/>
+								</MenuItem.Icon>
+							</MenuItem>
+							<MenuItem Click="OnToggleLinkDyes" Visibility="{Binding IsWeapon, Converter={StaticResource B2V}, Mode=OneWay}">
+								<MenuItem.Header>
+									<Grid>
+										<XivToolsWpf:TextBlock Key="EquipmentSelector_UnlinkDyes" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource B2V}}"/>
+										<XivToolsWpf:TextBlock Key="EquipmentSelector_LinkDyes" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource !B2V}}"/>
+									</Grid>
+								</MenuItem.Header>
+								<MenuItem.Icon>
+									<Grid>
+										<fa:IconImage Icon="Unlink" Foreground="{StaticResource PrimaryHueMidBrush}" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource B2V}}"/>
+										<fa:IconImage Icon="Link" Foreground="{StaticResource PrimaryHueMidBrush}" Visibility="{Binding LinkWeaponDyes, Converter={StaticResource !B2V}}"/>
+									</Grid>
 								</MenuItem.Icon>
 							</MenuItem>
 						</ContextMenu>

--- a/Anamnesis/Actor/Views/ItemView.xaml
+++ b/Anamnesis/Actor/Views/ItemView.xaml
@@ -151,16 +151,25 @@
 			<StackPanel Grid.Row="0" Grid.Column="1" Margin="3,0,0,0" Orientation="Horizontal" IsEnabled="{Binding Actor.CanRefresh, Mode=OneWay}">
 				<StackPanel Orientation="Horizontal" IsEnabled="{Binding CanEditItem, Mode=OneWay}">
 					<XivToolsWpf:NumberBox Width="28" Value="{Binding ItemModel.Set}" FontSize="12" FontWeight="Light"
-								ToolTip="Character_Equipment_ItemSet"
-								Visibility="{Binding IsWeapon, Converter={StaticResource B2V}, Mode=OneWay}"/>
+										   Visibility="{Binding IsWeapon, Converter={StaticResource B2V}, Mode=OneWay}">
+						<XivToolsWpf:NumberBox.ToolTip>
+							<XivToolsWpf:TextBlock Key="Character_Equipment_ItemSet"/>
+						</XivToolsWpf:NumberBox.ToolTip>
+					</XivToolsWpf:NumberBox>
 
 					<TextBlock Text="," Style="{StaticResource Label}" Margin="2, 2, 4, 0" Visibility="{Binding IsWeapon, Converter={StaticResource B2V}, Mode=OneWay}"/>
-					<XivToolsWpf:NumberBox Width="28" Value="{Binding ItemModel.Base}" FontSize="12" FontWeight="Light" 
-									   ToolTip="Character_Equipment_ItemBase"/>
+					<XivToolsWpf:NumberBox Width="28" Value="{Binding ItemModel.Base}" FontSize="12" FontWeight="Light">
+						<XivToolsWpf:NumberBox.ToolTip>
+							<XivToolsWpf:TextBlock Key="Character_Equipment_ItemBase"/>
+						</XivToolsWpf:NumberBox.ToolTip>
+					</XivToolsWpf:NumberBox>
 
 					<TextBlock Text="," Style="{StaticResource Label}" Margin="2, 2, 4, 0" />
-					<XivToolsWpf:NumberBox Width="28" Value="{Binding ItemModel.Variant}" FontSize="12" FontWeight="Light" 
-									   ToolTip="Character_Equipment_ItemVariant"/>
+					<XivToolsWpf:NumberBox Width="28" Value="{Binding ItemModel.Variant}" FontSize="12" FontWeight="Light">
+						<XivToolsWpf:NumberBox.ToolTip>
+							<XivToolsWpf:TextBlock Key="Character_Equipment_ItemVariant"/>
+						</XivToolsWpf:NumberBox.ToolTip>
+					</XivToolsWpf:NumberBox>
 				</StackPanel>
 			</StackPanel>
 

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -218,7 +218,7 @@ public partial class ItemView : UserControl
 
 	private static bool MatchesWeapon(IItem item, WeaponMemory weaponVm, ItemSlots slot)
 	{
-		// For Off-Hand paired weapons, match against the SubModel
+		// For off-hand paired weapons, match against the submodel
 		if (slot == ItemSlots.OffHand && item.HasSubModel)
 		{
 			return item.SubModelSet == weaponVm.Set
@@ -541,7 +541,7 @@ public partial class ItemView : UserControl
 					// Do not re-fetch if the selected item is the same as the current item
 					IItem? item = weaponVm.EquippedItem ?? this.Item;
 
-					// Check if MainHand has a paired sub-model matching this OffHand
+					// Check if the main hand already has a paired sub-model matching the off-hand
 					if (item == null && slots == ItemSlots.OffHand && this.Actor.DrawData.MainHand?.EquippedItem is IItem mainItem && MatchesWeapon(mainItem, weaponVm, slots))
 					{
 						item = mainItem;

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -94,6 +94,16 @@ public partial class ItemView : UserControl
 	[DependsOn(nameof(IsWeapon))]
 	public bool ShowWeaponWarning => this.IsWeapon && GposeService.InstanceOrNull?.IsGpose != true;
 
+	public bool LinkWeaponDyes
+	{
+		get => EquipmentSelector.LinkWeaponDyes;
+		set
+		{
+			EquipmentSelector.LinkWeaponDyes = value;
+			this.OnPropertyChanged(nameof(this.LinkWeaponDyes));
+		}
+	}
+
 	public bool IsValidWeapon
 	{
 		get
@@ -342,6 +352,11 @@ public partial class ItemView : UserControl
 	{
 		this.ItemModel?.SwapDyeChannels();
 		this.PartnerWeapon?.SwapDyeChannels();
+	}
+
+	private void OnToggleLinkDyes(object sender, RoutedEventArgs e)
+	{
+		this.LinkWeaponDyes = !this.LinkWeaponDyes;
 	}
 
 	private void SetItem(IItem? item, bool autoOffhand = false, bool forceMain = false, bool forceOff = false)

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -216,6 +216,21 @@ public partial class ItemView : UserControl
 		}
 	}
 
+	private static bool MatchesWeapon(IItem item, WeaponMemory weaponVm, ItemSlots slot)
+	{
+		// For Off-Hand paired weapons, match against the SubModel
+		if (slot == ItemSlots.OffHand && item.HasSubModel)
+		{
+			return item.SubModelSet == weaponVm.Set
+				&& item.SubModelBase == weaponVm.Base
+				&& item.SubModelVariant == weaponVm.Variant;
+		}
+
+		return item.ModelSet == weaponVm.Set
+			&& item.ModelBase == weaponVm.Base
+			&& item.ModelVariant == weaponVm.Variant;
+	}
+
 	private void OnOpenInConsoleGamesWikiClicked(object sender, RoutedEventArgs e)
 	{
 		this.OpenItemInFanSiteUrl("https://ffxiv.consolegameswiki.com/wiki/" + this.Item?.Name.Replace(" ", "_"));
@@ -366,6 +381,9 @@ public partial class ItemView : UserControl
 
 		this.lockViewModel = true;
 
+		if (this.ItemModel != null)
+			this.ItemModel.EquippedItem = item;
+
 		if (item != null)
 		{
 			bool useSubModel = this.Slot == ItemSlots.OffHand && item.HasSubModel;
@@ -394,15 +412,21 @@ public partial class ItemView : UserControl
 				{
 					SetModel(this.Actor?.DrawData.OffHand, ivm.SubModelSet, ivm.SubModelBase, ivm.SubModelVariant);
 
-					if (EquipmentSelector.LinkWeaponDyes && this.ItemModel != null && this.Actor?.DrawData.OffHand is WeaponMemory offWeapon)
+					if (this.Actor?.DrawData.OffHand is WeaponMemory offWeapon)
 					{
-						offWeapon.Dye = this.ItemModel.Dye;
-						offWeapon.Dye2 = this.ItemModel.Dye2;
+						offWeapon.EquippedItem = ivm;
+						if (EquipmentSelector.LinkWeaponDyes && this.ItemModel != null)
+						{
+							offWeapon.Dye = this.ItemModel.Dye;
+							offWeapon.Dye2 = this.ItemModel.Dye2;
+						}
 					}
 				}
 				else
 				{
 					SetModel(this.Actor?.DrawData.OffHand, 0, 0, 0);
+					if (this.Actor?.DrawData.OffHand is WeaponMemory offWeapon)
+						offWeapon.EquippedItem = ItemUtility.NoneItem;
 				}
 			}
 
@@ -476,7 +500,15 @@ public partial class ItemView : UserControl
 
 				if (valueVm is ItemMemory itemVm)
 				{
-					IItem? item = ItemUtility.GetItem(slots, 0, itemVm.Base, itemVm.Variant, this.Actor.IsChocobo);
+					// Do not re-fetch if the selected item is the same as the current item
+					IItem? item = itemVm.EquippedItem ?? this.Item;
+					if (item == null || item.ModelBase != itemVm.Base || item.ModelVariant != itemVm.Variant)
+					{
+						item = ItemUtility.GetItem(slots, 0, itemVm.Base, itemVm.Variant, this.Actor.IsChocobo);
+					}
+
+					itemVm.EquippedItem = item;
+
 					IDye? dye;
 					IDye? dye2;
 
@@ -506,7 +538,21 @@ public partial class ItemView : UserControl
 				}
 				else if (valueVm is WeaponMemory weaponVm)
 				{
-					IItem? item = ItemUtility.GetItem(slots, weaponVm.Set, weaponVm.Base, weaponVm.Variant, this.Actor.IsChocobo);
+					// Do not re-fetch if the selected item is the same as the current item
+					IItem? item = weaponVm.EquippedItem ?? this.Item;
+
+					// Check if MainHand has a paired sub-model matching this OffHand
+					if (item == null && slots == ItemSlots.OffHand && this.Actor.DrawData.MainHand?.EquippedItem is IItem mainItem && MatchesWeapon(mainItem, weaponVm, slots))
+					{
+						item = mainItem;
+					}
+
+					if (item == null || !MatchesWeapon(item, weaponVm, slots))
+					{
+						item = ItemUtility.GetItem(slots, weaponVm.Set, weaponVm.Base, weaponVm.Variant, this.Actor.IsChocobo);
+					}
+
+					weaponVm.EquippedItem = item;
 
 					if (weaponVm.Set == 0)
 						weaponVm.Dye = 0;

--- a/Anamnesis/Actor/Views/ItemView.xaml.cs
+++ b/Anamnesis/Actor/Views/ItemView.xaml.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace Anamnesis.Actor.Views;
@@ -156,6 +156,17 @@ public partial class ItemView : UserControl
 		}
 	}
 
+	private WeaponMemory? PartnerWeapon
+	{
+		get
+		{
+			if (!this.IsWeapon || !EquipmentSelector.LinkWeaponDyes || this.Actor?.DrawData == null)
+				return null;
+
+			return (this.Slot == ItemSlots.MainHand) ? this.Actor.DrawData.OffHand : (this.Slot == ItemSlots.OffHand) ? this.Actor.DrawData.MainHand : null;
+		}
+	}
+
 	private static void OnItemModelChanged(ItemView sender, IEquipmentItemMemory? value)
 	{
 		if (sender.ItemModel != null)
@@ -278,6 +289,33 @@ public partial class ItemView : UserControl
 		}
 	}
 
+	private void SetDye(byte dyeId, bool isDye2)
+	{
+		if (this.ItemModel == null)
+			return;
+
+		if (isDye2)
+		{
+			this.ItemModel.Dye2 = dyeId;
+		}
+		else
+		{
+			this.ItemModel.Dye = dyeId;
+		}
+
+		if (this.PartnerWeapon is WeaponMemory partner)
+		{
+			if (isDye2)
+			{
+				partner.Dye2 = dyeId;
+			}
+			else
+			{
+				partner.Dye = dyeId;
+			}
+		}
+	}
+
 	private void OnDyeMouseUp(object sender, MouseButtonEventArgs e)
 	{
 		if (this.Actor?.CanRefresh != true || this.ItemModel == null)
@@ -285,7 +323,7 @@ public partial class ItemView : UserControl
 
 		if (e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Released)
 		{
-			this.ItemModel.Dye = 0;
+			this.SetDye(0, isDye2: false);
 		}
 	}
 
@@ -296,13 +334,14 @@ public partial class ItemView : UserControl
 
 		if (e.ChangedButton == MouseButton.Middle && e.ButtonState == MouseButtonState.Released)
 		{
-			this.ItemModel.Dye2 = 0;
+			this.SetDye(0, isDye2: true);
 		}
 	}
 
 	private void OnSwapDyeChannels(object sender, RoutedEventArgs e)
 	{
 		this.ItemModel?.SwapDyeChannels();
+		this.PartnerWeapon?.SwapDyeChannels();
 	}
 
 	private void SetItem(IItem? item, bool autoOffhand = false, bool forceMain = false, bool forceOff = false)
@@ -339,6 +378,12 @@ public partial class ItemView : UserControl
 				if (ivm.HasSubModel)
 				{
 					SetModel(this.Actor?.DrawData.OffHand, ivm.SubModelSet, ivm.SubModelBase, ivm.SubModelVariant);
+
+					if (EquipmentSelector.LinkWeaponDyes && this.ItemModel != null && this.Actor?.DrawData.OffHand is WeaponMemory offWeapon)
+					{
+						offWeapon.Dye = this.ItemModel.Dye;
+						offWeapon.Dye2 = this.ItemModel.Dye2;
+					}
 				}
 				else
 				{
@@ -364,16 +409,9 @@ public partial class ItemView : UserControl
 
 		SelectorDrawer.Show<DyeSelector, IDye>(this.Dye, (v) =>
 		{
-			if (v == null)
-				return;
-
-			if (this.ItemModel is ItemMemory item)
+			if (v != null)
 			{
-				item.Dye = v.Id;
-			}
-			else if (this.ItemModel is WeaponMemory weapon)
-			{
-				weapon.Dye = v.Id;
+				this.SetDye(v.Id, isDye2: false);
 			}
 		});
 	}
@@ -385,16 +423,9 @@ public partial class ItemView : UserControl
 
 		SelectorDrawer.Show<DyeSelector, IDye>(this.Dye2, (v) =>
 		{
-			if (v == null)
-				return;
-
-			if (this.ItemModel is ItemMemory item)
+			if (v != null)
 			{
-				item.Dye2 = v.Id;
-			}
-			else if (this.ItemModel is WeaponMemory weapon)
-			{
-				weapon.Dye2 = v.Id;
+				this.SetDye(v.Id, isDye2: true);
 			}
 		});
 	}

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -910,19 +910,9 @@ public class CharacterFile : JsonFileBase
 			}
 			else
 			{
-				if (isMainHand)
-				{
-					vm.Set = ItemUtility.EmperorsNewFists.ModelSet;
-					vm.Base = ItemUtility.EmperorsNewFists.ModelBase;
-					vm.Variant = ItemUtility.EmperorsNewFists.ModelVariant;
-				}
-				else
-				{
-					vm.Set = 0;
-					vm.Base = 0;
-					vm.Variant = 0;
-				}
-
+				vm.Set = 0;
+				vm.Base = 0;
+				vm.Variant = 0;
 				vm.Dye = ItemUtility.NoneDye.Id;
 				vm.Dye2 = ItemUtility.NoneDye.Id;
 			}

--- a/Anamnesis/GameData/Excel/Equipment.cs
+++ b/Anamnesis/GameData/Excel/Equipment.cs
@@ -98,26 +98,5 @@ public class Equipment : IItem, IRow
 
 	/// <inheritdoc/>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool FitsInSlot(ItemSlots slot)
-	{
-		return slot switch
-		{
-			ItemSlots.MainHand => this.Slot.HasFlagUnsafe(ItemSlots.MainHand),
-			ItemSlots.OffHand => this.Slot.HasFlagUnsafe(ItemSlots.OffHand),
-			ItemSlots.Head => this.Slot.HasFlagUnsafe(ItemSlots.Head),
-			ItemSlots.Body => this.Slot.HasFlagUnsafe(ItemSlots.Body),
-			ItemSlots.Hands => this.Slot.HasFlagUnsafe(ItemSlots.Hands),
-			ItemSlots.Waist => this.Slot.HasFlagUnsafe(ItemSlots.Waist),
-			ItemSlots.Legs => this.Slot.HasFlagUnsafe(ItemSlots.Legs),
-			ItemSlots.Feet => this.Slot.HasFlagUnsafe(ItemSlots.Feet),
-			ItemSlots.Ears => this.Slot.HasFlagUnsafe(ItemSlots.Ears),
-			ItemSlots.Neck => this.Slot.HasFlagUnsafe(ItemSlots.Neck),
-			ItemSlots.Wrists => this.Slot.HasFlagUnsafe(ItemSlots.Wrists),
-			ItemSlots.RightRing => this.Slot.HasFlagUnsafe(ItemSlots.RightRing),
-			ItemSlots.LeftRing => this.Slot.HasFlagUnsafe(ItemSlots.LeftRing),
-			ItemSlots.Glasses => this.Slot.HasFlagUnsafe(ItemSlots.Glasses),
-			ItemSlots.SoulCrystal => this.Slot.HasFlagUnsafe(ItemSlots.SoulCrystal),
-			_ => false,
-		};
-	}
+	public bool FitsInSlot(ItemSlots slot) => (this.Slot & slot) != 0;
 }

--- a/Anamnesis/GameData/Excel/EventNpc.cs
+++ b/Anamnesis/GameData/Excel/EventNpc.cs
@@ -287,7 +287,7 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 	/// <param name="baseVal">The model base value of the item.</param>
 	/// <param name="equipVal">The equipment model value of the item.</param>
 	/// <returns>
-	/// The weapon item from game data, or <see cref="ItemUtility.EmperorsNewFists"/>
+	/// The weapon item from game data, or <see cref="ItemUtility.NoneItem"/>
 	/// if none is found.
 	/// </returns>
 	private static IItem GetWeaponItem(ItemSlots slot, ulong baseVal, ulong? equipVal)
@@ -298,7 +298,7 @@ public readonly unsafe struct EventNpc(ExcelPage page, uint offset, uint row)
 		if (equipVal != null && equipVal != 0 && equipVal != uint.MaxValue && equipVal != long.MaxValue)
 			return LuminaExtensions.GetWeaponItem(slot, (ulong)equipVal);
 
-		return ItemUtility.EmperorsNewFists;
+		return ItemUtility.NoneItem;
 	}
 
 	/// <summary>

--- a/Anamnesis/GameData/Interfaces/INpcBase.cs
+++ b/Anamnesis/GameData/Interfaces/INpcBase.cs
@@ -398,7 +398,7 @@ public static class INpcBaseExtensions
 		{
 			save.ModelSet = item.SubModelSet;
 			save.ModelBase = item.SubModelBase;
-			save.ModelVariant = item.SubModelBase;
+			save.ModelVariant = item.SubModelVariant;
 		}
 
 		return save;

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -83,8 +83,10 @@
   "EquipmentSelector_ForceMainModelTooltip": "Use the main hand model instead of the off-hand model.",
   "EquipmentSelector_ForceOffModel": "Force off-hand model",
   "EquipmentSelector_ForceOffModelTooltip": "Use the off-hand model instead of the main hand model.",
-  "EquipmentSelector_LinkDyes": "Link main & off-hand dyes",
+  "EquipmentSelector_LinkDyes": "Link main & off-hand dye channels",
   "EquipmentSelector_LinkDyesTip": "Synchronize dye changes between main hand and off-hand",
+  "EquipmentSelector_UnlinkDyes": "Unlink main & off-hand dye channels",
+  "EquipmentSelector_UnlinkDyesTip": "Stop synchronizing dye changes between main hand and off-hand",
 
   "EquipmentSelector_FilterOther": "Other",
   "EquipmentSelector_Categories": "Categories",

--- a/Anamnesis/Languages/en.json
+++ b/Anamnesis/Languages/en.json
@@ -81,8 +81,10 @@
   "EquipmentSelector_AutoOffhandTip": "Automatically equip paired weapons in the off-hand slot, and unequip the off-hand when equipping two-handed weapons",
   "EquipmentSelector_ForceMainModel": "Force main hand model",
   "EquipmentSelector_ForceMainModelTooltip": "Use the main hand model instead of the off-hand model.",
-  "EquipmentSelector_ForceOffModel": "Force off hand model",
+  "EquipmentSelector_ForceOffModel": "Force off-hand model",
   "EquipmentSelector_ForceOffModelTooltip": "Use the off-hand model instead of the main hand model.",
+  "EquipmentSelector_LinkDyes": "Link main & off-hand dyes",
+  "EquipmentSelector_LinkDyesTip": "Synchronize dye changes between main hand and off-hand",
 
   "EquipmentSelector_FilterOther": "Other",
   "EquipmentSelector_Categories": "Categories",

--- a/Anamnesis/Memory/DrawDataMemory.cs
+++ b/Anamnesis/Memory/DrawDataMemory.cs
@@ -5,8 +5,9 @@ namespace Anamnesis.Memory;
 
 using Anamnesis.Core.Extensions;
 using PropertyChanged;
-using RemoteController.IPC;
 using System;
+using RemoteController.Interop.Types;
+using RemoteController.IPC;
 
 public class DrawDataMemory : MemoryBase
 {
@@ -24,8 +25,8 @@ public class DrawDataMemory : MemoryBase
 		HeadgearEarsHidden = 1 << 5,
 	}
 
-	[Bind(0x010)] public WeaponMemory? MainHand { get; set; }
-	[Bind(0x080)] public WeaponMemory? OffHand { get; set; }
+	[Bind(DrawDataContainer.MAIN_HAND_OFFSET)] public WeaponMemory? MainHand { get; set; }
+	[Bind(DrawDataContainer.OFF_HAND_OFFSET)] public WeaponMemory? OffHand { get; set; }
 	[Bind(0x01D0)] public ActorEquipmentMemory? Equipment { get; set; }
 	[Bind(0x0220)] public ActorCustomizeMemory? Customize { get; set; }
 

--- a/Anamnesis/Memory/DrawObjectMemory.cs
+++ b/Anamnesis/Memory/DrawObjectMemory.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace Anamnesis.Memory;
@@ -22,7 +22,7 @@ public class DrawObjectMemory : SceneObjectMemory
 	[DependsOn(nameof(Flags))]
 	public bool IsVisible
 	{
-		get => (this.Flags & 0x09) == 0x09;
-		set => this.Flags = (byte)(value ? this.Flags | 0x09 : this.Flags & ~0x09);
+		get => (this.Flags & (byte)DrawObjectFlags.ActiveRenderState) == (byte)DrawObjectFlags.ActiveRenderState;
+		set => this.Flags = (byte)(value ? this.Flags | (byte)DrawObjectFlags.ActiveRenderState : this.Flags & ~(byte)DrawObjectFlags.ActiveRenderState);
 	}
 }

--- a/Anamnesis/Memory/GameObjectMemory.cs
+++ b/Anamnesis/Memory/GameObjectMemory.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace Anamnesis.Memory;
@@ -12,13 +12,6 @@ using System;
 
 public class GameObjectMemory : MemoryBase
 {
-	public enum RenderModes : uint
-	{
-		Draw = 0,
-		Unload = 2,
-		Load = 4,
-	}
-
 	[Bind(0x030)] public Utf8String NameBytes { get; set; }
 	[Bind(0x078)] public uint ObjectId { get; set; }
 	[Bind(0x084)] public uint DataId { get; set; }
@@ -30,7 +23,7 @@ public class GameObjectMemory : MemoryBase
 	[Bind(0x096)] public byte DistanceFromPlayerY { get; set; }
 	[Bind(0x00C4)] public float Scale { get; set; }
 	[Bind(GameObject.DRAW_OBJECT_OFFSET, BindFlags.Pointer)] public DrawObjectMemory? ModelObject { get; set; }
-	[Bind(0x0118)] public RenderModes RenderMode { get; set; }
+	[Bind(GameObject.RENDER_FLAGS_OFFSET)] public RenderModes RenderMode { get; set; }
 
 	public string Id => $"n{this.NameHash}_d{this.DataId}_o{this.Address}";
 	public string IdNoAddress => $"n{this.NameHash}_d{this.DataId}"; ////_k{this.ObjectKind}";

--- a/Anamnesis/Memory/IEquipmentItemMemory.cs
+++ b/Anamnesis/Memory/IEquipmentItemMemory.cs
@@ -3,6 +3,7 @@
 
 namespace Anamnesis.Memory;
 
+using Anamnesis.GameData;
 using System.ComponentModel;
 
 public interface IEquipmentItemMemory : INotifyPropertyChanged
@@ -11,6 +12,7 @@ public interface IEquipmentItemMemory : INotifyPropertyChanged
 	byte Dye { get; set; }
 	byte Dye2 { get; set; }
 	ushort Set { get; set; }
+	IItem? EquippedItem { get; set; }
 
 	public void SwapDyeChannels();
 	public void Clear(bool isPlayer);

--- a/Anamnesis/Memory/ItemMemory.cs
+++ b/Anamnesis/Memory/ItemMemory.cs
@@ -36,6 +36,9 @@ public class ItemMemory : MemoryBase, IEquipmentItemMemory
 		}
 	}
 
+	// Items dont have a 'Set' but the UI wants to bind to something, so...
+	public ushort Set { get; set; } = 0;
+
 	[AlsoNotifyFor(nameof(ItemId))]
 	public ushort Base
 	{
@@ -112,8 +115,8 @@ public class ItemMemory : MemoryBase, IEquipmentItemMemory
 		}
 	}
 
-	// Items dont have a 'Set' but the UI wants to bind to something, so...
-	public ushort Set { get; set; } = 0;
+	public IItem? EquippedItem { get; set; }
+
 	public bool WeaponHidden { get; set; } = false;
 
 	public void Clear(bool isPlayer)

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -137,6 +137,8 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 	[Bind(WeaponData.DRAW_OBJECT_OFFSET, BindFlags.Pointer)] public WeaponModelMemory? Model { get; set; }
 	[Bind(WeaponData.STATE_OFFSET)] public WeaponStateFlags State { get; set; }
 
+	public IItem? EquippedItem { get; set; }
+
 	[DependsOn(nameof(State))]
 	public bool WeaponHidden
 	{

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -158,12 +158,12 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 			{
 				if (value)
 				{
-					this.Model.Flags |= (byte)DrawObjectFlags.Hidden;
+					this.Model.Flags = (byte)(this.Model.Flags & ~(byte)DrawObjectFlags.Visible);
 				}
 				else
 				{
 					// When unhiding, if weapon scale is set to 0 by the user, reset it to 1 so that the weapon is visible again.
-					this.Model.Flags = (byte)(this.Model.Flags & ~(byte)DrawObjectFlags.Hidden);
+					this.Model.Flags |= (byte)DrawObjectFlags.Visible;
 					if (this.Model.Transform != null && this.Model.Transform.Scale == Vector3.Zero)
 					{
 						this.Model.Transform.Scale = Vector3.One;

--- a/Anamnesis/Memory/WeaponMemory.cs
+++ b/Anamnesis/Memory/WeaponMemory.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace Anamnesis.Memory;
@@ -19,14 +19,8 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 	private readonly Lock weaponLock = new();
 	private WeaponModelId weaponModelId;
 
-	[Flags]
-	public enum WeaponFlagDefs : byte
-	{
-		WeaponHidden = 1 << 1,
-	}
-
 	[AlsoNotifyFor(nameof(Set), nameof(Base), nameof(Variant), nameof(Dye), nameof(Dye2))]
-	[Bind(0x000, BindFlags.ActorRefresh | BindFlags.WeaponRefresh)]
+	[Bind(WeaponData.MODEL_ID_OFFSET, BindFlags.ActorRefresh | BindFlags.WeaponRefresh)]
 	public WeaponModelId WeaponModelId
 	{
 		get
@@ -140,39 +134,39 @@ public class WeaponMemory : MemoryBase, IEquipmentItemMemory
 		}
 	}
 
-	[Bind(0x018, BindFlags.Pointer)] public WeaponModelMemory? Model { get; set; }
-	[Bind(0x040)] public bool IsSheathed { get; set; }
-	[Bind(0x060)] public WeaponFlagDefs WeaponFlags { get; set; }
+	[Bind(WeaponData.DRAW_OBJECT_OFFSET, BindFlags.Pointer)] public WeaponModelMemory? Model { get; set; }
+	[Bind(WeaponData.STATE_OFFSET)] public WeaponStateFlags State { get; set; }
 
-	[DependsOn(nameof(WeaponFlags), nameof(IsSheathed))]
+	[DependsOn(nameof(State))]
 	public bool WeaponHidden
 	{
-		get => (this.IsSheathed && this.WeaponFlags.HasFlagUnsafe(WeaponFlagDefs.WeaponHidden)) || (!this.IsSheathed && this.Model?.Transform?.Scale == Vector3.Zero);
+		get => this.State.HasFlagUnsafe(WeaponStateFlags.Hidden);
 		set
 		{
 			if (value)
 			{
-				this.WeaponFlags |= WeaponFlagDefs.WeaponHidden;
+				this.State |= WeaponStateFlags.Hidden;
 			}
 			else
 			{
-				this.WeaponFlags &= ~WeaponFlagDefs.WeaponHidden;
+				this.State &= ~WeaponStateFlags.Hidden;
 			}
 
-			if (this.Model?.Transform == null)
-				return;
-
-			// If the weapon is unsheathed (in hands) the visibility flag won't work,
-			// so fall back to setting the weapons scale to 0.
-			if (!this.IsSheathed)
+			if (this.Model != null)
 			{
-				this.Model.Transform.Scale = value ? Vector3.Zero : Vector3.One;
-			}
-
-			// Special handling for a weapon with 0 scale that has been sheathed attempting to un-hide
-			else if (!value && this.Model.Transform.Scale == Vector3.Zero)
-			{
-				this.Model.Transform.Scale = Vector3.One;
+				if (value)
+				{
+					this.Model.Flags |= (byte)DrawObjectFlags.Hidden;
+				}
+				else
+				{
+					// When unhiding, if weapon scale is set to 0 by the user, reset it to 1 so that the weapon is visible again.
+					this.Model.Flags = (byte)(this.Model.Flags & ~(byte)DrawObjectFlags.Hidden);
+					if (this.Model.Transform != null && this.Model.Transform.Scale == Vector3.Zero)
+					{
+						this.Model.Transform.Scale = Vector3.One;
+					}
+				}
 			}
 		}
 	}

--- a/Anamnesis/Serialization/Converters/IItemConverter.cs
+++ b/Anamnesis/Serialization/Converters/IItemConverter.cs
@@ -40,7 +40,8 @@ public class IItemConverter : JsonConverter<IItem>
 		if (str.Contains(','))
 		{
 			(ushort modelSet, ushort modelBase, ushort modelVariant) = SplitString(str);
-			return ItemUtility.GetDummyItem(modelSet, modelBase, modelVariant);
+			ItemSlots slot = modelSet != 0 ? ItemSlots.Weapons : ItemSlots.All;
+			return ItemUtility.GetItem(slot, modelSet, modelBase, modelVariant);
 		}
 		else
 		{

--- a/RemoteController/Controller.cs
+++ b/RemoteController/Controller.cs
@@ -1048,7 +1048,7 @@ public class Controller
 			RedrawFlags flags = (RedrawFlags)args[offset++];
 			request.Flags = flags;
 
-			if (flags.HasFlag(RedrawFlags.Weapons))
+			if (flags.HasFlag(RedrawFlags.Weapons) || flags.HasFlag(RedrawFlags.Appearance))
 			{
 				request.MainHandId = MemoryMarshal.Read<WeaponModelId>(args[offset..]);
 				offset += Unsafe.SizeOf<WeaponModelId>();

--- a/RemoteController/Controller.cs
+++ b/RemoteController/Controller.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace RemoteController;
@@ -1059,7 +1059,7 @@ public class Controller
 			if (flags.HasFlag(RedrawFlags.Facewear))
 			{
 				request.FacewearId = MemoryMarshal.Read<ushort>(args[offset..]);
-				offset += sizeof(uint);
+				offset += sizeof(ushort);
 			}
 
 			if (flags.HasFlag(RedrawFlags.Appearance))

--- a/RemoteController/Drivers/Modules/RedrawModule.cs
+++ b/RemoteController/Drivers/Modules/RedrawModule.cs
@@ -1,4 +1,4 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace RemoteController.Drivers;
@@ -205,10 +205,10 @@ public sealed class RedrawModule
 
 		if (success)
 		{
-			if (req.Flags.HasFlag(RedrawFlags.Weapons) && GposeDriver.InstanceOrNull?.IsInGpose == true)
+			if ((req.Flags.HasFlag(RedrawFlags.Weapons) || req.Flags.HasFlag(RedrawFlags.Appearance)) && GposeDriver.InstanceOrNull?.IsInGpose == true)
 			{
-				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.MainHand, req.MainHandId, 1, 0, 1, 0, 0);
-				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.OffHand, req.OffHandId, 1, 0, 1, 0, 0);
+				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.MainHand, req.MainHandId, 1, 0, 0, 0, 0);
+				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.OffHand, req.OffHandId, 1, 0, 0, 0, 0);
 			}
 
 			if (req.Flags.HasFlag(RedrawFlags.Facewear))

--- a/RemoteController/Drivers/Modules/RedrawModule.cs
+++ b/RemoteController/Drivers/Modules/RedrawModule.cs
@@ -207,8 +207,32 @@ public sealed class RedrawModule
 		{
 			if ((req.Flags.HasFlag(RedrawFlags.Weapons) || req.Flags.HasFlag(RedrawFlags.Appearance)) && GposeDriver.InstanceOrNull?.IsInGpose == true)
 			{
+				bool isMainHandHidden = drawData->MainHand.IsHidden;
+				bool isOffHandHidden = drawData->OffHand.IsHidden;
+
 				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.MainHand, req.MainHandId, 1, 0, 0, 0, 0);
 				this.loadWeapon.OriginalFunction(drawDataPtr, WeaponSlot.OffHand, req.OffHandId, 1, 0, 0, 0, 0);
+
+				// Re-apply the weapon visibility flags after loading weapons
+				drawData->MainHand.IsHidden = isMainHandHidden;
+				if (drawData->MainHand.WeaponPtr != nint.Zero)
+				{
+					DrawObject* mainHandDrawObj = (DrawObject*)drawData->MainHand.WeaponPtr;
+					if (isMainHandHidden)
+						mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+					else
+						mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+				}
+
+				drawData->OffHand.IsHidden = isOffHandHidden;
+				if (drawData->OffHand.WeaponPtr != nint.Zero)
+				{
+					DrawObject* offHandDrawObj = (DrawObject*)drawData->OffHand.WeaponPtr;
+					if (isOffHandHidden)
+						offHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+					else
+						offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+				}
 			}
 
 			if (req.Flags.HasFlag(RedrawFlags.Facewear))
@@ -232,10 +256,40 @@ public sealed class RedrawModule
 		return success ? [1] : [0];
 	}
 
-	private byte[] ExecuteFullRedraw(nint gameObjPtr)
+	private unsafe byte[] ExecuteFullRedraw(nint gameObjPtr)
 	{
+		nint drawDataPtr = gameObjPtr + Actor.DRAW_DATA_OFFSET;
+		DrawDataContainerStruct* drawData = (DrawDataContainerStruct*)drawDataPtr;
+		if (drawData == null)
+			return [0];
+
+		bool isMainHandHidden = drawData->MainHand.IsHidden;
+		bool isOffHandHidden = drawData->OffHand.IsHidden;
+
 		this.charDisableDraw.OriginalFunction(gameObjPtr);
 		this.charEnableDraw.OriginalFunction(gameObjPtr);
+
+		// Re-apply the hide/show flags after the redraw
+		drawData->MainHand.IsHidden = isMainHandHidden;
+		if (drawData->MainHand.WeaponPtr != nint.Zero)
+		{
+			DrawObject* mainHandDrawObj = (DrawObject*)drawData->MainHand.WeaponPtr;
+			if (isMainHandHidden)
+				mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+			else
+				mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+		}
+
+		drawData->OffHand.IsHidden = isOffHandHidden;
+		if (drawData->OffHand.WeaponPtr != nint.Zero)
+		{
+			DrawObject* offHandDrawObj = (DrawObject*)drawData->OffHand.WeaponPtr;
+			if (isOffHandHidden)
+				offHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+			else
+				offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+		}
+
 		return [1];
 	}
 

--- a/RemoteController/Drivers/Modules/RedrawModule.cs
+++ b/RemoteController/Drivers/Modules/RedrawModule.cs
@@ -219,9 +219,9 @@ public sealed class RedrawModule
 				{
 					DrawObject* mainHandDrawObj = (DrawObject*)drawData->MainHand.WeaponPtr;
 					if (isMainHandHidden)
-						mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+						mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Visible;
 					else
-						mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+						mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Visible;
 				}
 
 				drawData->OffHand.IsHidden = isOffHandHidden;
@@ -229,9 +229,9 @@ public sealed class RedrawModule
 				{
 					DrawObject* offHandDrawObj = (DrawObject*)drawData->OffHand.WeaponPtr;
 					if (isOffHandHidden)
-						offHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+						offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Visible;
 					else
-						offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+						offHandDrawObj->Flags |= (byte)DrawObjectFlags.Visible;
 				}
 			}
 
@@ -267,6 +267,12 @@ public sealed class RedrawModule
 		bool isOffHandHidden = drawData->OffHand.IsHidden;
 
 		this.charDisableDraw.OriginalFunction(gameObjPtr);
+
+		// Clear the game object's render mode flag to allow it to be drawn.
+		// Otherwise, the subsequent EnableDraw call will re-hide the object.
+		RenderModes* renderMode = (RenderModes*)(gameObjPtr + GameObjectStruct.RENDER_FLAGS_OFFSET);
+		*renderMode &= ~RenderModes.DisableDraw;
+
 		this.charEnableDraw.OriginalFunction(gameObjPtr);
 
 		// Re-apply the hide/show flags after the redraw
@@ -275,9 +281,9 @@ public sealed class RedrawModule
 		{
 			DrawObject* mainHandDrawObj = (DrawObject*)drawData->MainHand.WeaponPtr;
 			if (isMainHandHidden)
-				mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+				mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Visible;
 			else
-				mainHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+				mainHandDrawObj->Flags |= (byte)DrawObjectFlags.Visible;
 		}
 
 		drawData->OffHand.IsHidden = isOffHandHidden;
@@ -285,9 +291,9 @@ public sealed class RedrawModule
 		{
 			DrawObject* offHandDrawObj = (DrawObject*)drawData->OffHand.WeaponPtr;
 			if (isOffHandHidden)
-				offHandDrawObj->Flags |= (byte)DrawObjectFlags.Hidden;
+				offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Visible;
 			else
-				offHandDrawObj->Flags &= (byte)~DrawObjectFlags.Hidden;
+				offHandDrawObj->Flags |= (byte)DrawObjectFlags.Visible;
 		}
 
 		return [1];

--- a/RemoteController/Interop/Types/DrawDataContainer.cs
+++ b/RemoteController/Interop/Types/DrawDataContainer.cs
@@ -1,15 +1,49 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace RemoteController.Interop.Types;
 
 using System.Runtime.InteropServices;
 
+[Flags]
+public enum WeaponStateFlags : ushort
+{
+	None = 0,
+	Hidden = 1 << 1, // 0x02: Weapon is hidden in DrawDataContainer
+	Loaded = 1 << 4, // 0x10: Weapon model object loaded
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x70)]
+public struct WeaponData
+{
+	public const int MODEL_ID_OFFSET = 0x000;
+	public const int WEAPON_PTR_OFFSET = 0x008;
+	public const int DRAW_OBJECT_OFFSET = 0x018;
+	public const int STATE_OFFSET = 0x060;
+
+	[FieldOffset(MODEL_ID_OFFSET)] public WeaponModelId ModelId;
+	[FieldOffset(WEAPON_PTR_OFFSET)] public nint WeaponPtr;
+	[FieldOffset(DRAW_OBJECT_OFFSET)] public nint DrawObjectPtr;
+	[FieldOffset(STATE_OFFSET)] public WeaponStateFlags State;
+
+	public bool IsHidden
+	{
+		readonly get => this.State.HasFlag(WeaponStateFlags.Hidden);
+		set => this.State = value
+			? this.State | WeaponStateFlags.Hidden
+			: this.State & ~WeaponStateFlags.Hidden;
+	}
+}
+
 [StructLayout(LayoutKind.Explicit, Size = 0x268)]
 public struct DrawDataContainer
 {
+	public const int MAIN_HAND_OFFSET = 0x010;
+	public const int OFF_HAND_OFFSET = 0x080;
 	public const int FACEWEAR_DIRTY_FLAG = 0x248;
 
+	[FieldOffset(MAIN_HAND_OFFSET)] public WeaponData MainHand;
+	[FieldOffset(OFF_HAND_OFFSET)] public WeaponData OffHand;
 	[FieldOffset(0x23E)] public byte DrawFlags;
 	[FieldOffset(0x240)] public ushort FacewearId;
 	[FieldOffset(FACEWEAR_DIRTY_FLAG)] public byte FacewearDirtyFlag;

--- a/RemoteController/Interop/Types/DrawObject.cs
+++ b/RemoteController/Interop/Types/DrawObject.cs
@@ -1,9 +1,23 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace RemoteController.Interop.Types;
 
+using System;
 using System.Runtime.InteropServices;
+
+[Flags]
+public enum DrawObjectFlags : byte
+{
+	None = 0,
+	Hidden = 1 << 0,  // 0x01: Suppresses DirectX 3D model rendering in CharacterBase::UpdateRender
+	InWorld = 1 << 1, // 0x02: Object attached to scene world node
+	Loaded = 1 << 3,  // 0x08: Model resources initialized
+	Culled = 1 << 6,  // 0x40: Frustum / occlusion culled
+
+	// Combined mask for checking/setting initialized and visible draw objects (0x09: Loaded | Hidden)
+	ActiveRenderState = Loaded | Hidden,
+}
 
 [StructLayout(LayoutKind.Explicit, Size = 0x090)]
 public struct DrawObject
@@ -14,7 +28,7 @@ public struct DrawObject
 
 	public bool IsVisible
 	{
-		readonly get => (this.Flags & 0x09) == 0x09;
-		set => this.Flags = (byte)(value ? this.Flags | 0x09 : this.Flags & ~0x09);
+		readonly get => (this.Flags & (byte)DrawObjectFlags.ActiveRenderState) == (byte)DrawObjectFlags.ActiveRenderState;
+		set => this.Flags = (byte)(value ? this.Flags | (byte)DrawObjectFlags.ActiveRenderState : this.Flags & ~(byte)DrawObjectFlags.ActiveRenderState);
 	}
 }

--- a/RemoteController/Interop/Types/DrawObject.cs
+++ b/RemoteController/Interop/Types/DrawObject.cs
@@ -10,13 +10,13 @@ using System.Runtime.InteropServices;
 public enum DrawObjectFlags : byte
 {
 	None = 0,
-	Hidden = 1 << 0,  // 0x01: Suppresses DirectX 3D model rendering in CharacterBase::UpdateRender
+	Visible = 1 << 0, // 0x01: Controls DirectX 3D model rendering in CharacterBase::UpdateRender
 	InWorld = 1 << 1, // 0x02: Object attached to scene world node
 	Loaded = 1 << 3,  // 0x08: Model resources initialized
 	Culled = 1 << 6,  // 0x40: Frustum / occlusion culled
 
-	// Combined mask for checking/setting initialized and visible draw objects (0x09: Loaded | Hidden)
-	ActiveRenderState = Loaded | Hidden,
+	// Combined mask for checking/setting initialized and visible draw objects (0x09: Loaded | Visible)
+	ActiveRenderState = Loaded | Visible,
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x090)]

--- a/RemoteController/Interop/Types/GameObject.cs
+++ b/RemoteController/Interop/Types/GameObject.cs
@@ -1,15 +1,56 @@
-﻿// © Anamnesis.
+// © Anamnesis.
 // Licensed under the MIT license.
 
 namespace RemoteController.Interop.Types;
 
+using System;
 using System.Runtime.InteropServices;
+
+/// <summary>
+/// A visibility arbitration bitmask for <see cref="GameObject"/>.
+/// </summary>
+/// <remarks>
+/// The game uses this field to determine whether an actor should be rendered or hidden in the scene.
+/// Different subsystems (cutscenes, layout streaming, mount/dismount managers, event handlers, etc.)
+/// can set individual bits in this field to indicate that the actor should be hidden for the flagged reason.
+/// <para>
+/// An actor is rendered by the render engine if and only if <see cref="RenderMode"/> evaluates to <see cref="Draw"/> (0),
+/// indicating no subsystem is actively requesting the actor to be hidden.
+/// </para>
+/// </remarks>
+[Flags]
+public enum RenderModes : ulong
+{
+	/// <summary>
+	/// No subsystem is requesting the object to be hidden. The object is drawn normally.
+	/// </summary>
+	Draw = 0,
+
+	/// <summary>
+	/// Object model resources are unloaded / pending unload.
+	/// </summary>
+	Unload = 1UL << 1,
+
+	/// <summary>
+	/// Object model resources are actively loading.
+	/// </summary>
+	Load = 1UL << 2,
+
+	/// <summary>
+	/// Set by <c>GameObject::DisableDraw</c> when tearing down draw state.
+	/// </summary>
+	DisableDraw = 1UL << 11,
+}
 
 [StructLayout(LayoutKind.Explicit, Size = 0x01A0)]
 public struct GameObject
 {
 	public const int DRAW_OBJECT_OFFSET = 0x0100;
+	public const int RENDER_FLAGS_OFFSET = 0x0118;
 
-	[FieldOffset(0x100)]
+	[FieldOffset(DRAW_OBJECT_OFFSET)]
 	public unsafe DrawObject* ModelObject;
+
+	[FieldOffset(RENDER_FLAGS_OFFSET)]
+	public RenderModes RenderMode;
 }


### PR DESCRIPTION
**Changelog:**
- Added a checkbox toggle feature that links the dye channels of the main hand and off-hand. It is enabled by default.
  - **Explanation:** This is done as the game only checks the off-hand dye channels on some items (e.g. monk fists). Since most users are unlikely to want to switch the dyes independently, the checkbox is toggled on by default.
- Resolved an issue, which caused actors to become and stay invisible after a redraw when swapping between one-handed and two-handed weapon types that differ from what was equipped prior to entering GPose.
- Fixed an issue where certain weapons (e.g., monk fists) failed to update their model assets when switched under specific conditions.
- Resolved a bug where updating equipment prevented weapon models (e.g. monk fists) from re-rendering during actor redraws.
- Weapon visibilitty state is now preserved across actor redraws.
  - **Explanation:** Previously, weapon visibility would reset to whatever sheathe state the actor had before entering GPose.
- Refactored the weapon visibility toggle feature to use the weapon's object flags instead of modifying transform scale.
  - **Explanation:** This replaces the old hacky solution, which mimicked visibility toggling by updating the weapon's model scale to 0 and 1.
- Fixed an issue with model ID handling for weapons which prevented some off-hand items from being recognized as weapons.
- Resolved an issue with off-hand weapons not importing correctly on some NPC appearances.
- Fixed a localization issue with the model set, base, and variant field tooltips in the item view component.
- Removed previous workaround that set the main hand to "Emperor's New Fists" on weapon change to model id 0 (i.e., no item).